### PR TITLE
Fix Apple TV playback stalls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
           if [ "${{ matrix.platform }}" = "x86_64" ]; then
             # Native: run the self-check (should print "cliairplay check").
             "./$bin" --check | grep -qE "cliairplay.*check"
+            make test CC=${{ matrix.cc }}
           else
             # Cross-built: can't execute here, just confirm the architecture.
             file "$bin" | grep -qi "aarch64"
@@ -77,6 +78,7 @@ jobs:
           test -f "$bin"
           if [ "${{ matrix.platform }}" = "arm64" ]; then
             "./$bin" --check | grep -qE "cliairplay.*check"
+            make test CC=clang
           else
             file "$bin" | grep -qi "x86_64"
           fi

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -389,6 +389,8 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 - **Socket deadlines** — established RTSP request/response cycles use cumulative
   absolute deadlines appropriate to the request: 1.5 seconds for feedback,
   2 seconds for control, 5 seconds for metadata, and 15 seconds for artwork.
+  The deadline also bounds waiting for the RTSP serialization lock, so a long
+  artwork transaction cannot silently extend a feedback request's budget.
   Event/DataStream writes have a one-second deadline, while realtime RTP/control
   UDP sends are nonblocking with a short bounded retry. A dead encrypted channel
   is fail-closed and terminal so an advanced nonce is never reused.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -390,7 +390,9 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
   absolute deadlines appropriate to the request: 1.5 seconds for feedback,
   2 seconds for control, 5 seconds for metadata, and 15 seconds for artwork.
   The deadline also bounds waiting for the RTSP serialization lock, so a long
-  artwork transaction cannot silently extend a feedback request's budget.
+  artwork transaction cannot silently extend a feedback request's budget. A
+  feedback tick that exhausts its budget before acquiring that lock is skipped:
+  it consumes no CSeq/nonce and does not count as a receiver failure.
   Event/DataStream writes have a one-second deadline, while realtime RTP/control
   UDP sends are nonblocking with a short bounded retry. A dead encrypted channel
   is fail-closed and terminal so an advanced nonce is never reused.
@@ -419,8 +421,10 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
   commands, explicit playback state, and a serialized NowPlayingClient.
   Start/pause/resume/stop transitions stay synchronized with the audio state.
   This path is enabled by default (`CLIAIRPLAY_MRP=0` is the diagnostic opt-out);
-  its state is mutex-protected from the feedback worker, and metadata remains
-  best-effort so audio never gates on it (§8).
+  mutable state is snapshotted under a short lock, while RTSP/DataStream I/O
+  runs afterward under a separate publication serializer. The feedback worker
+  is the sole DataStream state sender, and realtime health reads an atomic event
+  snapshot, so best-effort metadata never gates audio (§8).
 - **Metadata inputs** — UTF-8 strings become UTF-16BE binary-plist strings when
   needed. `ARTWORK` accepts local files and MA's local HTTP imageproxy URLs;
   imageproxy requests are normalized to supported `size=512&fmt=jpeg` values,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -387,6 +387,10 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 - **Socket timeouts** — the RTSP socket, events socket, and the buffered TCP
   socket are receive/send-timeout bounded; a receiver that stops draining
   can never hang the process.
+- **Reverse event channel** — pair-verified sessions derive independent
+  `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
+  `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS
+  to tear down a MediaRemote-active stream after roughly 30 seconds.
 - **Eager input ring** — a dedicated reader drains stdin into a 4 MB ring as
   fast as the source delivers, decoupled from network pacing: the pipeline
   fills before a scheduled start, while a full ring backpressures the pipe.
@@ -396,9 +400,17 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
   caller has not set any (Sonos withholds audio until it has metadata; the
   native flow also requires `RTP-Info` on the metadata request — Sonos 400s
   without it).
-- **MediaRemote now-playing** — pair-verified Apple sessions additionally push
-  now-playing over `POST /command` on the same cadence as `/feedback` (§8);
-  best-effort, audio never gates on it.
+- **Apple MediaRemote metadata** — pair-verified native sessions register a
+  DEVICE_INFO origin, then send `updateMRNowPlayingInfo` followed by supported
+  commands, explicit playback state, and a serialized NowPlayingClient.
+  Start/pause/resume/stop transitions stay synchronized with the audio state.
+  This path is enabled by default (`CLIAIRPLAY_MRP=0` is the diagnostic opt-out);
+  best-effort, audio never gates on it (§8).
+- **Metadata inputs** — UTF-8 strings become UTF-16BE binary-plist strings when
+  needed. `ARTWORK` accepts local files and MA's local HTTP imageproxy URLs;
+  imageproxy requests are normalized to supported `size=512&fmt=jpeg` values,
+  and fetches have a 5-second overall deadline so metadata I/O cannot starve
+  the feedback/event keepalive loop.
 
 ## 11. Device-behavior findings
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -386,11 +386,12 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 - **RTSP serialization** — one mutex serializes the RTSP channel, so the
   keepalive thread and the streaming path can never interleave frames on the
   encrypted channel.
-- **Socket deadlines** — established RTSP request/response cycles have a
-  1.5-second absolute deadline, event/DataStream writes have a one-second
-  deadline, and realtime RTP/control UDP sends are nonblocking with a short
-  bounded retry. A dead RTSP channel is terminal and surfaced to the caller
-  instead of leaving a half-alive process.
+- **Socket deadlines** — established RTSP request/response cycles use cumulative
+  absolute deadlines appropriate to the request: 1.5 seconds for feedback,
+  2 seconds for control, 5 seconds for metadata, and 15 seconds for artwork.
+  Event/DataStream writes have a one-second deadline, while realtime RTP/control
+  UDP sends are nonblocking with a short bounded retry. A dead encrypted channel
+  is fail-closed and terminal so an advanced nonce is never reused.
 - **Reverse event channel** — pair-verified sessions derive independent
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS
@@ -398,6 +399,13 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 - **Eager input ring** — a dedicated reader drains stdin into a 4 MB ring as
   fast as the source delivers, decoupled from network pacing: the pipeline
   fills before a scheduled start, while a full ring backpressures the pipe.
+  Native playback waits in 250 ms intervals so control failures remain visible
+  during producer starvation. If realtime lead is exhausted, it advances the
+  scheduling/PTP anchor while preserving contiguous RTP content.
+- **Realtime send outcomes** — local UDP backpressure is a bounded transient
+  drop that advances sequence, RTP, and scheduling timestamps. Encode,
+  allocation, encryption, socket, and control failures are terminal and produce
+  a nonzero process exit rather than a false EOF.
 - **EOF drain** — after input EOF the session drains at most
   `latency + 2 s`, then tears down.
 - **Initial metadata** — pushed at connect with a placeholder title if the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -378,15 +378,19 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 
 ## 10. Session robustness
 
-- **Keepalive** — native AP2 sessions POST `/feedback` every ~2 s (real
-  senders do; receivers idle-time-out long sessions without it). RAOP paths
-  use libraop's keepalive (~20 s).
+- **Keepalive** — native AP2 sessions have a dedicated worker that POSTs
+  `/feedback` every ~2 s (real senders do; receivers idle-time-out long
+  sessions without it), independent of command-pipe metadata, artwork loading,
+  and progress updates. The worker services encrypted reverse events after
+  each feedback POST. RAOP paths use libraop's keepalive (~20 s).
 - **RTSP serialization** — one mutex serializes the RTSP channel, so the
   keepalive thread and the streaming path can never interleave frames on the
   encrypted channel.
-- **Socket timeouts** — the RTSP socket, events socket, and the buffered TCP
-  socket are receive/send-timeout bounded; a receiver that stops draining
-  can never hang the process.
+- **Socket deadlines** — established RTSP request/response cycles have a
+  1.5-second absolute deadline, event/DataStream writes have a one-second
+  deadline, and realtime RTP/control UDP sends are nonblocking with a short
+  bounded retry. A dead RTSP channel is terminal and surfaced to the caller
+  instead of leaving a half-alive process.
 - **Reverse event channel** — pair-verified sessions derive independent
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS
@@ -405,7 +409,8 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
   commands, explicit playback state, and a serialized NowPlayingClient.
   Start/pause/resume/stop transitions stay synchronized with the audio state.
   This path is enabled by default (`CLIAIRPLAY_MRP=0` is the diagnostic opt-out);
-  best-effort, audio never gates on it (§8).
+  its state is mutex-protected from the feedback worker, and metadata remains
+  best-effort so audio never gates on it (§8).
 - **Metadata inputs** — UTF-8 strings become UTF-16BE binary-plist strings when
   needed. `ARTWORK` accepts local files and MA's local HTTP imageproxy URLs;
   imageproxy requests are normalized to supported `size=512&fmt=jpeg` values,

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,6 @@ $(EVENT_TEST): tests/test_ap2_event.c $(BUILDDIR)/ap2_mrp.o \
 $(IO_TEST): tests/test_ap2_io.c src/ap2_io.c src/ap2_io.h Makefile
 	@mkdir -p $(dir $@)
 	$(CC) $(TEST_CFLAGS) -Isrc tests/test_ap2_io.c src/ap2_io.c \
-		$(EXTRA_LDFLAGS) -o $@
+		$(EXTRA_LDFLAGS) -lpthread -o $@
 
 .PHONY: all directory clean test

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ AP2_SOURCES = ap2_client.c ap2_hap.c ap2_ptp.c ap2_ptp_shm.c ap2_plist.c ap2_mrp
 
 # Common/CLI sources
 CLI_SOURCES = cross_log.c cross_ssl.c cross_util.c cross_net.c platform.c \
-	cliairplay.c pairing.cpp bplist.cpp ap2_bplist.cpp alac_ext.cpp
+	cliairplay.c artwork.c pairing.cpp bplist.cpp ap2_bplist.cpp alac_ext.cpp
 
 # Pre-built static libraries
 # We use a patched copy of libcodecs.a with the buggy alac_create_encoder removed,

--- a/Makefile
+++ b/Makefile
@@ -152,11 +152,13 @@ test: directory $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST)
 	$(IO_TEST)
 
 $(TIMELINE_TEST): tests/test_ap2_timeline.c src/ap2_timeline.h Makefile
+	@mkdir -p $(dir $@)
 	$(CC) $(TEST_CFLAGS) -Isrc $< $(EXTRA_LDFLAGS) -o $@
 
 $(EVENT_TEST): tests/test_ap2_event.c $(BUILDDIR)/ap2_mrp.o \
 		$(BUILDDIR)/ap2_io.o $(BUILDDIR)/ap2_plist.o \
 		$(BUILDDIR)/cross_log.o Makefile
+	@mkdir -p $(dir $@)
 	$(CC) $(TEST_CFLAGS) $(INCLUDE) \
 		$< $(BUILDDIR)/ap2_mrp.o $(BUILDDIR)/ap2_io.o \
 		$(BUILDDIR)/ap2_plist.o $(BUILDDIR)/cross_log.o \

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ EXECUTABLE  = $(BINDIR)/cliairplay-$(HOST)-$(PLATFORM)
 IO_TEST       = build/tests/test_ap2_io
 TIMELINE_TEST = build/tests/test_ap2_timeline
 EVENT_TEST    = build/tests/test_ap2_event
+CLIENT_TEST   = build/tests/test_ap2_client
 TEST_CFLAGS   = -Wall -Wextra -Werror -O2 $(CPPFLAGS) $(EXTRA_CFLAGS)
 
 # Compiler flags
@@ -122,6 +123,8 @@ OBJECTS_CLI  = $(patsubst %.c,$(BUILDDIR)/%.o,$(filter %.c,$(CLI_SOURCES)))
 OBJECTS_CLI += $(patsubst %.cpp,$(BUILDDIR)/%.o,$(filter %.cpp,$(CLI_SOURCES)))
 
 OBJECTS_ALL = $(OBJECTS_RAOP) $(OBJECTS_AP2) $(OBJECTS_CLI)
+CLIENT_TEST_OBJECTS = $(filter-out $(BUILDDIR)/ap2_client.o \
+	$(BUILDDIR)/cliairplay.o $(BUILDDIR)/cross_ssl.o,$(OBJECTS_ALL))
 
 all: directory $(EXECUTABLE)
 
@@ -146,10 +149,11 @@ $(BUILDDIR)/%.o: %.cpp
 clean:
 	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED) build/tests
 
-test: directory $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST)
+test: directory $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(CLIENT_TEST)
 	$(TIMELINE_TEST)
 	$(EVENT_TEST)
 	$(IO_TEST)
+	$(CLIENT_TEST)
 
 $(TIMELINE_TEST): tests/test_ap2_timeline.c src/ap2_timeline.h Makefile
 	@mkdir -p $(dir $@)
@@ -168,5 +172,27 @@ $(IO_TEST): tests/test_ap2_io.c src/ap2_io.c src/ap2_io.h Makefile
 	@mkdir -p $(dir $@)
 	$(CC) $(TEST_CFLAGS) -Isrc tests/test_ap2_io.c src/ap2_io.c \
 		$(EXTRA_LDFLAGS) -lpthread -o $@
+
+build/tests/ap2_client.o: src/ap2_client.c Makefile
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) -DAP2_TESTING $< -c -o $@
+
+build/tests/cross_ssl.o: $(TOOLS)/cross_ssl.c Makefile
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) -DSSL_STATIC_LIB $< -c -o $@
+
+build/tests/test_ap2_client_main.o: tests/test_ap2_client.c Makefile
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_CFLAGS) $(INCLUDE) $< -c -o $@
+
+$(CLIENT_TEST): build/tests/test_ap2_client_main.o build/tests/ap2_client.o \
+		build/tests/cross_ssl.o \
+		$(CLIENT_TEST_OBJECTS) $(LIBCODECS_PATCHED) Makefile
+	@mkdir -p $(dir $@)
+	$(CXX) build/tests/test_ap2_client_main.o build/tests/ap2_client.o \
+		build/tests/cross_ssl.o \
+		$(CLIENT_TEST_OBJECTS) $(LIBCODECS_PATCHED) \
+		$(MDNS)/$(HOST)/$(PLATFORM)/libmdns.a \
+		$(OPENSSL)/libopenssl.a $(LDFLAGS) -o $@
 
 .PHONY: all directory clean test

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,10 @@ BINDIR      = bin
 
 # Output binary
 EXECUTABLE  = $(BINDIR)/cliairplay-$(HOST)-$(PLATFORM)
-TEST_EXECUTABLE = build/tests/test_ap2_io
+IO_TEST       = build/tests/test_ap2_io
+TIMELINE_TEST = build/tests/test_ap2_timeline
+EVENT_TEST    = build/tests/test_ap2_event
+TEST_CFLAGS   = -Wall -Wextra -Werror -O2 $(CPPFLAGS) $(EXTRA_CFLAGS)
 
 # Compiler flags
 DEFINES  = -DNDEBUG -D_GNU_SOURCE -DOPENSSL_SUPPRESS_DEPRECATED
@@ -141,13 +144,27 @@ $(BUILDDIR)/%.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) $< -c -o $@
 
 clean:
-	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED) $(TEST_EXECUTABLE)
+	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED) build/tests
 
-test: $(TEST_EXECUTABLE)
-	$(TEST_EXECUTABLE)
+test: directory $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST)
+	$(TIMELINE_TEST)
+	$(EVENT_TEST)
+	$(IO_TEST)
 
-$(TEST_EXECUTABLE): tests/test_ap2_io.c src/ap2_io.c src/ap2_io.h
+$(TIMELINE_TEST): tests/test_ap2_timeline.c src/ap2_timeline.h Makefile
+	$(CC) $(TEST_CFLAGS) -Isrc $< $(EXTRA_LDFLAGS) -o $@
+
+$(EVENT_TEST): tests/test_ap2_event.c $(BUILDDIR)/ap2_mrp.o \
+		$(BUILDDIR)/ap2_io.o $(BUILDDIR)/ap2_plist.o \
+		$(BUILDDIR)/cross_log.o Makefile
+	$(CC) $(TEST_CFLAGS) $(INCLUDE) \
+		$< $(BUILDDIR)/ap2_mrp.o $(BUILDDIR)/ap2_io.o \
+		$(BUILDDIR)/ap2_plist.o $(BUILDDIR)/cross_log.o \
+		$(OPENSSL)/libopenssl.a $(LDFLAGS) -o $@
+
+$(IO_TEST): tests/test_ap2_io.c src/ap2_io.c src/ap2_io.h Makefile
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -Isrc tests/test_ap2_io.c src/ap2_io.c -o $@
+	$(CC) $(TEST_CFLAGS) -Isrc tests/test_ap2_io.c src/ap2_io.c \
+		$(EXTRA_LDFLAGS) -o $@
 
 .PHONY: all directory clean test

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ BINDIR      = bin
 
 # Output binary
 EXECUTABLE  = $(BINDIR)/cliairplay-$(HOST)-$(PLATFORM)
+TEST_EXECUTABLE = build/tests/test_ap2_io
 
 # Compiler flags
 DEFINES  = -DNDEBUG -D_GNU_SOURCE -DOPENSSL_SUPPRESS_DEPRECATED
@@ -91,7 +92,7 @@ RAOP_SOURCES = raop_client.c rtsp_client.c \
 	alac.c
 
 # AirPlay 2 sources (new)
-AP2_SOURCES = ap2_client.c ap2_hap.c ap2_ptp.c ap2_ptp_shm.c ap2_plist.c ap2_mrp.c
+AP2_SOURCES = ap2_client.c ap2_hap.c ap2_io.c ap2_ptp.c ap2_ptp_shm.c ap2_plist.c ap2_mrp.c
 
 # Common/CLI sources
 CLI_SOURCES = cross_log.c cross_ssl.c cross_util.c cross_net.c platform.c \
@@ -140,6 +141,13 @@ $(BUILDDIR)/%.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) $< -c -o $@
 
 clean:
-	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED)
+	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED) $(TEST_EXECUTABLE)
 
-.PHONY: all directory clean
+test: $(TEST_EXECUTABLE)
+	$(TEST_EXECUTABLE)
+
+$(TEST_EXECUTABLE): tests/test_ap2_io.c src/ap2_io.c src/ap2_io.h
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -Isrc tests/test_ap2_io.c src/ap2_io.c -o $@
+
+.PHONY: all directory clean test

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ src/ap2_client.c      AP2 orchestrator: route resolution, RAOP-compat + native
                       flows, realtime/buffered senders, anchor & pacing
 src/ap2_hap.c         HAP pair-verify, transient and PIN pair-setup, encrypted
                       RTSP framing (ChaCha20-Poly1305)
+src/ap2_io.c          Absolute-deadline socket I/O shared by RTSP and MRP
 src/ap2_mrp.c         MediaRemote now-playing sender: /command builders,
                       proto2 + bplist emitters, type-130 DataStream channel
 src/ap2_plist.c       Binary plist writer (nested streams array)

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ running stream:
 - `VOLUME=<0-100>`
 - `ACTION=PLAY|PAUSE|STOP`
 - Metadata: `TITLE=`, `ARTIST=`, `ALBUM=`, `DURATION=<s>`, `PROGRESS=<s>`,
-  `ARTWORK=<local file path>` (URLs are ignored), followed by
+  `ARTWORK=<local file path or http:// imageproxy URL>`, followed by
   `ACTION=SENDMETA` to push the set.
 
 Some receivers (notably Sonos) do not emit audio until they have received
@@ -187,6 +187,9 @@ audio starts regardless of whether the caller ever sends `SENDMETA`.
 Pair-verified native Apple sessions additionally mirror these updates over
 MediaRemote `POST /command`, including explicit play/pause/stop state. Set
 `CLIAIRPLAY_MRP=0` only to disable that path for comparison or diagnosis.
+Metadata strings are encoded as Unicode binary-plist strings; artwork is
+signature-checked and capped at 5 MiB. MA imageproxy URLs are normalized to a
+supported `size=512&fmt=jpeg` request.
 
 ## Building
 

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -48,15 +48,20 @@
 #include "ap2_plist.h"
 #include "ap2_bplist.h"
 #include "ap2_ptp.h"
+#include "ap2_timeline.h"
 
 extern log_level *loglevel;
 
 #define AP2_FRAMES_PER_CHUNK 352
 #define AP2_CHACHA_TAG_SIZE  16
-#define AP2_RTSP_SETUP_TIMEOUT_MS 8000
-#define AP2_RTSP_LIVE_TIMEOUT_MS  1500
-#define AP2_FEEDBACK_INTERVAL_MS  2000
-#define AP2_UDP_SEND_TIMEOUT_MS   20
+#define AP2_RTSP_SETUP_TIMEOUT_MS    8000
+#define AP2_RTSP_CONTROL_TIMEOUT_MS  2000
+#define AP2_RTSP_FEEDBACK_TIMEOUT_MS 1500
+#define AP2_RTSP_METADATA_TIMEOUT_MS 5000
+#define AP2_RTSP_ARTWORK_TIMEOUT_MS  15000
+#define AP2_FEEDBACK_INTERVAL_MS     2000
+#define AP2_UDP_SEND_TIMEOUT_MS      20
+#define AP2_BUFFERED_WRITE_TIMEOUT_MS 8000
 
 typedef enum {
     FLOW_RAOP_COMPAT = 0,
@@ -95,11 +100,12 @@ struct ap2cl_s {
     int sock_fd;                  /* TCP connection */
     /* The RTSP socket carries whole request/response cycles from multiple
      * threads (streaming thread: SETRATEANCHORTIME/FLUSHBUFFERED/TEARDOWN;
-     * cmdpipe thread: SET_PARAMETER volume/metadata, /feedback keepalive).
+     * cmdpipe thread: SET_PARAMETER volume/metadata; feedback worker: keepalive).
      * This lock serializes the cycles so a response cannot be attributed to
      * the wrong request and the HAP nonce sequence stays intact. */
     pthread_mutex_t rtsp_lock;
     atomic_bool rtsp_dead;
+    atomic_bool media_healthy;
     bool rtsp_established;
     pthread_t feedback_thread;
     atomic_bool feedback_stop;
@@ -125,6 +131,12 @@ struct ap2cl_s {
     uint32_t ssrc;
     uint64_t head_ts;
     bool first_packet;
+    uint64_t audio_packets_sent;
+    uint64_t audio_packets_dropped;
+    uint64_t sync_packets_sent;
+    uint64_t sync_packets_dropped;
+    atomic_uint feedback_failures;
+    uint64_t timeline_reanchors;
 
     /* Frozen realtime anchor line (PTP): the rtp<->wall mapping is fixed once
      * at stream start and every periodic time-announce extrapolates along it.
@@ -136,7 +148,7 @@ struct ap2cl_s {
     uint64_t rt_anchor_wall0;      /* master-clock ns of the anchor point */
     uint32_t rt_anchor_pos0;       /* rtp timestamp at the anchor point */
     uint64_t start_ntp;            /* shared group start (NTP fixed-point), 0 = none */
-    uint32_t rtp_offset;           /* per-process timeline offset (see start_at) */
+    _Atomic uint32_t rtp_offset;   /* per-process timeline offset (see start_at) */
     uint64_t audio_nonce_counter;
     char session_url[128];
     char session_uuid[40];
@@ -180,6 +192,18 @@ static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
     errno = saved_errno;
 }
 
+static int ap2_rtsp_timeout_ms(struct ap2cl_s *p, const char *method,
+                               const char *uri, const char *content_type)
+{
+    if (!p->rtsp_established) return AP2_RTSP_SETUP_TIMEOUT_MS;
+    if (!strcmp(uri, "/feedback")) return AP2_RTSP_FEEDBACK_TIMEOUT_MS;
+    if (content_type && !strncasecmp(content_type, "image/", 6))
+        return AP2_RTSP_ARTWORK_TIMEOUT_MS;
+    if (!strcmp(uri, "/command") || !strcmp(method, "SET_PARAMETER"))
+        return AP2_RTSP_METADATA_TIMEOUT_MS;
+    return AP2_RTSP_CONTROL_TIMEOUT_MS;
+}
+
 static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, const char *uri,
                           const uint8_t *body, int body_len, const char *ct,
                           const char *extra_hdr,
@@ -202,6 +226,11 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         ct ? "Content-Type: " : "", ct ? ct : "", ct ? "\r\n" : "",
         extra_hdr ? extra_hdr : "",
         body_len);
+    if (hdr_len <= 0 || hdr_len >= (int)sizeof(hdr)) {
+        errno = EMSGSIZE;
+        ap2_mark_rtsp_dead(p, method, uri, "construct", 0);
+        return 0;
+    }
 
     uint8_t *msg = NULL;
     int msg_len = 0;
@@ -210,20 +239,34 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         /* Encrypt RTSP via HAP framing */
         int raw_len = hdr_len + body_len;
         uint8_t *raw = malloc(raw_len);
+        if (!raw) {
+            errno = ENOMEM;
+            ap2_mark_rtsp_dead(p, method, uri, "allocate", 0);
+            return 0;
+        }
         memcpy(raw, hdr, hdr_len);
         if (body && body_len > 0) memcpy(raw + hdr_len, body, body_len);
         msg_len = ap2_hap_encrypt(p->hap, raw, raw_len, &msg);
         free(raw);
-        if (msg_len <= 0) { free(msg); return 0; }
+        if (msg_len <= 0) {
+            free(msg);
+            errno = EPROTO;
+            ap2_mark_rtsp_dead(p, method, uri, "encrypt", 0);
+            return 0;
+        }
     } else {
         msg_len = hdr_len + body_len;
         msg = malloc(msg_len);
+        if (!msg) {
+            errno = ENOMEM;
+            ap2_mark_rtsp_dead(p, method, uri, "allocate", 0);
+            return 0;
+        }
         memcpy(msg, hdr, hdr_len);
         if (body && body_len > 0) memcpy(msg + hdr_len, body, body_len);
     }
 
-    int timeout_ms = p->rtsp_established ? AP2_RTSP_LIVE_TIMEOUT_MS
-                                         : AP2_RTSP_SETUP_TIMEOUT_MS;
+    int timeout_ms = ap2_rtsp_timeout_ms(p, method, uri, ct);
     uint64_t started_ms = ap2_io_monotonic_ms();
     uint64_t deadline_ms = started_ms + (uint64_t)timeout_ms;
     LOG_DEBUG("[AP2] RTSP TX cseq=%d %s %s body=%d wire=%d timeout=%dms",
@@ -242,105 +285,99 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
     uint8_t buf[16384] = {0};
     int total = 0;
     if (!p->hap) {
-        /* Unencrypted: simple read */
-        while (total < (int)sizeof(buf) - 1) {
-            int n = (int)ap2_io_read_deadline(p->sock_fd, buf + total,
-                                              sizeof(buf) - total, deadline_ms);
+        while (total < (int)sizeof(buf)) {
+            int n = (int)ap2_io_read_deadline(
+                p->sock_fd, buf + total, sizeof(buf) - (size_t)total,
+                deadline_ms);
             if (n <= 0) break;
             total += n;
-            char *end = strstr((char *)buf, "\r\n\r\n");
-            if (end) {
-                int h_len = (end - (char *)buf) + 4;
-                int cl = 0;
-                char *clh = strcasestr((char *)buf, "Content-Length:");
-                if (clh) cl = atoi(clh + 15);
-                if (total >= h_len + cl) break;
+            ap2_rtsp_response_t parsed;
+            int parse_status = ap2_io_parse_rtsp_response(
+                buf, (size_t)total, &parsed);
+            if (parse_status < 0) {
+                errno = EPROTO;
+                break;
             }
-        }
-        if (total > 0 && strstr((char *)buf, "\r\n\r\n")) {
-            int h_len = (strstr((char *)buf, "\r\n\r\n") - (char *)buf) + 4;
-            int status = 0;
-            sscanf((char *)buf, "%*s %d", &status);
-            *resp_len = total - h_len;
-            *resp_body = (*resp_len > 0) ? malloc(*resp_len) : NULL;
-            if (*resp_body) memcpy(*resp_body, buf + h_len, *resp_len);
-            LOG_DEBUG("[AP2] RTSP RX cseq=%d %s %s status=%d body=%d elapsed=%" PRIu64 "ms",
-                      cseq, method, uri, status, *resp_len,
-                      ap2_io_monotonic_ms() - started_ms);
-            return status;
+            if (parse_status > 0) {
+                if (parsed.message_len != (size_t)total ||
+                    parsed.cseq != cseq) {
+                    errno = EPROTO;
+                    break;
+                }
+                *resp_len = (int)parsed.body_len;
+                *resp_body = parsed.body_len ? malloc(parsed.body_len) : NULL;
+                if (parsed.body_len && !*resp_body) {
+                    errno = ENOMEM;
+                    break;
+                }
+                if (*resp_body)
+                    memcpy(*resp_body, buf + parsed.header_len, parsed.body_len);
+                return parsed.status;
+            }
         }
         ap2_mark_rtsp_dead(p, method, uri, "read",
                            ap2_io_monotonic_ms() - started_ms);
-        *resp_body = NULL; *resp_len = 0;
+        *resp_body = NULL;
+        *resp_len = 0;
         return 0;
     }
 
-    /* Encrypted: read all HAP frames, then decrypt */
-    while (total < (int)sizeof(buf) - 1) {
-        int n = (int)ap2_io_read_deadline(p->sock_fd, buf + total,
-                                          sizeof(buf) - total, deadline_ms);
+    while (total < (int)sizeof(buf)) {
+        int n = (int)ap2_io_read_deadline(
+            p->sock_fd, buf + total, sizeof(buf) - (size_t)total,
+            deadline_ms);
         if (n <= 0) break;
         total += n;
+        if (total < 2) continue;
 
-        /* Check if we have at least one complete HAP frame to peek at */
-        if (total >= 2) {
-            int frame_len = buf[0] | (buf[1] << 8);
-            if (total >= 2 + frame_len + 16) {
-                /* We have at least one frame. Try decrypting all available frames. */
-                uint8_t *dec = NULL;
-                /* Save nonce counter in case we need to retry */
-                uint64_t saved_counter = ap2_hap_save_read_counter(p->hap);
-                int dec_len = ap2_hap_decrypt(p->hap, buf, total, &dec);
-                if (dec_len > 0 && dec) {
-                    /* Check if decrypted data contains a complete RTSP response */
-                    if (strstr((char *)dec, "\r\n\r\n")) {
-                        int h_len = (strstr((char *)dec, "\r\n\r\n") - (char *)dec) + 4;
-                        int cl = 0;
-                        char *clh = strcasestr((char *)dec, "Content-Length:");
-                        if (clh) cl = atoi(clh + 15);
-                        if (dec_len >= h_len + cl) {
-                            int status = 0;
-                            sscanf((char *)dec, "%*s %d", &status);
-                            *resp_len = dec_len - h_len;
-                            *resp_body = (*resp_len > 0) ? malloc(*resp_len) : NULL;
-                            if (*resp_body) memcpy(*resp_body, dec + h_len, *resp_len);
-                            free(dec);
-                            LOG_DEBUG("[AP2] RTSP RX cseq=%d %s %s status=%d body=%d elapsed=%" PRIu64 "ms",
-                                      cseq, method, uri, status, *resp_len,
-                                      ap2_io_monotonic_ms() - started_ms);
-                            return status;
-                        }
-                    }
-                    free(dec);
-                    /* Incomplete RTSP response, need more HAP frames */
-                    /* Restore nonce counter since we'll re-decrypt with more data */
-                    ap2_hap_restore_read_counter(p->hap, saved_counter);
-                } else {
-                    free(dec);
-                    /* Decrypt failed - might need more data or broken frame */
-                    ap2_hap_restore_read_counter(p->hap, saved_counter);
-                }
+        int frame_len = buf[0] | (buf[1] << 8);
+        if (total < 2 + frame_len + AP2_CHACHA_TAG_SIZE) continue;
+
+        uint8_t *dec = NULL;
+        uint64_t saved_counter = ap2_hap_save_read_counter(p->hap);
+        int dec_len = ap2_hap_decrypt(p->hap, buf, total, &dec);
+        if (dec_len > 0 && dec) {
+            ap2_rtsp_response_t parsed;
+            int parse_status = ap2_io_parse_rtsp_response(
+                dec, (size_t)dec_len, &parsed);
+            if (parse_status < 0) {
+                free(dec);
+                errno = EPROTO;
+                break;
             }
-        }
-    }
-
-    LOG_ERROR("[AP2] Encrypted response read failed (total=%d bytes)", total);
-    if (total > 0) {
-        int dump = total < 64 ? total : 64;
-        char hex[200];
-        for (int i = 0; i < dump; i++) sprintf(hex + i*3, "%02x ", buf[i]);
-        hex[dump*3] = '\0';
-        LOG_ERROR("[AP2] Raw: %s", hex);
-        /* First 2 bytes = HAP frame length */
-        if (total >= 2) {
-            int fl = buf[0] | (buf[1] << 8);
-            LOG_ERROR("[AP2] HAP frame_len=%d, have=%d, need=%d", fl, total, 2 + fl + 16);
+            if (parse_status > 0) {
+                if (parsed.message_len != (size_t)dec_len ||
+                    parsed.cseq != cseq) {
+                    free(dec);
+                    errno = EPROTO;
+                    break;
+                }
+                *resp_len = (int)parsed.body_len;
+                *resp_body = parsed.body_len ? malloc(parsed.body_len) : NULL;
+                if (parsed.body_len && !*resp_body) {
+                    free(dec);
+                    errno = ENOMEM;
+                    break;
+                }
+                if (*resp_body)
+                    memcpy(*resp_body, dec + parsed.header_len,
+                           parsed.body_len);
+                int status = parsed.status;
+                free(dec);
+                return status;
+            }
+            free(dec);
+            ap2_hap_restore_read_counter(p->hap, saved_counter);
+        } else {
+            free(dec);
+            ap2_hap_restore_read_counter(p->hap, saved_counter);
         }
     }
 
     ap2_mark_rtsp_dead(p, method, uri, "read",
                        ap2_io_monotonic_ms() - started_ms);
-    *resp_body = NULL; *resp_len = 0;
+    *resp_body = NULL;
+    *resp_len = 0;
     return 0;
 }
 
@@ -684,6 +721,7 @@ static void ap2_native_setup_mrp(struct ap2cl_s *p)
         p->mrp = NULL;
         return;
     }
+    p->events_sock = -1;
 
     if (!ap2_mrp_attach(p->mrp, data_port, seed)) {
         LOG_WARN("[MRP] data-channel attach failed; degrading to no-MRP");
@@ -1234,20 +1272,6 @@ static bool ap2_native_connect(struct ap2cl_s *p)
 
 /* ---- Native AP2 audio send ---- */
 
-static ssize_t ap2_send_datagram(int fd, const uint8_t *data, size_t len,
-                                 const struct sockaddr_in *addr)
-{
-    uint64_t deadline_ms = ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS;
-    for (;;) {
-        ssize_t sent = sendto(fd, data, len, MSG_DONTWAIT,
-                              (const struct sockaddr *)addr, sizeof(*addr));
-        if (sent >= 0) return sent;
-        if (errno == EINTR) continue;
-        if (errno != EAGAIN && errno != EWOULDBLOCK) return -1;
-        if (ap2_io_poll_fd(fd, POLLOUT, deadline_ms) <= 0) return -1;
-    }
-}
-
 static bool ap2_set_nonblocking(int fd, const char *name)
 {
     int flags = fcntl(fd, F_GETFL);
@@ -1268,9 +1292,13 @@ static bool ap2_set_nonblocking(int fd, const char *name)
  *   bytes 12-15: NTP fraction (network order)
  *   bytes 16-19: current RTP timestamp (network order)
  * Sent unencrypted on the control UDP socket. */
-static void ap2_send_sync_packet(struct ap2cl_s *p, bool first)
+static ap2_send_result_t ap2_send_sync_packet(struct ap2cl_s *p, bool first)
 {
-    if (p->ctrl_sock < 0) return;
+    if (p->ctrl_sock < 0) {
+        LOG_ERROR("[AP2] NTP sync socket is unavailable");
+        atomic_store(&p->media_healthy, false);
+        return AP2_SEND_FATAL;
+    }
 
     uint8_t pkt[20];
     pkt[0] = first ? 0x90 : 0x80;
@@ -1294,9 +1322,23 @@ static void ap2_send_sync_packet(struct ap2cl_s *p, bool first)
     uint32_t cur_ts_be = htonl(p->rtp_timestamp);
     memcpy(pkt + 16, &cur_ts_be, 4);
 
-    if (ap2_send_datagram(p->ctrl_sock, pkt, sizeof(pkt), &p->ctrl_addr) !=
-        (ssize_t)sizeof(pkt))
-        LOG_WARN("[AP2] NTP sync datagram failed: %s", strerror(errno));
+    ap2_send_result_t result = ap2_io_send_datagram_deadline(
+        p->ctrl_sock, pkt, sizeof(pkt),
+        (const struct sockaddr *)&p->ctrl_addr, sizeof(p->ctrl_addr),
+        ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS);
+    if (result == AP2_SEND_SENT) {
+        p->sync_packets_sent++;
+    } else {
+        p->sync_packets_dropped++;
+        if (result == AP2_SEND_FATAL) {
+            atomic_store(&p->media_healthy, false);
+            LOG_ERROR("[AP2] NTP sync send failed: %s", strerror(errno));
+        } else if (p->sync_packets_dropped <= 3 ||
+                   (p->sync_packets_dropped % 100) == 0) {
+            LOG_WARN("[AP2] NTP sync send transiently dropped");
+        }
+    }
+    return result;
 }
 
 /* Send AP2 PTP sync (anchor) packet (28 bytes) to the control port.
@@ -1309,9 +1351,13 @@ static void ap2_send_sync_packet(struct ap2cl_s *p, bool first)
  *   bytes 20-27: our PTP clock identity (BE64)
  * The wall-clock ns and the clock identity come from the PTP grandmaster so the
  * receiver, slaved to that clock, can place the anchor precisely. */
-static void ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
+static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
 {
-    if (p->ctrl_sock < 0) return;
+    if (p->ctrl_sock < 0) {
+        LOG_ERROR("[AP2] PTP sync socket is unavailable");
+        atomic_store(&p->media_healthy, false);
+        return AP2_SEND_FATAL;
+    }
 
     uint8_t pkt[28];
     pkt[0] = first ? 0x90 : 0x80;
@@ -1341,7 +1387,7 @@ static void ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
                              + (((p->start_ntp & 0xFFFFFFFFULL) * 1000000000ULL) >> 32);
             p->rt_anchor_wall0 = unix_ns - (uint64_t)p->latency_ms * 1000000ULL;
             p->rt_anchor_pos0 = (uint32_t)NTP2TS(p->start_ntp, p->format.sample_rate)
-                              + p->rtp_offset;
+                              + atomic_load(&p->rtp_offset);
         } else {
             p->rt_anchor_wall0 = wall;
             p->rt_anchor_pos0 = p->rtp_timestamp;
@@ -1375,16 +1421,58 @@ static void ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
     memcpy(pkt + 20, &cid_hi, 4);
     memcpy(pkt + 24, &cid_lo, 4);
 
-    if (ap2_send_datagram(p->ctrl_sock, pkt, sizeof(pkt), &p->ctrl_addr) !=
-        (ssize_t)sizeof(pkt))
-        LOG_WARN("[AP2] PTP sync datagram failed: %s", strerror(errno));
+    ap2_send_result_t result = ap2_io_send_datagram_deadline(
+        p->ctrl_sock, pkt, sizeof(pkt),
+        (const struct sockaddr *)&p->ctrl_addr, sizeof(p->ctrl_addr),
+        ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS);
+    if (result == AP2_SEND_SENT) {
+        p->sync_packets_sent++;
+    } else {
+        p->sync_packets_dropped++;
+        if (result == AP2_SEND_FATAL) {
+            atomic_store(&p->media_healthy, false);
+            LOG_ERROR("[AP2] PTP sync send failed: %s", strerror(errno));
+        } else if (p->sync_packets_dropped <= 3 ||
+                   (p->sync_packets_dropped % 100) == 0) {
+            LOG_WARN("[AP2] PTP sync send transiently dropped");
+        }
+    }
     int32_t send_ahead = (int32_t)(p->rtp_timestamp - play_pos);
     LOG_DEBUG("[AP2] TX PTP sync %s play_pos=%u rtp_head=%u ahead=%d frames wall=%" PRIu64 "ns",
               first ? "(initial)" : "", play_pos, p->rtp_timestamp,
               send_ahead, wall);
+    return result;
 }
 
 /* ---- Native AP2 buffered audio (type 103) ---- */
+
+static bool ap2_encrypt_audio(const uint8_t key[32], const uint8_t nonce[12],
+                              const uint8_t aad[8], const uint8_t *plain,
+                              int plain_len, uint8_t *cipher,
+                              int *cipher_len, uint8_t tag[AP2_CHACHA_TAG_SIZE])
+{
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (!ctx) return false;
+    int len = 0;
+    int total = 0;
+    bool ok =
+        EVP_EncryptInit_ex(ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) > 0 &&
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) > 0 &&
+        EVP_EncryptInit_ex(ctx, NULL, NULL, key, nonce) > 0 &&
+        EVP_EncryptUpdate(ctx, NULL, &len, aad, 8) > 0 &&
+        EVP_EncryptUpdate(ctx, cipher, &len, plain, plain_len) > 0;
+    if (ok) {
+        total = len;
+        ok = EVP_EncryptFinal_ex(ctx, cipher + total, &len) > 0;
+        total += len;
+    }
+    if (ok)
+        ok = EVP_CIPHER_CTX_ctrl(
+                 ctx, EVP_CTRL_AEAD_GET_TAG, AP2_CHACHA_TAG_SIZE, tag) > 0;
+    EVP_CIPHER_CTX_free(ctx);
+    if (ok) *cipher_len = total;
+    return ok;
+}
 
 /* Send the SETRATEANCHORTIME anchor. It pins an RTP sample number to a point on
  * the PTP timeline at a playback rate, so the receiver can schedule every
@@ -1454,22 +1542,30 @@ static bool ap2_send_flushbuffered(struct ap2cl_s *p)
 
 /* Push one encoded chunk over the buffered TCP data connection. The wire frame
  * is a 2-byte big-endian length prefix followed by the encrypted RTP packet
- * [12B hdr][ciphertext][16B tag][8B nonce]. TCP provides reliability and, via
- * backpressure on the blocking write, flow control (no resend logic). */
-static bool ap2_buffered_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames)
+ * [12B hdr][ciphertext][16B tag][8B nonce]. TCP provides reliability and
+ * bounded backpressure for flow control. */
+static ap2_send_result_t ap2_buffered_send_chunk(
+    struct ap2cl_s *p, uint8_t *sample, int frames)
 {
-    if (p->buffered_sock < 0 || !p->alac) return false;
+    if (p->buffered_sock < 0 || !p->alac) {
+        LOG_ERROR("[AP2] Buffered audio channel is unavailable");
+        return AP2_SEND_FATAL;
+    }
 
     uint8_t *encoded = NULL;
     int enc_size = 0;
     pcm_to_alac(p->alac, sample, frames, &encoded, &enc_size);
-    if (!encoded || enc_size <= 0) { free(encoded); return false; }
+    if (!encoded || enc_size <= 0) {
+        LOG_ERROR("[AP2] ALAC encoder failed for buffered audio");
+        free(encoded);
+        return AP2_SEND_FATAL;
+    }
 
     const uint8_t *audio_key = ap2_hap_get_shared_secret(p->hap);
     if (!audio_key) {
         LOG_ERROR("[AP2] No shared secret for audio encryption");
         free(encoded);
-        return false;
+        return AP2_SEND_FATAL;
     }
 
     /* RTP header (12 bytes). Payload type = stream type (103), marker bit set on
@@ -1483,35 +1579,40 @@ static bool ap2_buffered_send_chunk(struct ap2cl_s *p, uint8_t *sample, int fram
     memcpy(rtp_hdr + 4, &ts_be, 4);
     uint32_t ssrc_be = htonl(p->ssrc);
     memcpy(rtp_hdr + 8, &ssrc_be, 4);
-    p->first_packet = false;
-
     /* Nonce = 4 zero bytes + an 8-byte little-endian per-packet counter placed at
      * offset 4 (matching the realtime nonce layout). The same 8 counter bytes are
      * appended to the packet so the receiver reconstructs the nonce explicitly.
      * AAD = RTP header bytes 4..11 (timestamp + ssrc), as in the realtime path. */
-    uint64_t counter = p->audio_nonce_counter++;
+    uint64_t counter = p->audio_nonce_counter;
     uint8_t nonce[12];
     memset(nonce, 0, 12);
     for (int i = 0; i < 8; i++) nonce[4 + i] = (uint8_t)((counter >> (8 * i)) & 0xFF);
 
     int cap = 2 + 12 + enc_size + AP2_CHACHA_TAG_SIZE + 8;
     uint8_t *frame = malloc(cap);
+    if (!frame) {
+        LOG_ERROR("[AP2] Cannot allocate buffered RTP packet");
+        free(encoded);
+        return AP2_SEND_FATAL;
+    }
     uint8_t *pkt = frame + 2;   /* payload starts after the 2-byte length prefix */
     memcpy(pkt, rtp_hdr, 12);
 
-    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
-    int len;
-    EVP_EncryptInit_ex(ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL);
-    EVP_EncryptInit_ex(ctx, NULL, NULL, audio_key, nonce);
-    EVP_EncryptUpdate(ctx, NULL, &len, rtp_hdr + 4, 8);  /* AAD = timestamp + ssrc */
-    EVP_EncryptUpdate(ctx, pkt + 12, &len, encoded, enc_size);
-    int ct_len = len;
-    EVP_EncryptFinal_ex(ctx, pkt + 12 + ct_len, &len);
-    ct_len += len;
-    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, AP2_CHACHA_TAG_SIZE, pkt + 12 + ct_len);
-    EVP_CIPHER_CTX_free(ctx);
+    int ct_len = 0;
+    uint8_t tag[AP2_CHACHA_TAG_SIZE];
+    bool encrypted_ok = ap2_encrypt_audio(
+        audio_key, nonce, rtp_hdr + 4, encoded, enc_size,
+        pkt + 12, &ct_len, tag);
     free(encoded);
+    if (!encrypted_ok) {
+        LOG_ERROR("[AP2] Buffered audio encryption failed");
+        free(frame);
+        return AP2_SEND_FATAL;
+    }
+    memcpy(pkt + 12 + ct_len, tag, sizeof(tag));
+    /* Encryption consumed this nonce. A write failure below closes the socket,
+     * so the advanced counter can never be reused on this channel. */
+    p->audio_nonce_counter++;
 
     int payload_len = 12 + ct_len + AP2_CHACHA_TAG_SIZE;
     memcpy(pkt + payload_len, nonce + 4, 8);   /* trailing nonce (nonce[4..11]) */
@@ -1524,48 +1625,57 @@ static bool ap2_buffered_send_chunk(struct ap2cl_s *p, uint8_t *sample, int fram
     frame[0] = (uint8_t)((total >> 8) & 0xFF);
     frame[1] = (uint8_t)(total & 0xFF);
 
-    int off = 0;
-    bool ok = true;
-    while (off < total) {
-        ssize_t w = write(p->buffered_sock, frame + off, total - off);
-        if (w > 0) { off += w; continue; }
-        if (w < 0 && errno == EINTR) continue;
-        ok = false;   /* SO_SNDTIMEO expiry or a hard error: receiver stalled/gone */
-        break;
-    }
+    bool ok = ap2_io_write_all_deadline(
+        p->buffered_sock, frame, (size_t)total,
+        ap2_io_monotonic_ms() + AP2_BUFFERED_WRITE_TIMEOUT_MS);
     free(frame);
 
     if (ok) {
+        p->first_packet = false;
         p->seq_number++;
         p->rtp_timestamp += frames;
         p->head_ts += frames;
     } else {
         LOG_ERROR("[AP2] Buffered TCP write failed: %s", strerror(errno));
+        shutdown(p->buffered_sock, SHUT_RDWR);
+        close(p->buffered_sock);
+        p->buffered_sock = -1;
+        return AP2_SEND_FATAL;
     }
-    return ok;
+    return AP2_SEND_SENT;
 }
 
-static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames)
+static ap2_send_result_t ap2_native_send_chunk(
+    struct ap2cl_s *p, uint8_t *sample, int frames)
 {
     if (p->use_buffered) return ap2_buffered_send_chunk(p, sample, frames);
-    if (p->data_sock < 0 || !p->alac) return false;
+    if (p->data_sock < 0 || !p->alac || !p->hap) {
+        LOG_ERROR("[AP2] Realtime audio session is incomplete");
+        return AP2_SEND_FATAL;
+    }
 
     /* Send initial sync/anchor packet before the very first audio packet, then
      * periodically every ~100 chunks (~0.8s at 352fpp/44.1kHz). PTP sessions use
      * the 28-byte anchor form; NTP sessions the 20-byte form. */
+    ap2_send_result_t sync_result = AP2_SEND_SENT;
     if (p->first_packet) {
-        if (p->use_ptp) ap2_send_sync_packet_ptp(p, true);
-        else ap2_send_sync_packet(p, true);
+        sync_result = p->use_ptp ? ap2_send_sync_packet_ptp(p, true)
+                                 : ap2_send_sync_packet(p, true);
     } else if ((p->seq_number % 100) == 0) {
-        if (p->use_ptp) ap2_send_sync_packet_ptp(p, false);
-        else ap2_send_sync_packet(p, false);
+        sync_result = p->use_ptp ? ap2_send_sync_packet_ptp(p, false)
+                                 : ap2_send_sync_packet(p, false);
     }
+    if (sync_result == AP2_SEND_FATAL) return AP2_SEND_FATAL;
 
     /* ALAC encode */
     uint8_t *encoded = NULL;
     int enc_size = 0;
     pcm_to_alac(p->alac, sample, frames, &encoded, &enc_size);
-    if (!encoded || enc_size <= 0) { free(encoded); return false; }
+    if (!encoded || enc_size <= 0) {
+        LOG_ERROR("[AP2] ALAC encoder failed for realtime audio");
+        free(encoded);
+        return AP2_SEND_FATAL;
+    }
 
     /* Build RTP header (12 bytes) */
     uint8_t rtp_hdr[12];
@@ -1577,8 +1687,6 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
     memcpy(rtp_hdr + 4, &ts_be, 4);
     uint32_t ssrc_be = htonl(p->ssrc);
     memcpy(rtp_hdr + 8, &ssrc_be, 4);
-    p->first_packet = false;
-
     /* Encrypt the ALAC payload with ChaCha20-Poly1305 (AP2 realtime audio).
      * Key:   the 32-byte pairing audio key (shk) — the raw X25519 secret for
      *        pair-verify, SHA512(S)[:32] for transient pairing.
@@ -1590,7 +1698,7 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
     if (!audio_key) {
         LOG_ERROR("[AP2] No shared secret for audio encryption");
         free(encoded);
-        return false;
+        return AP2_SEND_FATAL;
     }
 
     uint8_t nonce[12];
@@ -1602,21 +1710,25 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
 
     int pkt_size = 12 + enc_size + AP2_CHACHA_TAG_SIZE + 8;
     uint8_t *pkt = malloc(pkt_size);
+    if (!pkt) {
+        LOG_ERROR("[AP2] Cannot allocate realtime RTP packet");
+        free(encoded);
+        return AP2_SEND_FATAL;
+    }
     memcpy(pkt, rtp_hdr, 12);
 
-    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
-    int len;
-    EVP_EncryptInit_ex(ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL);
-    EVP_EncryptInit_ex(ctx, NULL, NULL, audio_key, nonce);
-    EVP_EncryptUpdate(ctx, NULL, &len, rtp_hdr + 4, 8);  /* AAD = timestamp + ssrc */
-    EVP_EncryptUpdate(ctx, pkt + 12, &len, encoded, enc_size);
-    int ct_len = len;
-    EVP_EncryptFinal_ex(ctx, pkt + 12 + ct_len, &len);
-    ct_len += len;
-    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, AP2_CHACHA_TAG_SIZE, pkt + 12 + ct_len);
-    EVP_CIPHER_CTX_free(ctx);
+    int ct_len = 0;
+    uint8_t tag[AP2_CHACHA_TAG_SIZE];
+    bool encrypted_ok = ap2_encrypt_audio(
+        audio_key, nonce, rtp_hdr + 4, encoded, enc_size,
+        pkt + 12, &ct_len, tag);
     free(encoded);
+    if (!encrypted_ok) {
+        LOG_ERROR("[AP2] Realtime audio encryption failed");
+        free(pkt);
+        return AP2_SEND_FATAL;
+    }
+    memcpy(pkt + 12 + ct_len, tag, sizeof(tag));
 
     /* Append the 8-byte per-packet nonce (the low 8 bytes of the 12-byte nonce)
      * so the receiver can reconstruct it. AP2 realtime wire format is
@@ -1624,16 +1736,30 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
      * packet fails its auth tag and is silently dropped. */
     memcpy(pkt + 12 + ct_len + AP2_CHACHA_TAG_SIZE, nonce + 4, 8);
     int actual_pkt_size = 12 + ct_len + AP2_CHACHA_TAG_SIZE + 8;
-    ssize_t sent = ap2_send_datagram(p->data_sock, pkt,
-                                     (size_t)actual_pkt_size, &p->data_addr);
+    ap2_send_result_t result = ap2_io_send_datagram_deadline(
+        p->data_sock, pkt, (size_t)actual_pkt_size,
+        (const struct sockaddr *)&p->data_addr, sizeof(p->data_addr),
+        ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS);
     free(pkt);
 
-    if (sent != actual_pkt_size) {
-        LOG_ERROR("[AP2] Realtime RTP send failed seq=%u rtptime=%u bytes=%d: %s",
+    if (result == AP2_SEND_SENT) {
+        p->audio_packets_sent++;
+    } else if (result == AP2_SEND_DROPPED) {
+        p->audio_packets_dropped++;
+        if (p->audio_packets_dropped <= 3 ||
+            (p->audio_packets_dropped % 100) == 0)
+            LOG_WARN("[AP2] RTP send transiently dropped seq=%u rtptime=%u",
+                     p->seq_number, p->rtp_timestamp);
+    } else {
+        LOG_ERROR("[AP2] Realtime RTP send failed seq=%u rtptime=%u "
+                  "bytes=%d: %s",
                   p->seq_number, p->rtp_timestamp, actual_pkt_size,
                   strerror(errno));
-        return false;
+        return AP2_SEND_FATAL;
     }
+    /* A transient local UDP drop exposes a sequence gap rather than retrying
+     * an old timestamp late, so the media timeline always advances. */
+    p->first_packet = false;
     p->seq_number++;
     p->rtp_timestamp += frames;
     p->head_ts += frames;
@@ -1643,7 +1769,7 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
                   p->seq_number, p->rtp_timestamp, p->head_ts,
                   p->rt_anchor_valid ? 1 : 0);
 
-    return true;
+    return result;
 }
 
 /* ---- RAOP-compat connect ---- */
@@ -1715,7 +1841,10 @@ struct ap2cl_s *ap2cl_create(
     pthread_mutex_init(&p->rtsp_lock, NULL);
     pthread_mutex_init(&p->mrp_lock, NULL);
     atomic_init(&p->rtsp_dead, false);
+    atomic_init(&p->media_healthy, true);
+    atomic_init(&p->feedback_failures, 0);
     atomic_init(&p->feedback_stop, true);
+    atomic_init(&p->rtp_offset, 0);
     if (dacp_id) p->dacp_id = strdup(dacp_id);
     if (active_remote) p->active_remote = strdup(active_remote);
     if (password) p->password = strdup(password);
@@ -1878,15 +2007,18 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
          * Sonos household stream tracking then cross-wires them and one
          * device goes silent. The anchor line carries the same offset, so
          * the audible schedule is untouched. */
-        p->rtp_offset = (uint32_t)(getpid() * 2654435761u) & 0x0FFFFF00u;
+        atomic_store(&p->rtp_offset,
+                     (uint32_t)(getpid() * 2654435761u) & 0x0FFFFF00u);
         /* head_ts stays in the pure scheduling domain (pacing compares it to
          * the wall frame clock); the offset is applied only to the on-wire
          * RTP timestamps and the anchor, which advance in lockstep. */
         p->head_ts = NTP2TS(ntp_start, p->format.sample_rate);
-        p->rtp_timestamp = (uint32_t)p->head_ts + p->rtp_offset;
+        p->rtp_timestamp = (uint32_t)p->head_ts +
+                           atomic_load(&p->rtp_offset);
         p->seq_number = (uint16_t)(getpid() * 40503u);
         p->start_ntp = ntp_start;
         p->state = AP2_STREAMING;
+        atomic_store(&p->media_healthy, true);
         pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) ap2_mrp_set_playing(p->mrp, true);
         pthread_mutex_unlock(&p->mrp_lock);
@@ -1896,8 +2028,11 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
          * announce shortly after RECORD can abandon the stream. The line is
          * fully determined by ntpstart, so this and the per-chunk announces
          * agree. */
-        if (p->use_ptp && !p->use_buffered && p->ctrl_sock >= 0)
-            ap2_send_sync_packet_ptp(p, true);
+        if (p->use_ptp && !p->use_buffered && p->ctrl_sock >= 0 &&
+            ap2_send_sync_packet_ptp(p, true) == AP2_SEND_FATAL) {
+            atomic_store(&p->media_healthy, false);
+            return false;
+        }
         /* Buffered playback is scheduled entirely by the anchor: map the
          * current RTP sample to the PTP timeline at the requested start
          * instant. A strict receiver 400s the anchor until it has acquired
@@ -1923,6 +2058,11 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
                 anchored_ok = ap2_send_setrateanchortime(p, p->rtp_timestamp,
                                                          anchor_ns, 1);
             }
+            if (!anchored_ok) {
+                atomic_store(&p->media_healthy, false);
+                LOG_ERROR("[AP2] Unable to establish buffered playback anchor");
+                return false;
+            }
             p->anchored = true;
         }
         return true;
@@ -1934,16 +2074,30 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
     return true;
 }
 
-bool ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames)
+ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample,
+                                   int frames)
 {
-    if (!p || p->state != AP2_STREAMING) return false;
-    if (p->flow == FLOW_NATIVE_AP2) {
-        if (atomic_load(&p->rtsp_dead)) return false;
-        return ap2_native_send_chunk(p, sample, frames);
+    if (!p || p->state != AP2_STREAMING) {
+        LOG_ERROR("[AP2] Audio send attempted outside a streaming session");
+        return AP2_SEND_FATAL;
     }
-    if (!p->raopcl) return false;
+    if (p->flow == FLOW_NATIVE_AP2) {
+        if (atomic_load(&p->rtsp_dead)) return AP2_SEND_FATAL;
+        ap2_send_result_t result = ap2_native_send_chunk(p, sample, frames);
+        if (result == AP2_SEND_FATAL)
+            atomic_store(&p->media_healthy, false);
+        return result;
+    }
+    if (!p->raopcl) return AP2_SEND_FATAL;
     uint64_t playtime;
-    return raopcl_send_chunk(p->raopcl, sample, frames, &playtime);
+    return raopcl_send_chunk(p->raopcl, sample, frames, &playtime)
+               ? AP2_SEND_SENT
+               : AP2_SEND_FATAL;
+}
+
+static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
+{
+    return p->dev_latency_max > 11025 ? p->dev_latency_max - 11025 : 77175;
 }
 
 bool ap2cl_accept_frames(struct ap2cl_s *p)
@@ -1968,12 +2122,67 @@ bool ap2cl_accept_frames(struct ap2cl_s *p)
          * matter how far ahead the start lies. */
         uint64_t now_ntp = raopcl_get_ntp(NULL);
         uint64_t now_ts = NTP2TS(now_ntp, p->format.sample_rate);
-        uint64_t window = p->dev_latency_max > 11025
-                          ? p->dev_latency_max - 11025 : 77175;
+        uint64_t window = ap2_pacing_window_frames(p);
         return (now_ts + window) >= p->head_ts;
     }
     if (!p->raopcl) return false;
     return raopcl_accept_frames(p->raopcl);
+}
+
+bool ap2cl_recover_input_gap(struct ap2cl_s *p)
+{
+    if (!p || p->flow != FLOW_NATIVE_AP2 || p->use_buffered ||
+        p->state != AP2_STREAMING)
+        return false;
+
+    uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
+    uint64_t floor = MS2TS(250, p->format.sample_rate);
+    uint64_t window = ap2_pacing_window_frames(p);
+    uint64_t latency = MS2TS(p->latency_ms, p->format.sample_rate);
+    uint64_t recovery_lead = latency < window ? latency : window;
+    ap2_timeline_recovery_t recovery;
+    if (!ap2_timeline_plan_recovery(
+            p->head_ts, p->rtp_timestamp, atomic_load(&p->rtp_offset),
+            now_ts, floor, recovery_lead, &recovery)) {
+        if (p->head_ts <= now_ts + floor &&
+            (uint32_t)p->head_ts + atomic_load(&p->rtp_offset) !=
+                p->rtp_timestamp)
+            LOG_ERROR("[AP2] Cannot re-anchor: RTP/head invariant already broken");
+        return false;
+    }
+
+    p->head_ts = recovery.head;
+    atomic_store(&p->rtp_offset, recovery.offset);
+    if (p->use_ptp && p->rt_anchor_valid) {
+        p->rt_anchor_wall0 += ap2_timeline_frames_to_ns(
+            recovery.shifted_frames, (uint32_t)p->format.sample_rate);
+    }
+    p->timeline_reanchors++;
+    ap2_send_result_t sync_result =
+        p->use_ptp ? ap2_send_sync_packet_ptp(p, true)
+                   : ap2_send_sync_packet(p, true);
+    if (sync_result == AP2_SEND_FATAL) return false;
+    LOG_WARN("[AP2] Re-anchored after PCM starvation: shifted_frames=%" PRIu64
+             " lead_frames=%" PRIu64 " count=%" PRIu64,
+             recovery.shifted_frames, recovery_lead, p->timeline_reanchors);
+    return true;
+}
+
+void ap2cl_log_diagnostics(struct ap2cl_s *p)
+{
+    if (!p || p->flow != FLOW_NATIVE_AP2 || *loglevel < lSDEBUG) return;
+    uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
+    int64_t pacing_ahead = p->head_ts >= now_ts
+                               ? (int64_t)(p->head_ts - now_ts)
+                               : -(int64_t)(now_ts - p->head_ts);
+    LOG_SDEBUG("[AP2DIAG] state=%d seq=%u rtp=%u head=%" PRIu64
+               " pacing_ahead_frames=%" PRId64 " audio_sent=%" PRIu64
+               " audio_dropped=%" PRIu64 " sync_sent=%" PRIu64
+               " sync_dropped=%" PRIu64 " reanchors=%" PRIu64,
+               p->state, p->seq_number, p->rtp_timestamp, p->head_ts,
+               pacing_ahead, p->audio_packets_sent, p->audio_packets_dropped,
+               p->sync_packets_sent, p->sync_packets_dropped,
+               p->timeline_reanchors);
 }
 
 void ap2cl_pause(struct ap2cl_s *p)
@@ -2066,7 +2275,25 @@ bool ap2cl_feedback(struct ap2cl_s *p)
         if (p->mrp) ap2_mrp_tick(p->mrp);
         pthread_mutex_unlock(&p->mrp_lock);
     }
+    if (status == 200) {
+        atomic_store(&p->feedback_failures, 0);
+    } else {
+        atomic_fetch_add(&p->feedback_failures, 1);
+    }
     return status == 200;
+}
+
+bool ap2cl_control_healthy(struct ap2cl_s *p)
+{
+    if (!p || p->flow != FLOW_NATIVE_AP2) return true;
+    if (atomic_load(&p->rtsp_dead) ||
+        !atomic_load(&p->media_healthy) ||
+        atomic_load(&p->feedback_failures) >= 3)
+        return false;
+    pthread_mutex_lock(&p->mrp_lock);
+    bool healthy = !p->mrp || ap2_mrp_event_status(p->mrp) != 0;
+    pthread_mutex_unlock(&p->mrp_lock);
+    return healthy;
 }
 
 bool ap2cl_set_volume(struct ap2cl_s *p, int volume)
@@ -2169,6 +2396,7 @@ static void ap2_mrp_ready(struct ap2cl_s *p)
         p->mrp = NULL;
         return;
     }
+    p->events_sock = -1;
     ap2_mrp_set_playing(p->mrp, p->state == AP2_STREAMING);
 }
 
@@ -2406,7 +2634,7 @@ bool ap2cl_set_progress(struct ap2cl_s *p, int elapsed_s, int duration_s)
          * units (the per-process timeline offset included, so the values match
          * the timestamps the receiver sees on the audio packets). */
         uint32_t now_w = (uint32_t)NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate)
-                       + p->rtp_offset;
+                       + atomic_load(&p->rtp_offset);
         uint32_t start = now_w - (uint32_t)((uint64_t)elapsed_s * p->format.sample_rate);
         uint32_t end = duration_s
                        ? start + (uint32_t)((uint64_t)duration_s * p->format.sample_rate)

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -561,6 +561,12 @@ static void ap2_native_setup_mrp(struct ap2cl_s *p)
                                 p->session_uuid, p->group_uuid,
                                 ap2_hap_get_shared_secret(p->hap));
     if (!p->mrp) return;
+    if (!ap2_mrp_attach_events(p->mrp, p->events_sock)) {
+        LOG_WARN("[MRP] event-channel attach failed; degrading to no-MRP");
+        ap2_mrp_destroy(p->mrp);
+        p->mrp = NULL;
+        return;
+    }
 
     if (!ap2_mrp_attach(p->mrp, data_port, seed)) {
         LOG_WARN("[MRP] data-channel attach failed; degrading to no-MRP");
@@ -826,10 +832,12 @@ static bool ap2_native_connect(struct ap2cl_s *p)
             inet_pton(AF_INET, p->device.address, &ev_addr.sin_addr);
             struct timeval etv = {.tv_sec = 3};
             setsockopt(events_sock, SOL_SOCKET, SO_RCVTIMEO, &etv, sizeof(etv));
+            setsockopt(events_sock, SOL_SOCKET, SO_SNDTIMEO, &etv, sizeof(etv));
             if (connect(events_sock, (struct sockaddr *)&ev_addr, sizeof(ev_addr)) == 0) {
                 LOG_INFO("[AP2] Events connection OK");
-                /* Keep the socket open - we don't need to read from it, just
-                 * keep it alive; closed again on disconnect/destroy. */
+                int one = 1;
+                setsockopt(events_sock, IPPROTO_TCP, TCP_NODELAY,
+                           &one, sizeof(one));
                 p->events_sock = events_sock;
             } else {
                 LOG_WARN("[AP2] Events connect failed");
@@ -1845,10 +1853,8 @@ bool ap2cl_feedback(struct ap2cl_s *p)
      * is raopcl_keepalive(). The response body carries stream status we do
      * not need; the POST itself is what resets the receiver's idle timer. */
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return false;
-    /* Ride the same 2s cadence for the MRP data channel (DESIGN.md §8):
-     * drain inbound frames (answer sync keep-alives) and re-push SET_STATE
-     * periodically to hold the now-playing session open. Separate socket from
-     * the RTSP /feedback POST; best-effort, harmless when no channel is up. */
+    /* Ride the same 2s cadence to answer encrypted reverse event requests and,
+     * when enabled, drain the type-130 channel. */
     if (p->mrp) ap2_mrp_tick(p->mrp);
     uint8_t *resp = NULL; int resp_len = 0;
     int status = ap2_rtsp_send(p, "POST", "/feedback", NULL, 0, NULL, &resp, &resp_len);
@@ -1933,15 +1939,14 @@ static bool ap2_native_send_metadata(struct ap2cl_s *p, const char *title,
     return status >= 200 && status < 300;
 }
 
-/* Lazily create the MediaRemote state carrier for pair-verified native
- * sessions. With no shared secret it only drives the source-side /command
- * metadata path; the optional type-130 channel supplies the secret itself.
+/* Lazily create MediaRemote for pair-verified native sessions and attach the
+ * encrypted reverse event channel before advertising any controllable state.
  * Transient-paired third-party speakers never receive these Apple-specific
  * messages. Set CLIAIRPLAY_MRP=0 to disable the path for diagnosis. */
 static void ap2_mrp_ready(struct ap2cl_s *p)
 {
     if (p->mrp || p->flow != FLOW_NATIVE_AP2 || !p->auth_credentials ||
-        p->sock_fd < 0 || !p->session_uuid[0])
+        p->sock_fd < 0 || p->events_sock < 0 || !p->session_uuid[0])
         return;
     const char *setting = getenv("CLIAIRPLAY_MRP");
     if (setting && (!strcmp(setting, "0") || !strcmp(setting, "false") ||
@@ -1949,9 +1954,16 @@ static void ap2_mrp_ready(struct ap2cl_s *p)
         return;
     p->mrp = ap2_mrp_create(p->device.address, p->device.port, p->auth_credentials,
                             p->dacp_id, p->device.name,
-                            p->session_uuid, p->group_uuid, NULL);
-    if (p->mrp)
-        ap2_mrp_set_playing(p->mrp, p->state == AP2_STREAMING);
+                            p->session_uuid, p->group_uuid,
+                            ap2_hap_get_shared_secret(p->hap));
+    if (!p->mrp) return;
+    if (!ap2_mrp_attach_events(p->mrp, p->events_sock)) {
+        LOG_WARN("[MRP] event-channel attach failed; MediaRemote disabled");
+        ap2_mrp_destroy(p->mrp);
+        p->mrp = NULL;
+        return;
+    }
+    ap2_mrp_set_playing(p->mrp, p->state == AP2_STREAMING);
 }
 
 /* Log an RTSP response body for diagnosis: a printable-text view (control bytes

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -28,6 +29,8 @@
 #include <netdb.h>
 #include <errno.h>
 #include <pthread.h>
+#include <poll.h>
+#include <stdatomic.h>
 
 #include <openssl/rand.h>
 #include <openssl/evp.h>
@@ -41,6 +44,7 @@
 #include "ap2_mrp.h"
 #include "ap2_client.h"
 #include "ap2_hap.h"
+#include "ap2_io.h"
 #include "ap2_plist.h"
 #include "ap2_bplist.h"
 #include "ap2_ptp.h"
@@ -49,6 +53,10 @@ extern log_level *loglevel;
 
 #define AP2_FRAMES_PER_CHUNK 352
 #define AP2_CHACHA_TAG_SIZE  16
+#define AP2_RTSP_SETUP_TIMEOUT_MS 8000
+#define AP2_RTSP_LIVE_TIMEOUT_MS  1500
+#define AP2_FEEDBACK_INTERVAL_MS  2000
+#define AP2_UDP_SEND_TIMEOUT_MS   20
 
 typedef enum {
     FLOW_RAOP_COMPAT = 0,
@@ -91,11 +99,17 @@ struct ap2cl_s {
      * This lock serializes the cycles so a response cannot be attributed to
      * the wrong request and the HAP nonce sequence stays intact. */
     pthread_mutex_t rtsp_lock;
+    atomic_bool rtsp_dead;
+    bool rtsp_established;
+    pthread_t feedback_thread;
+    atomic_bool feedback_stop;
+    bool feedback_thread_started;
     struct ap2_hap_ctx *hap;      /* HAP encryption context */
     struct ap2_ptp_ctx *ptp;      /* Timing */
     /* MRP now-playing over POST /command (path A, see DESIGN.md §8):
      * state carrier + body builder; only on pair-verified native sessions. */
     struct ap2_mrp_ctx *mrp;
+    pthread_mutex_t mrp_lock;
     bool mrp_device_registered;
     bool mrp_extended_registered;
     int mrp_last_playback_state;
@@ -147,20 +161,42 @@ struct ap2cl_s {
 static int ap2_mrp_send_playback_state(struct ap2cl_s *p,
                                        ap2_mrp_playback_state_t state,
                                        bool force);
+static bool ap2_set_nonblocking(int fd, const char *name);
 
 /* ---- Native AP2 RTSP I/O ---- */
+
+static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
+                               const char *uri, const char *phase,
+                               uint64_t elapsed_ms)
+{
+    int saved_errno = errno;
+    if ((p->rtsp_established || p->hap) &&
+        !atomic_exchange(&p->rtsp_dead, true)) {
+        LOG_ERROR("[AP2] RTSP channel failed during %s %s %s after %" PRIu64
+                  "ms: %s; terminating native session",
+                  method, uri, phase, elapsed_ms, strerror(saved_errno));
+        shutdown(p->sock_fd, SHUT_RDWR);
+    }
+    errno = saved_errno;
+}
 
 static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, const char *uri,
                           const uint8_t *body, int body_len, const char *ct,
                           const char *extra_hdr,
                           uint8_t **resp_body, int *resp_len)
 {
+    if (atomic_load(&p->rtsp_dead)) {
+        *resp_body = NULL;
+        *resp_len = 0;
+        return 0;
+    }
+    int cseq = p->cseq++;
     char hdr[1024];
     int hdr_len = snprintf(hdr, sizeof(hdr),
         "%s %s RTSP/1.0\r\nCSeq: %d\r\nUser-Agent: AirPlay/670.6.2\r\n"
         "DACP-ID: %s\r\nActive-Remote: %s\r\n%s%s%s%s"
         "Content-Length: %d\r\n\r\n",
-        method, uri, p->cseq++,
+        method, uri, cseq,
         p->dacp_id ? p->dacp_id : "0",
         p->active_remote ? p->active_remote : "0",
         ct ? "Content-Type: " : "", ct ? ct : "", ct ? "\r\n" : "",
@@ -186,21 +222,30 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         if (body && body_len > 0) memcpy(msg + hdr_len, body, body_len);
     }
 
-    if (write(p->sock_fd, msg, msg_len) != msg_len) { free(msg); return 0; }
+    int timeout_ms = p->rtsp_established ? AP2_RTSP_LIVE_TIMEOUT_MS
+                                         : AP2_RTSP_SETUP_TIMEOUT_MS;
+    uint64_t started_ms = ap2_io_monotonic_ms();
+    uint64_t deadline_ms = started_ms + (uint64_t)timeout_ms;
+    LOG_DEBUG("[AP2] RTSP TX cseq=%d %s %s body=%d wire=%d timeout=%dms",
+              cseq, method, uri, body_len, msg_len, timeout_ms);
+    if (!ap2_io_write_all_deadline(p->sock_fd, msg, msg_len, deadline_ms)) {
+        free(msg);
+        ap2_mark_rtsp_dead(p, method, uri, "write",
+                           ap2_io_monotonic_ms() - started_ms);
+        return 0;
+    }
     free(msg);
 
     /* Read encrypted response.
      * HAP framing: [2-byte LE length][encrypted chunk + 16-byte tag]
      * We accumulate raw bytes, then decrypt complete frames. */
-    uint8_t buf[16384];
+    uint8_t buf[16384] = {0};
     int total = 0;
-    struct timeval tv = {.tv_sec = 8};
-    setsockopt(p->sock_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-
     if (!p->hap) {
         /* Unencrypted: simple read */
         while (total < (int)sizeof(buf) - 1) {
-            int n = read(p->sock_fd, buf + total, sizeof(buf) - total);
+            int n = (int)ap2_io_read_deadline(p->sock_fd, buf + total,
+                                              sizeof(buf) - total, deadline_ms);
             if (n <= 0) break;
             total += n;
             char *end = strstr((char *)buf, "\r\n\r\n");
@@ -219,15 +264,21 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
             *resp_len = total - h_len;
             *resp_body = (*resp_len > 0) ? malloc(*resp_len) : NULL;
             if (*resp_body) memcpy(*resp_body, buf + h_len, *resp_len);
+            LOG_DEBUG("[AP2] RTSP RX cseq=%d %s %s status=%d body=%d elapsed=%" PRIu64 "ms",
+                      cseq, method, uri, status, *resp_len,
+                      ap2_io_monotonic_ms() - started_ms);
             return status;
         }
+        ap2_mark_rtsp_dead(p, method, uri, "read",
+                           ap2_io_monotonic_ms() - started_ms);
         *resp_body = NULL; *resp_len = 0;
         return 0;
     }
 
     /* Encrypted: read all HAP frames, then decrypt */
     while (total < (int)sizeof(buf) - 1) {
-        int n = read(p->sock_fd, buf + total, sizeof(buf) - total);
+        int n = (int)ap2_io_read_deadline(p->sock_fd, buf + total,
+                                          sizeof(buf) - total, deadline_ms);
         if (n <= 0) break;
         total += n;
 
@@ -254,6 +305,9 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
                             *resp_body = (*resp_len > 0) ? malloc(*resp_len) : NULL;
                             if (*resp_body) memcpy(*resp_body, dec + h_len, *resp_len);
                             free(dec);
+                            LOG_DEBUG("[AP2] RTSP RX cseq=%d %s %s status=%d body=%d elapsed=%" PRIu64 "ms",
+                                      cseq, method, uri, status, *resp_len,
+                                      ap2_io_monotonic_ms() - started_ms);
                             return status;
                         }
                     }
@@ -283,6 +337,9 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
             LOG_ERROR("[AP2] HAP frame_len=%d, have=%d, need=%d", fl, total, 2 + fl + 16);
         }
     }
+
+    ap2_mark_rtsp_dead(p, method, uri, "read",
+                       ap2_io_monotonic_ms() - started_ms);
     *resp_body = NULL; *resp_len = 0;
     return 0;
 }
@@ -294,7 +351,12 @@ static int ap2_rtsp_send_ex(struct ap2cl_s *p, const char *method, const char *u
                           const char *extra_hdr,
                           uint8_t **resp_body, int *resp_len)
 {
+    uint64_t wait_started = ap2_io_monotonic_ms();
     pthread_mutex_lock(&p->rtsp_lock);
+    uint64_t waited_ms = ap2_io_monotonic_ms() - wait_started;
+    if (waited_ms >= 250)
+        LOG_DEBUG("[AP2] RTSP %s %s waited %" PRIu64 "ms for control lock",
+                  method, uri, waited_ms);
     int status = ap2_rtsp_send_ex_unlocked(p, method, uri, body, body_len, ct,
                                            extra_hdr, resp_body, resp_len);
     pthread_mutex_unlock(&p->rtsp_lock);
@@ -308,6 +370,61 @@ static int ap2_rtsp_send(struct ap2cl_s *p, const char *method, const char *uri,
 {
     return ap2_rtsp_send_ex(p, method, uri, body, body_len, ct, NULL,
                             resp_body, resp_len);
+}
+
+static void *ap2_feedback_thread_main(void *arg)
+{
+    struct ap2cl_s *p = arg;
+    uint64_t last_tick_ms = ap2_io_monotonic_ms();
+    uint64_t next_tick_ms = last_tick_ms + AP2_FEEDBACK_INTERVAL_MS;
+
+    LOG_DEBUG("[AP2] feedback worker started (interval=%dms)",
+              AP2_FEEDBACK_INTERVAL_MS);
+    while (!atomic_load(&p->feedback_stop) &&
+           !atomic_load(&p->rtsp_dead)) {
+        uint64_t now_ms = ap2_io_monotonic_ms();
+        if (now_ms < next_tick_ms) {
+            uint64_t sleep_ms = next_tick_ms - now_ms;
+            if (sleep_ms > 100) sleep_ms = 100;
+            usleep((useconds_t)sleep_ms * 1000);
+            continue;
+        }
+
+        uint64_t gap_ms = now_ms - last_tick_ms;
+        LOG_DEBUG("[AP2] feedback tick gap=%" PRIu64 "ms", gap_ms);
+        if (gap_ms > AP2_FEEDBACK_INTERVAL_MS + 500)
+            LOG_WARN("[AP2] feedback cadence delayed: %" PRIu64 "ms since prior tick",
+                     gap_ms);
+        ap2cl_feedback(p);
+        last_tick_ms = ap2_io_monotonic_ms();
+        next_tick_ms += AP2_FEEDBACK_INTERVAL_MS;
+        if (next_tick_ms <= last_tick_ms)
+            next_tick_ms = last_tick_ms + AP2_FEEDBACK_INTERVAL_MS;
+    }
+    LOG_DEBUG("[AP2] feedback worker stopped (dead=%d)",
+              atomic_load(&p->rtsp_dead) ? 1 : 0);
+    return NULL;
+}
+
+static bool ap2_feedback_start(struct ap2cl_s *p)
+{
+    atomic_store(&p->feedback_stop, false);
+    int err = pthread_create(&p->feedback_thread, NULL,
+                             ap2_feedback_thread_main, p);
+    if (err != 0) {
+        LOG_ERROR("[AP2] Cannot start feedback worker: %s", strerror(err));
+        return false;
+    }
+    p->feedback_thread_started = true;
+    return true;
+}
+
+static void ap2_feedback_stop(struct ap2cl_s *p)
+{
+    if (!p || !p->feedback_thread_started) return;
+    atomic_store(&p->feedback_stop, true);
+    pthread_join(p->feedback_thread, NULL);
+    p->feedback_thread_started = false;
 }
 
 /* ---- Native AP2 connect helpers ---- */
@@ -858,15 +975,25 @@ static bool ap2_native_connect(struct ap2cl_s *p)
 
     /* Open UDP sockets */
     p->data_sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (p->data_sock < 0 || !ap2_set_nonblocking(p->data_sock, "RTP data"))
+        return false;
     struct sockaddr_in bind_addr = {.sin_family = AF_INET, .sin_addr = p->bind_addr};
-    bind(p->data_sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr));
+    if (bind(p->data_sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) != 0) {
+        LOG_ERROR("[AP2] Cannot bind RTP data socket: %s", strerror(errno));
+        return false;
+    }
     struct sockaddr_in ds_local;
     len = sizeof(ds_local);
     getsockname(p->data_sock, (struct sockaddr *)&ds_local, &len);
     int local_data_port = ntohs(ds_local.sin_port);
 
     p->ctrl_sock = socket(AF_INET, SOCK_DGRAM, 0);
-    bind(p->ctrl_sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr));
+    if (p->ctrl_sock < 0 || !ap2_set_nonblocking(p->ctrl_sock, "RTP control"))
+        return false;
+    if (bind(p->ctrl_sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) != 0) {
+        LOG_ERROR("[AP2] Cannot bind RTP control socket: %s", strerror(errno));
+        return false;
+    }
     struct sockaddr_in cs_local;
     len = sizeof(cs_local);
     getsockname(p->ctrl_sock, (struct sockaddr *)&cs_local, &len);
@@ -1009,7 +1136,9 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     resp = NULL; resp_len = 0;
     status = ap2_rtsp_send(p, "RECORD", p->session_url, NULL, 0, NULL, &resp, &resp_len);
     free(resp);
-    if (status != 200) {
+    if (status == 0) {
+        return false;
+    } else if (status != 200) {
         LOG_WARN("[AP2] RECORD returned %d", status);
     } else {
         LOG_INFO("[AP2] RECORD OK");
@@ -1031,6 +1160,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
         free(sp_data);
         free(resp);
         LOG_INFO("[AP2] SETPEERS [%s, %s] -> %d", p->device.address, our_addr, sp_status);
+        if (sp_status == 0) return false;
 
         const char *peers[2] = { p->device.address, our_addr };
         ap2_ptp_set_peers(p->ptp, peers, 2);
@@ -1091,12 +1221,43 @@ static bool ap2_native_connect(struct ap2cl_s *p)
                                    p->format.channels);
 
     p->first_packet = true;
+    if (atomic_load(&p->rtsp_dead)) return false;
+    p->rtsp_established = true;
     p->state = AP2_CONNECTED;
+    if (!ap2_feedback_start(p)) {
+        atomic_store(&p->rtsp_dead, true);
+        return false;
+    }
     LOG_INFO("[AP2] Native AP2 session ready");
     return true;
 }
 
 /* ---- Native AP2 audio send ---- */
+
+static ssize_t ap2_send_datagram(int fd, const uint8_t *data, size_t len,
+                                 const struct sockaddr_in *addr)
+{
+    uint64_t deadline_ms = ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS;
+    for (;;) {
+        ssize_t sent = sendto(fd, data, len, MSG_DONTWAIT,
+                              (const struct sockaddr *)addr, sizeof(*addr));
+        if (sent >= 0) return sent;
+        if (errno == EINTR) continue;
+        if (errno != EAGAIN && errno != EWOULDBLOCK) return -1;
+        if (ap2_io_poll_fd(fd, POLLOUT, deadline_ms) <= 0) return -1;
+    }
+}
+
+static bool ap2_set_nonblocking(int fd, const char *name)
+{
+    int flags = fcntl(fd, F_GETFL);
+    if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+        LOG_ERROR("[AP2] Cannot make %s socket nonblocking: %s",
+                  name, strerror(errno));
+        return false;
+    }
+    return true;
+}
 
 /* Send AP2 NTP sync packet (20 bytes) to control port.
  * Format (from owntone rtp_common.c sync_packet_ntp_make):
@@ -1133,8 +1294,9 @@ static void ap2_send_sync_packet(struct ap2cl_s *p, bool first)
     uint32_t cur_ts_be = htonl(p->rtp_timestamp);
     memcpy(pkt + 16, &cur_ts_be, 4);
 
-    sendto(p->ctrl_sock, pkt, sizeof(pkt), 0,
-           (struct sockaddr *)&p->ctrl_addr, sizeof(p->ctrl_addr));
+    if (ap2_send_datagram(p->ctrl_sock, pkt, sizeof(pkt), &p->ctrl_addr) !=
+        (ssize_t)sizeof(pkt))
+        LOG_WARN("[AP2] NTP sync datagram failed: %s", strerror(errno));
 }
 
 /* Send AP2 PTP sync (anchor) packet (28 bytes) to the control port.
@@ -1186,7 +1348,10 @@ static void ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
         }
         p->rt_anchor_valid = true;
     }
-    int64_t elapsed_ns = (int64_t)(wall - p->rt_anchor_wall0)
+    int64_t wall_delta_ns = wall >= p->rt_anchor_wall0
+                                ? (int64_t)(wall - p->rt_anchor_wall0)
+                                : -(int64_t)(p->rt_anchor_wall0 - wall);
+    int64_t elapsed_ns = wall_delta_ns
                        - (int64_t)p->latency_ms * 1000000LL;
     uint32_t play_pos = p->rt_anchor_pos0
                       + (uint32_t)((elapsed_ns * p->format.sample_rate) / 1000000000LL);
@@ -1210,10 +1375,13 @@ static void ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
     memcpy(pkt + 20, &cid_hi, 4);
     memcpy(pkt + 24, &cid_lo, 4);
 
-    sendto(p->ctrl_sock, pkt, sizeof(pkt), 0,
-           (struct sockaddr *)&p->ctrl_addr, sizeof(p->ctrl_addr));
-    LOG_DEBUG("[AP2] TX PTP sync %s play_pos=%u wall=%" PRIu64 "ns",
-              first ? "(initial)" : "", play_pos, wall);
+    if (ap2_send_datagram(p->ctrl_sock, pkt, sizeof(pkt), &p->ctrl_addr) !=
+        (ssize_t)sizeof(pkt))
+        LOG_WARN("[AP2] PTP sync datagram failed: %s", strerror(errno));
+    int32_t send_ahead = (int32_t)(p->rtp_timestamp - play_pos);
+    LOG_DEBUG("[AP2] TX PTP sync %s play_pos=%u rtp_head=%u ahead=%d frames wall=%" PRIu64 "ns",
+              first ? "(initial)" : "", play_pos, p->rtp_timestamp,
+              send_ahead, wall);
 }
 
 /* ---- Native AP2 buffered audio (type 103) ---- */
@@ -1456,15 +1624,26 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
      * packet fails its auth tag and is silently dropped. */
     memcpy(pkt + 12 + ct_len + AP2_CHACHA_TAG_SIZE, nonce + 4, 8);
     int actual_pkt_size = 12 + ct_len + AP2_CHACHA_TAG_SIZE + 8;
-    ssize_t sent = sendto(p->data_sock, pkt, actual_pkt_size, 0,
-                           (struct sockaddr *)&p->data_addr, sizeof(p->data_addr));
+    ssize_t sent = ap2_send_datagram(p->data_sock, pkt,
+                                     (size_t)actual_pkt_size, &p->data_addr);
     free(pkt);
 
+    if (sent != actual_pkt_size) {
+        LOG_ERROR("[AP2] Realtime RTP send failed seq=%u rtptime=%u bytes=%d: %s",
+                  p->seq_number, p->rtp_timestamp, actual_pkt_size,
+                  strerror(errno));
+        return false;
+    }
     p->seq_number++;
     p->rtp_timestamp += frames;
     p->head_ts += frames;
+    if ((p->seq_number % 500) == 0)
+        LOG_DEBUG("[AP2] RTP heartbeat seq=%u rtptime=%u head=%" PRIu64
+                  " anchor_valid=%d",
+                  p->seq_number, p->rtp_timestamp, p->head_ts,
+                  p->rt_anchor_valid ? 1 : 0);
 
-    return sent > 0;
+    return true;
 }
 
 /* ---- RAOP-compat connect ---- */
@@ -1534,6 +1713,9 @@ struct ap2cl_s *ap2cl_create(
     p->events_sock = -1;
     p->buffered_sock = -1;
     pthread_mutex_init(&p->rtsp_lock, NULL);
+    pthread_mutex_init(&p->mrp_lock, NULL);
+    atomic_init(&p->rtsp_dead, false);
+    atomic_init(&p->feedback_stop, true);
     if (dacp_id) p->dacp_id = strdup(dacp_id);
     if (active_remote) p->active_remote = strdup(active_remote);
     if (password) p->password = strdup(password);
@@ -1554,6 +1736,7 @@ struct ap2cl_s *ap2cl_create(
 bool ap2cl_destroy(struct ap2cl_s *p)
 {
     if (!p) return false;
+    ap2_feedback_stop(p);
     /* Preserve the on-wire shutdown sequence (final MediaRemote stopped state,
      * MRP disconnect, RTSP TEARDOWN) on the normal EOF path too. */
     if (p->state != AP2_DOWN || p->sock_fd >= 0)
@@ -1570,6 +1753,7 @@ bool ap2cl_destroy(struct ap2cl_s *p)
     if (p->sock_fd >= 0) { close(p->sock_fd); p->sock_fd = -1; }
     pthread_mutex_unlock(&p->rtsp_lock);
     pthread_mutex_destroy(&p->rtsp_lock);
+    pthread_mutex_destroy(&p->mrp_lock);
     if (p->data_sock >= 0) close(p->data_sock);
     if (p->ctrl_sock >= 0) close(p->ctrl_sock);
     if (p->events_sock >= 0) close(p->events_sock);
@@ -1650,13 +1834,16 @@ bool ap2cl_disconnect(struct ap2cl_s *p)
 {
     if (!p) return false;
     if (p->flow == FLOW_NATIVE_AP2) {
+        ap2_feedback_stop(p);
         /* Publish the final stopped state before disconnecting MediaRemote,
          * while the encrypted RTSP session is still live. */
+        pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) {
             ap2_mrp_set_stopped(p->mrp);
             ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_STOPPED, true);
             ap2_mrp_stop(p->mrp);
         }
+        pthread_mutex_unlock(&p->mrp_lock);
         if (p->events_sock >= 0) {
             close(p->events_sock);
             p->events_sock = -1;
@@ -1700,7 +1887,9 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
         p->seq_number = (uint16_t)(getpid() * 40503u);
         p->start_ntp = ntp_start;
         p->state = AP2_STREAMING;
+        pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) ap2_mrp_set_playing(p->mrp, true);
+        pthread_mutex_unlock(&p->mrp_lock);
         /* Announce the timeline IMMEDIATELY: with a future ntpstart the first
          * audio chunk (and the anchor coupled to it) would otherwise only go
          * out once pacing releases it, and a receiver that sees no time
@@ -1749,6 +1938,7 @@ bool ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames)
 {
     if (!p || p->state != AP2_STREAMING) return false;
     if (p->flow == FLOW_NATIVE_AP2) {
+        if (atomic_load(&p->rtsp_dead)) return false;
         return ap2_native_send_chunk(p, sample, frames);
     }
     if (!p->raopcl) return false;
@@ -1760,6 +1950,7 @@ bool ap2cl_accept_frames(struct ap2cl_s *p)
 {
     if (!p || p->state != AP2_STREAMING) return false;
     if (p->flow == FLOW_NATIVE_AP2) {
+        if (atomic_load(&p->rtsp_dead)) return false;
         /* Buffered pushes over TCP: the blocking write and its send timeout
          * provide flow control, so accept whenever we are streaming and let
          * backpressure pace us (rather than the realtime latency window). */
@@ -1792,19 +1983,23 @@ void ap2cl_pause(struct ap2cl_s *p)
         /* Freeze the buffered timeline in place with a rate-0 anchor. */
         ap2_send_setrateanchortime(p, p->rtp_timestamp, ap2_ptp_master_now_ns(p->ptp), 0);
         p->state = AP2_PAUSED;
+        pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) {
             ap2_mrp_set_playing(p->mrp, false);
             ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PAUSED, true);
         }
+        pthread_mutex_unlock(&p->mrp_lock);
         return;
     }
     if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
     p->rt_anchor_valid = false;    /* resume re-anchors on a fresh line */
     p->state = AP2_PAUSED;
+    pthread_mutex_lock(&p->mrp_lock);
     if (p->mrp) {
         ap2_mrp_set_playing(p->mrp, false);
         ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PAUSED, true);
     }
+    pthread_mutex_unlock(&p->mrp_lock);
 }
 
 void ap2cl_play(struct ap2cl_s *p)
@@ -1815,10 +2010,12 @@ void ap2cl_play(struct ap2cl_s *p)
         uint64_t anchor_ns = ap2_ptp_master_now_ns(p->ptp) + (uint64_t)p->latency_ms * 1000000ULL;
         ap2_send_setrateanchortime(p, p->rtp_timestamp, anchor_ns, 1);
         p->state = AP2_STREAMING;
+        pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) {
             ap2_mrp_set_playing(p->mrp, true);
             ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PLAYING, true);
         }
+        pthread_mutex_unlock(&p->mrp_lock);
         return;
     }
     if (p->raopcl) {
@@ -1827,10 +2024,12 @@ void ap2cl_play(struct ap2cl_s *p)
         raopcl_start_at(p->raopcl, now + MS2NTP(200) - TS2NTP(lat, raopcl_sample_rate(p->raopcl)));
     }
     p->state = AP2_STREAMING;
+    pthread_mutex_lock(&p->mrp_lock);
     if (p->mrp) {
         ap2_mrp_set_playing(p->mrp, true);
         ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PLAYING, true);
     }
+    pthread_mutex_unlock(&p->mrp_lock);
 }
 
 void ap2cl_stop(struct ap2cl_s *p)
@@ -1839,10 +2038,12 @@ void ap2cl_stop(struct ap2cl_s *p)
     if (p->use_buffered && p->buffered_sock >= 0)
         ap2_send_flushbuffered(p);
     if (p->raopcl) raopcl_stop(p->raopcl);
+    pthread_mutex_lock(&p->mrp_lock);
     if (p->mrp) {
         ap2_mrp_set_stopped(p->mrp);
         ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_STOPPED, true);
     }
+    pthread_mutex_unlock(&p->mrp_lock);
     p->rt_anchor_valid = false;
     p->state = AP2_DOWN;
 }
@@ -1853,13 +2054,18 @@ bool ap2cl_feedback(struct ap2cl_s *p)
      * is raopcl_keepalive(). The response body carries stream status we do
      * not need; the POST itself is what resets the receiver's idle timer. */
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return false;
-    /* Ride the same 2s cadence to answer encrypted reverse event requests and,
-     * when enabled, drain the type-130 channel. */
-    if (p->mrp) ap2_mrp_tick(p->mrp);
     uint8_t *resp = NULL; int resp_len = 0;
     int status = ap2_rtsp_send(p, "POST", "/feedback", NULL, 0, NULL, &resp, &resp_len);
     free(resp);
     LOG_DEBUG("[AP2] /feedback keepalive -> %d", status);
+    /* Keep event/DataStream servicing behind the receiver keepalive itself:
+     * an event reply can be delayed, but must never make /feedback miss its
+     * cadence. The MRP lock separates this worker from command-pipe updates. */
+    if (!atomic_load(&p->rtsp_dead)) {
+        pthread_mutex_lock(&p->mrp_lock);
+        if (p->mrp) ap2_mrp_tick(p->mrp);
+        pthread_mutex_unlock(&p->mrp_lock);
+    }
     return status == 200;
 }
 
@@ -2060,13 +2266,15 @@ static int ap2_mrp_send_extended_registration(struct ap2cl_s *p)
     return st_client;
 }
 
-int ap2cl_mrp_push(struct ap2cl_s *p)
+static int ap2cl_mrp_register_locked(struct ap2cl_s *p);
+
+static int ap2cl_mrp_push_locked(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return -1;
     ap2_mrp_ready(p);
     if (!p->mrp) return -1;
 
-    if (!p->mrp_device_registered && ap2cl_mrp_register(p) != 1)
+    if (!p->mrp_device_registered && ap2cl_mrp_register_locked(p) != 1)
         return 0;
 
     int status = ap2_mrp_post_command(
@@ -2088,6 +2296,15 @@ int ap2cl_mrp_push(struct ap2cl_s *p)
     return ap2_mrp_status_ok(ext_status) ? status : ext_status;
 }
 
+int ap2cl_mrp_push(struct ap2cl_s *p)
+{
+    if (!p) return -1;
+    pthread_mutex_lock(&p->mrp_lock);
+    int status = ap2cl_mrp_push_locked(p);
+    pthread_mutex_unlock(&p->mrp_lock);
+    return status;
+}
+
 /* MRP data-channel (path B) status for the [STATUS] mrp line:
  *   -1 = not attempted (non-Apple / not pair-verified),
  *    0 = attempted but the channel is not up,
@@ -2099,13 +2316,16 @@ int ap2cl_mrp_channel_status(struct ap2cl_s *p)
      * not attempted, report "not applicable" so the [STATUS] path=channel line
      * is suppressed and only path=command (the active now-playing path) shows. */
     if (!getenv("CLIAIRPLAY_MRP_TYPE130")) return -1;
-    return (p->mrp && ap2_mrp_is_connected(p->mrp)) ? 1 : 0;
+    pthread_mutex_lock(&p->mrp_lock);
+    int status = (p->mrp && ap2_mrp_is_connected(p->mrp)) ? 1 : 0;
+    pthread_mutex_unlock(&p->mrp_lock);
+    return status;
 }
 
 /* Register the sender identity before the first now-playing update. The
  * remaining extended metadata follows updateMRNowPlayingInfo in
  * ap2cl_mrp_push(), matching Apple's current AirPlaySender implementation. */
-int ap2cl_mrp_register(struct ap2cl_s *p)
+static int ap2cl_mrp_register_locked(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return -1;
     ap2_mrp_ready(p);
@@ -2119,13 +2339,24 @@ int ap2cl_mrp_register(struct ap2cl_s *p)
     return p->mrp_device_registered ? 1 : 0;
 }
 
+int ap2cl_mrp_register(struct ap2cl_s *p)
+{
+    if (!p) return -1;
+    pthread_mutex_lock(&p->mrp_lock);
+    int status = ap2cl_mrp_register_locked(p);
+    pthread_mutex_unlock(&p->mrp_lock);
+    return status;
+}
+
 bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist,
                         const char *album, int duration)
 {
     if (!p) return false;
+    pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
     if (p->mrp)
         ap2_mrp_set_metadata(p->mrp, title, artist, album, duration * 1000);
+    pthread_mutex_unlock(&p->mrp_lock);
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0)
         return ap2_native_send_metadata(p, title, artist, album);
     if (p->raopcl)
@@ -2137,9 +2368,11 @@ bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist
 bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size, const char *data)
 {
     if (!p) return false;
+    pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
     if (p->mrp)
         ap2_mrp_set_artwork(p->mrp, content_type, (const uint8_t *)data, size);
+    pthread_mutex_unlock(&p->mrp_lock);
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
         /* Same shape as the RAOP path: the image bytes as the SET_PARAMETER
          * body with its image content type, anchored via RTP-Info (receivers
@@ -2162,10 +2395,12 @@ bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size, co
 bool ap2cl_set_progress(struct ap2cl_s *p, int elapsed_s, int duration_s)
 {
     if (!p) return false;
+    pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
     if (p->mrp)
         ap2_mrp_set_progress(p->mrp, elapsed_s * 1000, duration_s * 1000,
                              p->state == AP2_STREAMING);
+    pthread_mutex_unlock(&p->mrp_lock);
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
         /* progress: <start>/<current>/<end>, all in the STREAM's RTP timestamp
          * units (the per-process timeline offset included, so the values match
@@ -2201,5 +2436,12 @@ void ap2cl_latency_info(struct ap2cl_s *p, int *lead_ms, uint32_t *dev_min, uint
 int ap2cl_render_latency_ms(struct ap2cl_s *p) { return p ? p->dev_render_ms : 0; }
 
 ap2_state_t ap2cl_state(struct ap2cl_s *p) { return p ? p->state : AP2_DOWN; }
-bool ap2cl_is_connected(struct ap2cl_s *p) { return p && p->state >= AP2_CONNECTED; }
-bool ap2cl_is_playing(struct ap2cl_s *p) { return p && p->state == AP2_STREAMING; }
+bool ap2cl_is_connected(struct ap2cl_s *p)
+{
+    return p && p->state >= AP2_CONNECTED && !atomic_load(&p->rtsp_dead);
+}
+
+bool ap2cl_is_playing(struct ap2cl_s *p)
+{
+    return p && p->state == AP2_STREAMING && !atomic_load(&p->rtsp_dead);
+}

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -113,9 +113,13 @@ struct ap2cl_s {
     struct ap2_hap_ctx *hap;      /* HAP encryption context */
     struct ap2_ptp_ctx *ptp;      /* Timing */
     /* MRP now-playing over POST /command (path A, see DESIGN.md §8):
-     * state carrier + body builder; only on pair-verified native sessions. */
+     * state carrier + body builder; only on pair-verified native sessions.
+     * mrp_lock protects mutable state/snapshots only. mrp_publish_lock orders
+     * mutations with network publication without affecting health reads. */
     struct ap2_mrp_ctx *mrp;
     pthread_mutex_t mrp_lock;
+    pthread_mutex_t mrp_publish_lock;
+    atomic_int mrp_event_health;
     bool mrp_device_registered;
     bool mrp_extended_registered;
     int mrp_last_playback_state;
@@ -173,6 +177,9 @@ struct ap2cl_s {
 static int ap2_mrp_send_playback_state(struct ap2cl_s *p,
                                        ap2_mrp_playback_state_t state,
                                        bool force);
+static void ap2_mrp_publish_playback(struct ap2cl_s *p,
+                                     ap2_mrp_playback_state_t state,
+                                     bool force);
 static bool ap2_set_nonblocking(int fd, const char *name);
 
 /* ---- Native AP2 RTSP I/O ---- */
@@ -208,7 +215,8 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
                           const uint8_t *body, int body_len, const char *ct,
                           const char *extra_hdr,
                           uint8_t **resp_body, int *resp_len,
-                          uint64_t started_ms, uint64_t deadline_ms)
+                          uint64_t started_ms, uint64_t deadline_ms,
+                          bool *request_started)
 {
     if (atomic_load(&p->rtsp_dead)) {
         *resp_body = NULL;
@@ -221,6 +229,7 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         errno = ETIMEDOUT;
         return -ETIMEDOUT;
     }
+    if (request_started) *request_started = true;
     int cseq = p->cseq++;
     char hdr[1024];
     int hdr_len = snprintf(hdr, sizeof(hdr),
@@ -388,11 +397,12 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
 
 /* Serialize the full request/response cycle (see the rtsp_lock field note);
  * taking the lock here covers every RTSP caller, whichever thread it runs on. */
-static int ap2_rtsp_send_ex(struct ap2cl_s *p, const char *method, const char *uri,
-                          const uint8_t *body, int body_len, const char *ct,
-                          const char *extra_hdr,
-                          uint8_t **resp_body, int *resp_len)
+static int ap2_rtsp_send_ex_tracked(
+    struct ap2cl_s *p, const char *method, const char *uri,
+    const uint8_t *body, int body_len, const char *ct, const char *extra_hdr,
+    uint8_t **resp_body, int *resp_len, bool *request_started)
 {
+    if (request_started) *request_started = false;
     int timeout_ms = ap2_rtsp_timeout_ms(p, method, uri, ct);
     uint64_t started_ms = ap2_io_monotonic_ms();
     uint64_t deadline_ms = started_ms + (uint64_t)timeout_ms;
@@ -421,9 +431,20 @@ static int ap2_rtsp_send_ex(struct ap2cl_s *p, const char *method, const char *u
                method, uri, waited_ms, timeout_ms);
     int status = ap2_rtsp_send_ex_unlocked(p, method, uri, body, body_len, ct,
                                            extra_hdr, resp_body, resp_len,
-                                           started_ms, deadline_ms);
+                                           started_ms, deadline_ms,
+                                           request_started);
     pthread_mutex_unlock(&p->rtsp_lock);
     return status;
+}
+
+static int ap2_rtsp_send_ex(struct ap2cl_s *p, const char *method,
+                            const char *uri, const uint8_t *body, int body_len,
+                            const char *ct, const char *extra_hdr,
+                            uint8_t **resp_body, int *resp_len)
+{
+    return ap2_rtsp_send_ex_tracked(
+        p, method, uri, body, body_len, ct, extra_hdr,
+        resp_body, resp_len, NULL);
 }
 
 /* Convenience wrapper: send an RTSP request with no extra headers. */
@@ -433,6 +454,16 @@ static int ap2_rtsp_send(struct ap2cl_s *p, const char *method, const char *uri,
 {
     return ap2_rtsp_send_ex(p, method, uri, body, body_len, ct, NULL,
                             resp_body, resp_len);
+}
+
+static int ap2_rtsp_send_tracked(
+    struct ap2cl_s *p, const char *method, const char *uri,
+    const uint8_t *body, int body_len, const char *ct,
+    uint8_t **resp_body, int *resp_len, bool *request_started)
+{
+    return ap2_rtsp_send_ex_tracked(
+        p, method, uri, body, body_len, ct, NULL,
+        resp_body, resp_len, request_started);
 }
 
 static void *ap2_feedback_thread_main(void *arg)
@@ -1866,9 +1897,11 @@ struct ap2cl_s *ap2cl_create(
     p->buffered_sock = -1;
     pthread_mutex_init(&p->rtsp_lock, NULL);
     pthread_mutex_init(&p->mrp_lock, NULL);
+    pthread_mutex_init(&p->mrp_publish_lock, NULL);
     atomic_init(&p->rtsp_dead, false);
     atomic_init(&p->media_healthy, true);
     atomic_init(&p->feedback_failures, 0);
+    atomic_init(&p->mrp_event_health, -1);
     atomic_init(&p->feedback_stop, true);
     atomic_init(&p->rtp_offset, 0);
     if (dacp_id) p->dacp_id = strdup(dacp_id);
@@ -1909,6 +1942,7 @@ bool ap2cl_destroy(struct ap2cl_s *p)
     pthread_mutex_unlock(&p->rtsp_lock);
     pthread_mutex_destroy(&p->rtsp_lock);
     pthread_mutex_destroy(&p->mrp_lock);
+    pthread_mutex_destroy(&p->mrp_publish_lock);
     if (p->data_sock >= 0) close(p->data_sock);
     if (p->ctrl_sock >= 0) close(p->ctrl_sock);
     if (p->events_sock >= 0) close(p->events_sock);
@@ -1992,13 +2026,16 @@ bool ap2cl_disconnect(struct ap2cl_s *p)
         ap2_feedback_stop(p);
         /* Publish the final stopped state before disconnecting MediaRemote,
          * while the encrypted RTSP session is still live. */
+        ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
+        pthread_mutex_lock(&p->mrp_publish_lock);
         pthread_mutex_lock(&p->mrp_lock);
-        if (p->mrp) {
-            ap2_mrp_set_stopped(p->mrp);
-            ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_STOPPED, true);
-            ap2_mrp_stop(p->mrp);
-        }
+        struct ap2_mrp_ctx *mrp = p->mrp;
         pthread_mutex_unlock(&p->mrp_lock);
+        if (mrp) {
+            ap2_mrp_stop(mrp);
+            atomic_store(&p->mrp_event_health, 0);
+        }
+        pthread_mutex_unlock(&p->mrp_publish_lock);
         if (p->events_sock >= 0) {
             close(p->events_sock);
             p->events_sock = -1;
@@ -2045,9 +2082,11 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
         p->start_ntp = ntp_start;
         p->state = AP2_STREAMING;
         atomic_store(&p->media_healthy, true);
+        pthread_mutex_lock(&p->mrp_publish_lock);
         pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) ap2_mrp_set_playing(p->mrp, true);
         pthread_mutex_unlock(&p->mrp_lock);
+        pthread_mutex_unlock(&p->mrp_publish_lock);
         /* Announce the timeline IMMEDIATELY: with a future ntpstart the first
          * audio chunk (and the anchor coupled to it) would otherwise only go
          * out once pacing releases it, and a receiver that sees no time
@@ -2218,23 +2257,13 @@ void ap2cl_pause(struct ap2cl_s *p)
         /* Freeze the buffered timeline in place with a rate-0 anchor. */
         ap2_send_setrateanchortime(p, p->rtp_timestamp, ap2_ptp_master_now_ns(p->ptp), 0);
         p->state = AP2_PAUSED;
-        pthread_mutex_lock(&p->mrp_lock);
-        if (p->mrp) {
-            ap2_mrp_set_playing(p->mrp, false);
-            ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PAUSED, true);
-        }
-        pthread_mutex_unlock(&p->mrp_lock);
+        ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_PAUSED, true);
         return;
     }
     if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
     p->rt_anchor_valid = false;    /* resume re-anchors on a fresh line */
     p->state = AP2_PAUSED;
-    pthread_mutex_lock(&p->mrp_lock);
-    if (p->mrp) {
-        ap2_mrp_set_playing(p->mrp, false);
-        ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PAUSED, true);
-    }
-    pthread_mutex_unlock(&p->mrp_lock);
+    ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_PAUSED, true);
 }
 
 void ap2cl_play(struct ap2cl_s *p)
@@ -2245,12 +2274,7 @@ void ap2cl_play(struct ap2cl_s *p)
         uint64_t anchor_ns = ap2_ptp_master_now_ns(p->ptp) + (uint64_t)p->latency_ms * 1000000ULL;
         ap2_send_setrateanchortime(p, p->rtp_timestamp, anchor_ns, 1);
         p->state = AP2_STREAMING;
-        pthread_mutex_lock(&p->mrp_lock);
-        if (p->mrp) {
-            ap2_mrp_set_playing(p->mrp, true);
-            ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PLAYING, true);
-        }
-        pthread_mutex_unlock(&p->mrp_lock);
+        ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_PLAYING, true);
         return;
     }
     if (p->raopcl) {
@@ -2259,12 +2283,7 @@ void ap2cl_play(struct ap2cl_s *p)
         raopcl_start_at(p->raopcl, now + MS2NTP(200) - TS2NTP(lat, raopcl_sample_rate(p->raopcl)));
     }
     p->state = AP2_STREAMING;
-    pthread_mutex_lock(&p->mrp_lock);
-    if (p->mrp) {
-        ap2_mrp_set_playing(p->mrp, true);
-        ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PLAYING, true);
-    }
-    pthread_mutex_unlock(&p->mrp_lock);
+    ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_PLAYING, true);
 }
 
 void ap2cl_stop(struct ap2cl_s *p)
@@ -2273,12 +2292,7 @@ void ap2cl_stop(struct ap2cl_s *p)
     if (p->use_buffered && p->buffered_sock >= 0)
         ap2_send_flushbuffered(p);
     if (p->raopcl) raopcl_stop(p->raopcl);
-    pthread_mutex_lock(&p->mrp_lock);
-    if (p->mrp) {
-        ap2_mrp_set_stopped(p->mrp);
-        ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_STOPPED, true);
-    }
-    pthread_mutex_unlock(&p->mrp_lock);
+    ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
     p->rt_anchor_valid = false;
     p->state = AP2_DOWN;
 }
@@ -2290,23 +2304,68 @@ bool ap2cl_feedback(struct ap2cl_s *p)
      * not need; the POST itself is what resets the receiver's idle timer. */
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return false;
     uint8_t *resp = NULL; int resp_len = 0;
-    int status = ap2_rtsp_send(p, "POST", "/feedback", NULL, 0, NULL, &resp, &resp_len);
+    bool request_started = false;
+    int status = ap2_rtsp_send_tracked(
+        p, "POST", "/feedback", NULL, 0, NULL,
+        &resp, &resp_len, &request_started);
     free(resp);
-    LOG_DEBUG("[AP2] /feedback keepalive -> %d", status);
-    /* Keep event/DataStream servicing behind the receiver keepalive itself:
-     * an event reply can be delayed, but must never make /feedback miss its
-     * cadence. The MRP lock separates this worker from command-pipe updates. */
+    ap2_feedback_result_t result =
+        ap2_io_feedback_result(status, request_started);
+    if (result == AP2_FEEDBACK_SKIPPED) {
+        LOG_SDEBUG("[AP2] /feedback tick skipped: RTSP control lock budget "
+                   "expired before request start");
+    } else {
+        LOG_DEBUG("[AP2] /feedback keepalive -> %d", status);
+    }
+    /* Service event/DataStream input after the receiver keepalive itself.
+     * State output takes the publication lock only when immediately available,
+     * so metadata work can never delay the next feedback cadence. */
     if (!atomic_load(&p->rtsp_dead)) {
         pthread_mutex_lock(&p->mrp_lock);
-        if (p->mrp) ap2_mrp_tick(p->mrp);
+        struct ap2_mrp_ctx *mrp = p->mrp;
         pthread_mutex_unlock(&p->mrp_lock);
+
+        if (mrp) {
+            ap2_mrp_tick(mrp);
+            pthread_mutex_lock(&p->mrp_lock);
+            if (p->mrp == mrp) {
+                atomic_store(&p->mrp_event_health,
+                             ap2_mrp_event_status(mrp));
+            }
+            pthread_mutex_unlock(&p->mrp_lock);
+
+            if (pthread_mutex_trylock(&p->mrp_publish_lock) == 0) {
+                uint8_t *state = NULL;
+                int state_len = 0;
+                uint64_t state_generation = 0;
+                pthread_mutex_lock(&p->mrp_lock);
+                bool prepared =
+                    p->mrp == mrp &&
+                    ap2_mrp_prepare_state_push(
+                        mrp, &state, &state_len, &state_generation);
+                pthread_mutex_unlock(&p->mrp_lock);
+                if (prepared) {
+                    bool state_ok =
+                        ap2_mrp_send_state_push(mrp, state, state_len);
+                    pthread_mutex_lock(&p->mrp_lock);
+                    if (p->mrp == mrp)
+                        ap2_mrp_complete_state_push(
+                            mrp, state_generation, state_ok);
+                    pthread_mutex_unlock(&p->mrp_lock);
+                }
+                free(state);
+                pthread_mutex_unlock(&p->mrp_publish_lock);
+            } else {
+                LOG_SDEBUG("[MRP] state push deferred behind publication");
+            }
+        }
     }
-    if (status == 200) {
+    if (result == AP2_FEEDBACK_SUCCEEDED) {
         atomic_store(&p->feedback_failures, 0);
-    } else {
+    } else if (result == AP2_FEEDBACK_FAILED) {
         atomic_fetch_add(&p->feedback_failures, 1);
     }
-    return status == 200;
+    return result == AP2_FEEDBACK_SUCCEEDED;
 }
 
 bool ap2cl_control_healthy(struct ap2cl_s *p)
@@ -2316,10 +2375,7 @@ bool ap2cl_control_healthy(struct ap2cl_s *p)
         !atomic_load(&p->media_healthy) ||
         atomic_load(&p->feedback_failures) >= 3)
         return false;
-    pthread_mutex_lock(&p->mrp_lock);
-    bool healthy = !p->mrp || ap2_mrp_event_status(p->mrp) != 0;
-    pthread_mutex_unlock(&p->mrp_lock);
-    return healthy;
+    return atomic_load(&p->mrp_event_health) != 0;
 }
 
 bool ap2cl_set_volume(struct ap2cl_s *p, int volume)
@@ -2420,10 +2476,12 @@ static void ap2_mrp_ready(struct ap2cl_s *p)
         LOG_WARN("[MRP] event-channel attach failed; MediaRemote disabled");
         ap2_mrp_destroy(p->mrp);
         p->mrp = NULL;
+        atomic_store(&p->mrp_event_health, -1);
         return;
     }
     p->events_sock = -1;
     ap2_mrp_set_playing(p->mrp, p->state == AP2_STREAMING);
+    atomic_store(&p->mrp_event_health, ap2_mrp_event_status(p->mrp));
 }
 
 /* Log an RTSP response body for diagnosis: a printable-text view (control bytes
@@ -2453,10 +2511,16 @@ typedef bool (*ap2_mrp_command_builder_t)(struct ap2_mrp_ctx *,
 
 static int ap2_mrp_post_command(struct ap2cl_s *p,
                                 ap2_mrp_command_builder_t builder,
-                                const char *tag)
+                                const char *tag,
+                                uint64_t *artwork_generation)
 {
     uint8_t *body = NULL; int body_len = 0;
-    if (!builder(p->mrp, &body, &body_len)) return -1;
+    pthread_mutex_lock(&p->mrp_lock);
+    bool built = p->mrp && builder(p->mrp, &body, &body_len);
+    if (built && artwork_generation)
+        *artwork_generation = ap2_mrp_artwork_generation(p->mrp);
+    pthread_mutex_unlock(&p->mrp_lock);
+    if (!built) return -1;
     uint8_t *resp = NULL;
     int resp_len = 0;
     int status = ap2_rtsp_send(p, "POST", "/command", body, body_len,
@@ -2484,10 +2548,29 @@ static int ap2_mrp_send_playback_state(struct ap2cl_s *p,
 
     int status = ap2_mrp_post_command(
         p, ap2_mrp_build_playbackstate_command,
-        "[MRP] /command updateMRPlaybackState");
+        "[MRP] /command updateMRPlaybackState", NULL);
     if (ap2_mrp_status_ok(status))
         p->mrp_last_playback_state = state;
     return status;
+}
+
+static void ap2_mrp_publish_playback(struct ap2cl_s *p,
+                                     ap2_mrp_playback_state_t state,
+                                     bool force)
+{
+    if (!p || p->flow != FLOW_NATIVE_AP2) return;
+    pthread_mutex_lock(&p->mrp_publish_lock);
+    pthread_mutex_lock(&p->mrp_lock);
+    if (p->mrp) {
+        if (state == AP2_MRP_PLAYBACK_STOPPED)
+            ap2_mrp_set_stopped(p->mrp);
+        else
+            ap2_mrp_set_playing(
+                p->mrp, state == AP2_MRP_PLAYBACK_PLAYING);
+    }
+    pthread_mutex_unlock(&p->mrp_lock);
+    ap2_mrp_send_playback_state(p, state, force);
+    pthread_mutex_unlock(&p->mrp_publish_lock);
 }
 
 /* Apple AirPlaySender sends the extended metadata immediately after the first
@@ -2503,11 +2586,11 @@ static int ap2_mrp_send_extended_registration(struct ap2cl_s *p)
 
     int st_cmd = ap2_mrp_post_command(
         p, ap2_mrp_build_supportedcommands_command,
-        "[MRP] /command updateMRSupportedCommands");
+        "[MRP] /command updateMRSupportedCommands", NULL);
     int st_state = ap2_mrp_send_playback_state(p, state, true);
     int st_client = ap2_mrp_post_command(
         p, ap2_mrp_build_nowplayingclient_command,
-        "[MRP] /command updateMRNowPlayingClient");
+        "[MRP] /command updateMRNowPlayingClient", NULL);
 
     p->mrp_extended_registered =
         ap2_mrp_status_ok(st_cmd) && ap2_mrp_status_ok(st_state) &&
@@ -2520,22 +2603,30 @@ static int ap2_mrp_send_extended_registration(struct ap2cl_s *p)
     return st_client;
 }
 
-static int ap2cl_mrp_register_locked(struct ap2cl_s *p);
+static int ap2cl_mrp_register_serialized(struct ap2cl_s *p);
 
-static int ap2cl_mrp_push_locked(struct ap2cl_s *p)
+static int ap2cl_mrp_push_serialized(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return -1;
+    pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
-    if (!p->mrp) return -1;
+    bool have_mrp = p->mrp != NULL;
+    pthread_mutex_unlock(&p->mrp_lock);
+    if (!have_mrp) return -1;
 
-    if (!p->mrp_device_registered && ap2cl_mrp_register_locked(p) != 1)
+    if (!p->mrp_device_registered && ap2cl_mrp_register_serialized(p) != 1)
         return 0;
 
+    uint64_t artwork_generation = 0;
     int status = ap2_mrp_post_command(
         p, ap2_mrp_build_nowplaying_command,
-        "[MRP] /command updateMRNowPlayingInfo");
+        "[MRP] /command updateMRNowPlayingInfo", &artwork_generation);
     if (!ap2_mrp_status_ok(status)) return status;
-    ap2_mrp_mark_artwork_sent(p->mrp);
+    pthread_mutex_lock(&p->mrp_lock);
+    if (p->mrp)
+        ap2_mrp_mark_artwork_sent_if_generation(
+            p->mrp, artwork_generation);
+    pthread_mutex_unlock(&p->mrp_lock);
 
     int ext_status;
     if (!p->mrp_extended_registered) {
@@ -2553,9 +2644,9 @@ static int ap2cl_mrp_push_locked(struct ap2cl_s *p)
 int ap2cl_mrp_push(struct ap2cl_s *p)
 {
     if (!p) return -1;
-    pthread_mutex_lock(&p->mrp_lock);
-    int status = ap2cl_mrp_push_locked(p);
-    pthread_mutex_unlock(&p->mrp_lock);
+    pthread_mutex_lock(&p->mrp_publish_lock);
+    int status = ap2cl_mrp_push_serialized(p);
+    pthread_mutex_unlock(&p->mrp_publish_lock);
     return status;
 }
 
@@ -2579,16 +2670,19 @@ int ap2cl_mrp_channel_status(struct ap2cl_s *p)
 /* Register the sender identity before the first now-playing update. The
  * remaining extended metadata follows updateMRNowPlayingInfo in
  * ap2cl_mrp_push(), matching Apple's current AirPlaySender implementation. */
-static int ap2cl_mrp_register_locked(struct ap2cl_s *p)
+static int ap2cl_mrp_register_serialized(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return -1;
+    pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
-    if (!p->mrp) return -1;
+    bool have_mrp = p->mrp != NULL;
+    pthread_mutex_unlock(&p->mrp_lock);
+    if (!have_mrp) return -1;
     if (p->mrp_device_registered) return 1;
 
     int status = ap2_mrp_post_command(
         p, ap2_mrp_build_deviceinfo_command,
-        "[MRP] /command DEVICE_INFO");
+        "[MRP] /command DEVICE_INFO", NULL);
     p->mrp_device_registered = ap2_mrp_status_ok(status);
     return p->mrp_device_registered ? 1 : 0;
 }
@@ -2596,9 +2690,9 @@ static int ap2cl_mrp_register_locked(struct ap2cl_s *p)
 int ap2cl_mrp_register(struct ap2cl_s *p)
 {
     if (!p) return -1;
-    pthread_mutex_lock(&p->mrp_lock);
-    int status = ap2cl_mrp_register_locked(p);
-    pthread_mutex_unlock(&p->mrp_lock);
+    pthread_mutex_lock(&p->mrp_publish_lock);
+    int status = ap2cl_mrp_register_serialized(p);
+    pthread_mutex_unlock(&p->mrp_publish_lock);
     return status;
 }
 
@@ -2606,11 +2700,13 @@ bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist
                         const char *album, int duration)
 {
     if (!p) return false;
+    pthread_mutex_lock(&p->mrp_publish_lock);
     pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
     if (p->mrp)
         ap2_mrp_set_metadata(p->mrp, title, artist, album, duration * 1000);
     pthread_mutex_unlock(&p->mrp_lock);
+    pthread_mutex_unlock(&p->mrp_publish_lock);
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0)
         return ap2_native_send_metadata(p, title, artist, album);
     if (p->raopcl)
@@ -2622,11 +2718,13 @@ bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist
 bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size, const char *data)
 {
     if (!p) return false;
+    pthread_mutex_lock(&p->mrp_publish_lock);
     pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
     if (p->mrp)
         ap2_mrp_set_artwork(p->mrp, content_type, (const uint8_t *)data, size);
     pthread_mutex_unlock(&p->mrp_lock);
+    pthread_mutex_unlock(&p->mrp_publish_lock);
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
         /* Same shape as the RAOP path: the image bytes as the SET_PARAMETER
          * body with its image content type, anchored via RTP-Info (receivers
@@ -2649,12 +2747,14 @@ bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size, co
 bool ap2cl_set_progress(struct ap2cl_s *p, int elapsed_s, int duration_s)
 {
     if (!p) return false;
+    pthread_mutex_lock(&p->mrp_publish_lock);
     pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
     if (p->mrp)
         ap2_mrp_set_progress(p->mrp, elapsed_s * 1000, duration_s * 1000,
                              p->state == AP2_STREAMING);
     pthread_mutex_unlock(&p->mrp_lock);
+    pthread_mutex_unlock(&p->mrp_publish_lock);
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
         /* progress: <start>/<current>/<end>, all in the STREAM's RTP timestamp
          * units (the per-process timeline offset included, so the values match
@@ -2699,3 +2799,15 @@ bool ap2cl_is_playing(struct ap2cl_s *p)
 {
     return p && p->state == AP2_STREAMING && !atomic_load(&p->rtsp_dead);
 }
+
+#ifdef AP2_TESTING
+void ap2cl_test_lock_mrp(struct ap2cl_s *p)
+{
+    pthread_mutex_lock(&p->mrp_lock);
+}
+
+void ap2cl_test_unlock_mrp(struct ap2cl_s *p)
+{
+    pthread_mutex_unlock(&p->mrp_lock);
+}
+#endif

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -207,12 +207,19 @@ static int ap2_rtsp_timeout_ms(struct ap2cl_s *p, const char *method,
 static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, const char *uri,
                           const uint8_t *body, int body_len, const char *ct,
                           const char *extra_hdr,
-                          uint8_t **resp_body, int *resp_len)
+                          uint8_t **resp_body, int *resp_len,
+                          uint64_t started_ms, uint64_t deadline_ms)
 {
     if (atomic_load(&p->rtsp_dead)) {
         *resp_body = NULL;
         *resp_len = 0;
         return 0;
+    }
+    if (ap2_io_monotonic_ms() >= deadline_ms) {
+        *resp_body = NULL;
+        *resp_len = 0;
+        errno = ETIMEDOUT;
+        return -ETIMEDOUT;
     }
     int cseq = p->cseq++;
     char hdr[1024];
@@ -266,11 +273,9 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         if (body && body_len > 0) memcpy(msg + hdr_len, body, body_len);
     }
 
-    int timeout_ms = ap2_rtsp_timeout_ms(p, method, uri, ct);
-    uint64_t started_ms = ap2_io_monotonic_ms();
-    uint64_t deadline_ms = started_ms + (uint64_t)timeout_ms;
     LOG_DEBUG("[AP2] RTSP TX cseq=%d %s %s body=%d wire=%d timeout=%dms",
-              cseq, method, uri, body_len, msg_len, timeout_ms);
+              cseq, method, uri, body_len, msg_len,
+              (int)(deadline_ms - started_ms));
     if (!ap2_io_write_all_deadline(p->sock_fd, msg, msg_len, deadline_ms)) {
         free(msg);
         ap2_mark_rtsp_dead(p, method, uri, "write",
@@ -388,14 +393,35 @@ static int ap2_rtsp_send_ex(struct ap2cl_s *p, const char *method, const char *u
                           const char *extra_hdr,
                           uint8_t **resp_body, int *resp_len)
 {
-    uint64_t wait_started = ap2_io_monotonic_ms();
-    pthread_mutex_lock(&p->rtsp_lock);
-    uint64_t waited_ms = ap2_io_monotonic_ms() - wait_started;
-    if (waited_ms >= 250)
-        LOG_DEBUG("[AP2] RTSP %s %s waited %" PRIu64 "ms for control lock",
-                  method, uri, waited_ms);
+    int timeout_ms = ap2_rtsp_timeout_ms(p, method, uri, ct);
+    uint64_t started_ms = ap2_io_monotonic_ms();
+    uint64_t deadline_ms = started_ms + (uint64_t)timeout_ms;
+    int lock_status =
+        ap2_io_mutex_lock_deadline(&p->rtsp_lock, deadline_ms);
+    uint64_t waited_ms = ap2_io_monotonic_ms() - started_ms;
+    if (lock_status <= 0) {
+        int lock_errno = errno;
+        *resp_body = NULL;
+        *resp_len = 0;
+        if (lock_status == 0) {
+            LOG_SDEBUG("[AP2] RTSP %s %s control lock timed out after "
+                      "%" PRIu64 "ms (budget=%dms)",
+                      method, uri, waited_ms, timeout_ms);
+            errno = ETIMEDOUT;
+            return -ETIMEDOUT;
+        }
+        LOG_ERROR("[AP2] RTSP %s %s control lock failed after %" PRIu64
+                  "ms: %s",
+                  method, uri, waited_ms, strerror(lock_errno));
+        errno = lock_errno;
+        return -lock_errno;
+    }
+    LOG_SDEBUG("[AP2] RTSP %s %s acquired control lock after %" PRIu64
+               "ms (budget=%dms)",
+               method, uri, waited_ms, timeout_ms);
     int status = ap2_rtsp_send_ex_unlocked(p, method, uri, body, body_len, ct,
-                                           extra_hdr, resp_body, resp_len);
+                                           extra_hdr, resp_body, resp_len,
+                                           started_ms, deadline_ms);
     pthread_mutex_unlock(&p->rtsp_lock);
     return status;
 }
@@ -1174,7 +1200,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     resp = NULL; resp_len = 0;
     status = ap2_rtsp_send(p, "RECORD", p->session_url, NULL, 0, NULL, &resp, &resp_len);
     free(resp);
-    if (status == 0) {
+    if (status <= 0) {
         return false;
     } else if (status != 200) {
         LOG_WARN("[AP2] RECORD returned %d", status);
@@ -1198,7 +1224,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
         free(sp_data);
         free(resp);
         LOG_INFO("[AP2] SETPEERS [%s, %s] -> %d", p->device.address, our_addr, sp_status);
-        if (sp_status == 0) return false;
+        if (sp_status <= 0) return false;
 
         const char *peers[2] = { p->device.address, our_addr };
         ap2_ptp_set_peers(p->ptp, peers, 2);

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -31,6 +31,7 @@
 #include <pthread.h>
 #include <poll.h>
 #include <stdatomic.h>
+#include <inttypes.h>
 
 #include <openssl/rand.h>
 #include <openssl/evp.h>

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <netinet/in.h>
 
+#include "ap2_io.h"
+
 struct ap2cl_s;
 
 /* AP2 session states */
@@ -128,14 +130,25 @@ bool ap2cl_disconnect(struct ap2cl_s *p);
 bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start);
 
 /* Send a chunk of PCM audio data.
- * Returns true on success.
+ * A transient realtime UDP drop advances the media timeline and returns
+ * AP2_SEND_DROPPED; hard encode/control/session failures return AP2_SEND_FATAL.
  * :param sample: Raw PCM audio bytes (interleaved, little-endian).
  * :param frames: Number of audio frames in the sample buffer.
  */
-bool ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames);
+ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample,
+                                   int frames);
 
 /* Check if the client is ready to accept more audio frames. */
 bool ap2cl_accept_frames(struct ap2cl_s *p);
+
+/* Re-anchor a realtime stream after PCM starvation exhausts its pacing lead. */
+bool ap2cl_recover_input_gap(struct ap2cl_s *p);
+
+/* Emit native pacing, packet-drop, and anchor diagnostics at debug level 10. */
+void ap2cl_log_diagnostics(struct ap2cl_s *p);
+
+/* False after terminal RTSP/media/event failures. */
+bool ap2cl_control_healthy(struct ap2cl_s *p);
 
 /* Pause playback. */
 void ap2cl_pause(struct ap2cl_s *p);

--- a/src/ap2_hap.c
+++ b/src/ap2_hap.c
@@ -1388,7 +1388,7 @@ int ap2_hap_decrypt(struct ap2_hap_ctx *ctx, const uint8_t *in, int in_len,
     if (!ctx || !ctx->verified || !in || in_len <= 0) return -1;
 
     /* Worst case: output is slightly smaller than input */
-    *out = malloc(in_len);
+    *out = malloc((size_t)in_len + 1);
     if (!*out) return -1;
 
     int out_offset = 0, in_offset = 0;
@@ -1426,5 +1426,6 @@ int ap2_hap_decrypt(struct ap2_hap_ctx *ctx, const uint8_t *in, int in_len,
         in_offset += chunk + HAP_TAG_SIZE;
     }
 
+    (*out)[out_offset] = '\0';
     return out_offset;
 }

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -147,6 +147,7 @@ ap2_send_result_t ap2_io_send_datagram_deadline(
             errno = ETIMEDOUT;
             return AP2_SEND_DROPPED;
         }
+
         ssize_t sent = addr
                            ? sendto(fd, data, len, MSG_DONTWAIT, addr, addr_len)
                            : send(fd, data, len, MSG_DONTWAIT);
@@ -165,6 +166,15 @@ ap2_send_result_t ap2_io_send_datagram_deadline(
         if (ready == 0) return AP2_SEND_DROPPED;
         return AP2_SEND_FATAL;
     }
+}
+
+ap2_feedback_result_t ap2_io_feedback_result(int rtsp_status,
+                                             bool request_started)
+{
+    if (rtsp_status == 200) return AP2_FEEDBACK_SUCCEEDED;
+    if (rtsp_status == -ETIMEDOUT && !request_started)
+        return AP2_FEEDBACK_SKIPPED;
+    return AP2_FEEDBACK_FAILED;
 }
 
 static size_t ap2_find_header_end(const uint8_t *data, size_t len)

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -17,6 +17,35 @@ uint64_t ap2_io_monotonic_ms(void)
     return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)ts.tv_nsec / 1000000ULL;
 }
 
+int ap2_io_mutex_lock_deadline(pthread_mutex_t *mutex, uint64_t deadline_ms)
+{
+    if (!mutex) {
+        errno = EINVAL;
+        return -1;
+    }
+    for (;;) {
+        uint64_t now = ap2_io_monotonic_ms();
+        if (now >= deadline_ms) {
+            errno = ETIMEDOUT;
+            return 0;
+        }
+
+        int err = pthread_mutex_trylock(mutex);
+        if (err == 0) return 1;
+        if (err != EBUSY) {
+            errno = err;
+            return -1;
+        }
+
+        uint64_t remaining_ms = deadline_ms - now;
+        long sleep_ns = remaining_ms > 1
+                            ? 1000000L
+                            : (long)remaining_ms * 1000000L;
+        struct timespec delay = {.tv_nsec = sleep_ns};
+        while (nanosleep(&delay, &delay) < 0 && errno == EINTR) {}
+    }
+}
+
 int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms)
 {
     for (;;) {

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -1,0 +1,98 @@
+#include "ap2_io.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <time.h>
+
+uint64_t ap2_io_monotonic_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)ts.tv_nsec / 1000000ULL;
+}
+
+int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms)
+{
+    for (;;) {
+        uint64_t now = ap2_io_monotonic_ms();
+        if (now >= deadline_ms) {
+            errno = ETIMEDOUT;
+            return 0;
+        }
+        int timeout = (int)(deadline_ms - now);
+        struct pollfd pfd = {.fd = fd, .events = events};
+        int ret = poll(&pfd, 1, timeout);
+        if (ret < 0 && errno == EINTR) continue;
+        if (ret <= 0) {
+            if (ret == 0) errno = ETIMEDOUT;
+            return ret;
+        }
+        if (pfd.revents & events) return 1;
+        if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            errno = ECONNRESET;
+            return -1;
+        }
+    }
+}
+
+bool ap2_io_write_all_deadline(int fd, const uint8_t *data, int len,
+                               uint64_t deadline_ms)
+{
+    int original_flags = fcntl(fd, F_GETFL);
+    if (original_flags < 0) return false;
+    bool restore_flags = !(original_flags & O_NONBLOCK);
+    if (restore_flags && fcntl(fd, F_SETFL, original_flags | O_NONBLOCK) < 0)
+        return false;
+
+    bool ok = false;
+    int off = 0;
+    while (off < len) {
+        if (ap2_io_poll_fd(fd, POLLOUT, deadline_ms) <= 0) break;
+        ssize_t n = send(fd, data + off, (size_t)(len - off), MSG_DONTWAIT);
+        if (n > 0) {
+            off += (int)n;
+        } else if (n < 0 && (errno == EINTR || errno == EAGAIN ||
+                             errno == EWOULDBLOCK)) {
+            continue;
+        } else {
+            if (n == 0) errno = EPIPE;
+            break;
+        }
+    }
+    if (off == len) ok = true;
+    int saved_errno = errno;
+    if (restore_flags) fcntl(fd, F_SETFL, original_flags);
+    errno = saved_errno;
+    return ok;
+}
+
+ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
+                             uint64_t deadline_ms)
+{
+    int original_flags = fcntl(fd, F_GETFL);
+    if (original_flags < 0) return -1;
+    bool restore_flags = !(original_flags & O_NONBLOCK);
+    if (restore_flags && fcntl(fd, F_SETFL, original_flags | O_NONBLOCK) < 0)
+        return -1;
+
+    ssize_t result;
+    for (;;) {
+        if (ap2_io_poll_fd(fd, POLLIN, deadline_ms) <= 0) {
+            result = -1;
+            break;
+        }
+        ssize_t n = recv(fd, buf, len, MSG_DONTWAIT);
+        if (n < 0 && (errno == EINTR || errno == EAGAIN ||
+                      errno == EWOULDBLOCK))
+            continue;
+        if (n == 0) errno = ECONNRESET;
+        result = n;
+        break;
+    }
+    int saved_errno = errno;
+    if (restore_flags) fcntl(fd, F_SETFL, original_flags);
+    errno = saved_errno;
+    return result;
+}

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -2,8 +2,12 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <poll.h>
-#include <sys/socket.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 #include <time.h>
 
 uint64_t ap2_io_monotonic_ms(void)
@@ -21,7 +25,8 @@ int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms)
             errno = ETIMEDOUT;
             return 0;
         }
-        int timeout = (int)(deadline_ms - now);
+        uint64_t remaining = deadline_ms - now;
+        int timeout = remaining > INT_MAX ? INT_MAX : (int)remaining;
         struct pollfd pfd = {.fd = fd, .events = events};
         int ret = poll(&pfd, 1, timeout);
         if (ret < 0 && errno == EINTR) continue;
@@ -37,7 +42,7 @@ int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms)
     }
 }
 
-bool ap2_io_write_all_deadline(int fd, const uint8_t *data, int len,
+bool ap2_io_write_all_deadline(int fd, const uint8_t *data, size_t len,
                                uint64_t deadline_ms)
 {
     int original_flags = fcntl(fd, F_GETFL);
@@ -47,21 +52,31 @@ bool ap2_io_write_all_deadline(int fd, const uint8_t *data, int len,
         return false;
 
     bool ok = false;
-    int off = 0;
-    while (off < len) {
+    size_t offset = 0;
+    while (offset < len) {
+        if (ap2_io_monotonic_ms() >= deadline_ms) {
+            errno = ETIMEDOUT;
+            break;
+        }
         if (ap2_io_poll_fd(fd, POLLOUT, deadline_ms) <= 0) break;
-        ssize_t n = send(fd, data + off, (size_t)(len - off), MSG_DONTWAIT);
-        if (n > 0) {
-            off += (int)n;
-        } else if (n < 0 && (errno == EINTR || errno == EAGAIN ||
-                             errno == EWOULDBLOCK)) {
+#ifdef MSG_NOSIGNAL
+        ssize_t written = send(fd, data + offset, len - offset,
+                               MSG_DONTWAIT | MSG_NOSIGNAL);
+#else
+        ssize_t written = send(fd, data + offset, len - offset, MSG_DONTWAIT);
+#endif
+        if (written > 0) {
+            offset += (size_t)written;
+        } else if (written < 0 &&
+                   (errno == EINTR || errno == EAGAIN ||
+                    errno == EWOULDBLOCK || errno == ENOBUFS)) {
             continue;
         } else {
-            if (n == 0) errno = EPIPE;
+            if (written == 0) errno = EPIPE;
             break;
         }
     }
-    if (off == len) ok = true;
+    if (offset == len) ok = true;
     int saved_errno = errno;
     if (restore_flags) fcntl(fd, F_SETFL, original_flags);
     errno = saved_errno;
@@ -77,22 +92,146 @@ ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
     if (restore_flags && fcntl(fd, F_SETFL, original_flags | O_NONBLOCK) < 0)
         return -1;
 
-    ssize_t result;
+    ssize_t result = -1;
     for (;;) {
-        if (ap2_io_poll_fd(fd, POLLIN, deadline_ms) <= 0) {
-            result = -1;
-            break;
-        }
-        ssize_t n = recv(fd, buf, len, MSG_DONTWAIT);
-        if (n < 0 && (errno == EINTR || errno == EAGAIN ||
-                      errno == EWOULDBLOCK))
+        if (ap2_io_poll_fd(fd, POLLIN, deadline_ms) <= 0) break;
+        result = recv(fd, buf, len, MSG_DONTWAIT);
+        if (result < 0 &&
+            (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK))
             continue;
-        if (n == 0) errno = ECONNRESET;
-        result = n;
+        if (result == 0) errno = ECONNRESET;
         break;
     }
     int saved_errno = errno;
     if (restore_flags) fcntl(fd, F_SETFL, original_flags);
     errno = saved_errno;
     return result;
+}
+
+ap2_send_result_t ap2_io_send_datagram_deadline(
+    int fd, const uint8_t *data, size_t len,
+    const struct sockaddr *addr, socklen_t addr_len, uint64_t deadline_ms)
+{
+    bool backpressured = false;
+    for (;;) {
+        if (backpressured && ap2_io_monotonic_ms() >= deadline_ms) {
+            errno = ETIMEDOUT;
+            return AP2_SEND_DROPPED;
+        }
+        ssize_t sent = addr
+                           ? sendto(fd, data, len, MSG_DONTWAIT, addr, addr_len)
+                           : send(fd, data, len, MSG_DONTWAIT);
+        if (sent == (ssize_t)len) return AP2_SEND_SENT;
+        if (sent >= 0) {
+            errno = EMSGSIZE;
+            return AP2_SEND_FATAL;
+        }
+        if (errno == EINTR) continue;
+        if (errno != EAGAIN && errno != EWOULDBLOCK && errno != ENOBUFS)
+            return AP2_SEND_FATAL;
+
+        backpressured = true;
+        int ready = ap2_io_poll_fd(fd, POLLOUT, deadline_ms);
+        if (ready > 0) continue;
+        if (ready == 0) return AP2_SEND_DROPPED;
+        return AP2_SEND_FATAL;
+    }
+}
+
+static size_t ap2_find_header_end(const uint8_t *data, size_t len)
+{
+    for (size_t i = 0; i + 3 < len; i++) {
+        if (data[i] == '\r' && data[i + 1] == '\n' &&
+            data[i + 2] == '\r' && data[i + 3] == '\n')
+            return i + 4;
+    }
+    return 0;
+}
+
+static bool ap2_parse_decimal(const uint8_t *data, size_t len, long *value)
+{
+    if (!len || len >= 32) return false;
+    char text[32];
+    memcpy(text, data, len);
+    text[len] = '\0';
+    char *end = NULL;
+    errno = 0;
+    long parsed = strtol(text, &end, 10);
+    if (errno || end == text || *end != '\0' || parsed < 0) return false;
+    *value = parsed;
+    return true;
+}
+
+int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
+                               ap2_rtsp_response_t *response)
+{
+    if (!data || !response) return -1;
+    size_t header_len = ap2_find_header_end(data, len);
+    if (!header_len) return 0;
+
+    const uint8_t *line_end = NULL;
+    for (size_t i = 0; i + 1 < header_len; i++) {
+        if (data[i] == '\r' && data[i + 1] == '\n') {
+            line_end = data + i;
+            break;
+        }
+    }
+    if (!line_end) return -1;
+
+    int status = 0;
+    char status_line[128];
+    size_t status_len = (size_t)(line_end - data);
+    if (status_len >= sizeof(status_line)) return -1;
+    memcpy(status_line, data, status_len);
+    status_line[status_len] = '\0';
+    if (sscanf(status_line, "RTSP/%*s %d", &status) != 1 || status <= 0)
+        return -1;
+
+    size_t body_len = 0;
+    int cseq = -1;
+    size_t offset = status_len + 2;
+    while (offset + 2 <= header_len) {
+        size_t end = offset;
+        while (end + 1 < header_len &&
+               !(data[end] == '\r' && data[end + 1] == '\n'))
+            end++;
+        if (end == offset) break;
+
+        size_t colon = offset;
+        while (colon < end && data[colon] != ':') colon++;
+        if (colon == end) return -1;
+        size_t value = colon + 1;
+        while (value < end && (data[value] == ' ' || data[value] == '\t'))
+            value++;
+        size_t value_end = end;
+        while (value_end > value &&
+               (data[value_end - 1] == ' ' || data[value_end - 1] == '\t'))
+            value_end--;
+
+        long parsed = 0;
+        size_t name_len = colon - offset;
+        if (name_len == 14 &&
+            strncasecmp((const char *)data + offset, "Content-Length", 14) == 0) {
+            if (!ap2_parse_decimal(data + value, value_end - value, &parsed))
+                return -1;
+            body_len = (size_t)parsed;
+        } else if (name_len == 4 &&
+                   strncasecmp((const char *)data + offset, "CSeq", 4) == 0) {
+            if (!ap2_parse_decimal(data + value, value_end - value, &parsed) ||
+                parsed > INT_MAX)
+                return -1;
+            cseq = (int)parsed;
+        }
+        offset = end + 2;
+    }
+
+    if (body_len > SIZE_MAX - header_len) return -1;
+    size_t message_len = header_len + body_len;
+    if (len < message_len) return 0;
+    response->status = status;
+    response->cseq = cseq;
+    response->header_len = header_len;
+    response->body_len = body_len;
+    response->message_len = message_len;
+    return 1;
 }

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -4,13 +4,36 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <sys/socket.h>
 #include <sys/types.h>
+
+typedef enum {
+    AP2_SEND_FATAL = -1,
+    AP2_SEND_DROPPED = 0,
+    AP2_SEND_SENT = 1,
+} ap2_send_result_t;
+
+typedef struct {
+    int status;
+    int cseq;
+    size_t header_len;
+    size_t body_len;
+    size_t message_len;
+} ap2_rtsp_response_t;
 
 uint64_t ap2_io_monotonic_ms(void);
 int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms);
-bool ap2_io_write_all_deadline(int fd, const uint8_t *data, int len,
+bool ap2_io_write_all_deadline(int fd, const uint8_t *data, size_t len,
                                uint64_t deadline_ms);
 ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
                              uint64_t deadline_ms);
+ap2_send_result_t ap2_io_send_datagram_deadline(
+    int fd, const uint8_t *data, size_t len,
+    const struct sockaddr *addr, socklen_t addr_len, uint64_t deadline_ms);
+
+/* Returns 1 for a complete response, 0 for incomplete input, and -1 for
+ * malformed input. */
+int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
+                               ap2_rtsp_response_t *response);
 
 #endif

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -14,6 +14,12 @@ typedef enum {
     AP2_SEND_SENT = 1,
 } ap2_send_result_t;
 
+typedef enum {
+    AP2_FEEDBACK_FAILED = -1,
+    AP2_FEEDBACK_SKIPPED = 0,
+    AP2_FEEDBACK_SUCCEEDED = 1,
+} ap2_feedback_result_t;
+
 typedef struct {
     int status;
     int cseq;
@@ -33,6 +39,9 @@ ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
 ap2_send_result_t ap2_io_send_datagram_deadline(
     int fd, const uint8_t *data, size_t len,
     const struct sockaddr *addr, socklen_t addr_len, uint64_t deadline_ms);
+
+ap2_feedback_result_t ap2_io_feedback_result(int rtsp_status,
+                                             bool request_started);
 
 /* Returns 1 for a complete response, 0 for incomplete input, and -1 for
  * malformed input. */

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -1,0 +1,16 @@
+#ifndef __AP2_IO_H_
+#define __AP2_IO_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+uint64_t ap2_io_monotonic_ms(void);
+int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms);
+bool ap2_io_write_all_deadline(int fd, const uint8_t *data, int len,
+                               uint64_t deadline_ms);
+ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
+                             uint64_t deadline_ms);
+
+#endif

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <pthread.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 
@@ -22,6 +23,8 @@ typedef struct {
 } ap2_rtsp_response_t;
 
 uint64_t ap2_io_monotonic_ms(void);
+/* Returns 1 when acquired, 0 on deadline expiry, and -1 on mutex error. */
+int ap2_io_mutex_lock_deadline(pthread_mutex_t *mutex, uint64_t deadline_ms);
 int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms);
 bool ap2_io_write_all_deadline(int fd, const uint8_t *data, size_t len,
                                uint64_t deadline_ms);

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <stdbool.h>
 #include <unistd.h>
 #include <errno.h>
@@ -171,6 +172,20 @@ struct ap2_mrp_ctx {
     int rx_enc_len;
     uint8_t rx_msg[16384];    /* decrypted data-frame bytes */
     int rx_msg_len;
+
+    /* Encrypted reverse event channel. It has independent HKDF keys/counters
+     * from both RTSP control and the optional type-130 data channel. The socket
+     * remains owned by ap2_client. */
+    int event_sock;
+    bool event_connected;
+    uint8_t event_out_key[MRP_KEY_SIZE]; /* Events-Read-Encryption-Key */
+    uint8_t event_in_key[MRP_KEY_SIZE];  /* Events-Write-Encryption-Key */
+    uint64_t event_out_counter;
+    uint64_t event_in_counter;
+    uint8_t event_rx_enc[8192];
+    int event_rx_enc_len;
+    uint8_t event_plain[16384];
+    int event_plain_len;
 
     /* Now-playing state (owned copies) */
     char *title;
@@ -639,10 +654,11 @@ static int mrp_chacha_decrypt(const uint8_t *key, const uint8_t *nonce,
     return ok == 1 ? pt_len : -1;
 }
 
-/* Encrypt a plaintext blob into HAP channel frames with our out_key/counter.
- * Caller frees *out. Returns total byte count or -1. */
-static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
-                               int in_len, uint8_t **out)
+/* Encrypt a plaintext blob into HAP channel frames. Caller frees *out. */
+static int mrp_channel_encrypt_with(const uint8_t key[MRP_KEY_SIZE],
+                                    uint64_t *counter,
+                                    const uint8_t *in, int in_len,
+                                    uint8_t **out)
 {
     int num_frames = (in_len + MRP_FRAME_MAX - 1) / MRP_FRAME_MAX;
     int total = num_frames * (2 + MRP_TAG_SIZE) + in_len;
@@ -659,10 +675,10 @@ static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
         out_off += 2;
 
         uint8_t nonce[MRP_NONCE_SIZE];
-        mrp_make_nonce(m->out_counter++, nonce);
+        mrp_make_nonce((*counter)++, nonce);
 
         uint8_t tag[MRP_TAG_SIZE];
-        if (mrp_chacha_encrypt(m->out_key, nonce, len_bytes, 2,
+        if (mrp_chacha_encrypt(key, nonce, len_bytes, 2,
                                in + in_off, chunk,
                                *out + out_off, tag) < 0) {
             free(*out);
@@ -677,7 +693,30 @@ static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
     return out_off;
 }
 
+static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
+                               int in_len, uint8_t **out)
+{
+    return mrp_channel_encrypt_with(m->out_key, &m->out_counter,
+                                    in, in_len, out);
+}
+
 /* ---- Data-frame construction and send ---- */
+
+static bool mrp_write_all(int fd, const uint8_t *data, int len)
+{
+    int off = 0;
+    while (off < len) {
+        ssize_t n = write(fd, data + off, (size_t)(len - off));
+        if (n > 0) {
+            off += (int)n;
+        } else if (n < 0 && errno == EINTR) {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
 
 /* Write the 32-byte big-endian data-frame header. */
 static void mrp_write_data_header(uint8_t hdr[MRP_DATA_HDR_LEN],
@@ -706,7 +745,7 @@ static bool mrp_send_raw(struct ap2_mrp_ctx *m, const uint8_t *data, int len)
     int enc_len = mrp_channel_encrypt(m, data, len, &enc);
     bool ok = false;
     if (enc_len > 0 && enc)
-        ok = write(m->sock, enc, enc_len) == enc_len;
+        ok = mrp_write_all(m->sock, enc, enc_len);
     free(enc);
     pthread_mutex_unlock(&m->send_lock);
     return ok;
@@ -780,38 +819,57 @@ static bool mrp_push_state(struct ap2_mrp_ctx *m, bool include_artwork)
 
 /* ---- Inbound handling ---- */
 
-/* Decrypt whatever channel frames are complete in rx_enc into rx_msg. */
-static void mrp_drain_encrypted(struct ap2_mrp_ctx *m)
+static bool mrp_drain_channel_frames(uint8_t *enc, int *enc_len,
+                                     uint8_t *plain, int *plain_len,
+                                     int plain_cap,
+                                     const uint8_t key[MRP_KEY_SIZE],
+                                     uint64_t *counter,
+                                     const char *label)
 {
     int off = 0;
-    while (off + 2 <= m->rx_enc_len) {
-        int chunk = m->rx_enc[off] | (m->rx_enc[off + 1] << 8);
-        if (off + 2 + chunk + MRP_TAG_SIZE > m->rx_enc_len) break;
-
-        uint8_t len_bytes[2] = { m->rx_enc[off], m->rx_enc[off + 1] };
-        uint8_t nonce[MRP_NONCE_SIZE];
-        mrp_make_nonce(m->in_counter++, nonce);
-
-        if (m->rx_msg_len + chunk <= (int)sizeof(m->rx_msg)) {
-            int n = mrp_chacha_decrypt(m->in_key, nonce, len_bytes, 2,
-                                       m->rx_enc + off + 2, chunk,
-                                       m->rx_enc + off + 2 + chunk,
-                                       m->rx_msg + m->rx_msg_len);
-            if (n < 0) {
-                LOG_ERROR("[MRP] channel frame decryption failed");
-                m->connected = false;
-                return;
-            }
-            m->rx_msg_len += n;
-        } else {
-            LOG_WARN("[MRP] inbound message buffer full, dropping frame");
+    while (off + 2 <= *enc_len) {
+        int chunk = enc[off] | (enc[off + 1] << 8);
+        if (chunk <= 0 || chunk > MRP_FRAME_MAX) {
+            LOG_ERROR("[MRP] invalid %s frame size %d", label, chunk);
+            return false;
         }
+        if (off + 2 + chunk + MRP_TAG_SIZE > *enc_len) break;
+
+        if (*plain_len + chunk > plain_cap) {
+            LOG_ERROR("[MRP] %s plaintext buffer full", label);
+            return false;
+        }
+
+        uint8_t len_bytes[2] = { enc[off], enc[off + 1] };
+        uint8_t nonce[MRP_NONCE_SIZE];
+        mrp_make_nonce((*counter)++, nonce);
+
+        int n = mrp_chacha_decrypt(key, nonce, len_bytes, 2,
+                                   enc + off + 2, chunk,
+                                   enc + off + 2 + chunk,
+                                   plain + *plain_len);
+        if (n < 0) {
+            LOG_ERROR("[MRP] %s frame decryption failed", label);
+            return false;
+        }
+        *plain_len += n;
         off += 2 + chunk + MRP_TAG_SIZE;
     }
     if (off > 0) {
-        memmove(m->rx_enc, m->rx_enc + off, m->rx_enc_len - off);
-        m->rx_enc_len -= off;
+        memmove(enc, enc + off, *enc_len - off);
+        *enc_len -= off;
     }
+    return true;
+}
+
+/* Decrypt whatever data-channel frames are complete into rx_msg. */
+static void mrp_drain_encrypted(struct ap2_mrp_ctx *m)
+{
+    if (!mrp_drain_channel_frames(m->rx_enc, &m->rx_enc_len,
+                                  m->rx_msg, &m->rx_msg_len,
+                                  (int)sizeof(m->rx_msg),
+                                  m->in_key, &m->in_counter, "data channel"))
+        m->connected = false;
 }
 
 /* Consume complete 32-byte-header data frames from rx_msg. Incoming protobufs
@@ -850,6 +908,191 @@ static void mrp_process_frames(struct ap2_mrp_ctx *m)
     }
 }
 
+/* ---- Reverse event-channel handling ---- */
+
+static int mrp_http_header_end(const uint8_t *data, int len)
+{
+    for (int i = 0; i + 3 < len; i++) {
+        if (data[i] == '\r' && data[i + 1] == '\n' &&
+            data[i + 2] == '\r' && data[i + 3] == '\n')
+            return i + 4;
+    }
+    return 0;
+}
+
+static bool mrp_http_header_value(const char *header, const char *name,
+                                  char *out, size_t out_size)
+{
+    size_t name_len = strlen(name);
+    const char *line = strstr(header, "\r\n");
+    if (!line) return false;
+    line += 2;
+
+    while (*line) {
+        const char *end = strstr(line, "\r\n");
+        if (!end || end == line) break;
+        size_t line_len = (size_t)(end - line);
+        if (line_len > name_len && line[name_len] == ':' &&
+            strncasecmp(line, name, name_len) == 0) {
+            const char *value = line + name_len + 1;
+            while (value < end && (*value == ' ' || *value == '\t')) value++;
+            while (end > value && (end[-1] == ' ' || end[-1] == '\t')) end--;
+            size_t value_len = (size_t)(end - value);
+            if (value_len >= out_size) value_len = out_size - 1;
+            memcpy(out, value, value_len);
+            out[value_len] = '\0';
+            return true;
+        }
+        line = end + 2;
+    }
+    return false;
+}
+
+static bool mrp_event_send_response(struct ap2_mrp_ctx *m,
+                                    const uint8_t *response, int response_len)
+{
+    pthread_mutex_lock(&m->send_lock);
+    uint8_t *enc = NULL;
+    int enc_len = mrp_channel_encrypt_with(
+        m->event_out_key, &m->event_out_counter,
+        response, response_len, &enc);
+    bool ok = enc_len > 0 && enc &&
+              mrp_write_all(m->event_sock, enc, enc_len);
+    free(enc);
+    pthread_mutex_unlock(&m->send_lock);
+    return ok;
+}
+
+static bool mrp_process_event_requests(struct ap2_mrp_ctx *m)
+{
+    int off = 0;
+    while (off < m->event_plain_len) {
+        int available = m->event_plain_len - off;
+        int header_len = mrp_http_header_end(m->event_plain + off, available);
+        if (!header_len) break;
+        if (header_len >= 8192) {
+            LOG_ERROR("[MRP] event HTTP header too large");
+            return false;
+        }
+
+        char header[8192];
+        memcpy(header, m->event_plain + off, (size_t)header_len);
+        header[header_len] = '\0';
+
+        int content_len = 0;
+        char value[256];
+        if (mrp_http_header_value(header, "Content-Length",
+                                  value, sizeof(value))) {
+            char *end = NULL;
+            long parsed = strtol(value, &end, 10);
+            if (!end || end == value || *end != '\0' || parsed < 0 ||
+                parsed > (long)sizeof(m->event_plain)) {
+                LOG_ERROR("[MRP] invalid event Content-Length: %s", value);
+                return false;
+            }
+            content_len = (int)parsed;
+        }
+        if (header_len + content_len > available) break;
+
+        char method[16] = "";
+        char path[256] = "";
+        char version[16] = "RTSP/1.0";
+        if (sscanf(header, "%15s %255s %15s", method, path, version) < 3) {
+            LOG_ERROR("[MRP] malformed event request line");
+            return false;
+        }
+
+        char cseq[64] = "";
+        char server[256] = "";
+        bool have_cseq = mrp_http_header_value(header, "CSeq",
+                                               cseq, sizeof(cseq));
+        bool have_server = mrp_http_header_value(header, "Server",
+                                                 server, sizeof(server));
+        char response[768];
+        int response_len = snprintf(
+            response, sizeof(response),
+            "%s 200 OK\r\n"
+            "Content-Length: 0\r\n"
+            "Audio-Latency: 0\r\n"
+            "%s%s%s"
+            "%s%s%s"
+            "\r\n",
+            version,
+            have_server ? "Server: " : "", have_server ? server : "",
+            have_server ? "\r\n" : "",
+            have_cseq ? "CSeq: " : "", have_cseq ? cseq : "",
+            have_cseq ? "\r\n" : "");
+        if (response_len <= 0 || response_len >= (int)sizeof(response) ||
+            !mrp_event_send_response(m, (const uint8_t *)response,
+                                     response_len)) {
+            LOG_ERROR("[MRP] event response send failed");
+            return false;
+        }
+        LOG_DEBUG("[MRP] event %s %s -> 200%s%s",
+                  method, path, have_cseq ? " cseq=" : "",
+                  have_cseq ? cseq : "");
+        off += header_len + content_len;
+    }
+
+    if (off > 0) {
+        memmove(m->event_plain, m->event_plain + off,
+                (size_t)(m->event_plain_len - off));
+        m->event_plain_len -= off;
+    }
+    return true;
+}
+
+static void mrp_tick_events(struct ap2_mrp_ctx *m)
+{
+    if (!m->event_connected || m->event_sock < 0) return;
+
+    struct pollfd pfd = {
+        .fd = m->event_sock,
+        .events = POLLIN,
+    };
+    while (poll(&pfd, 1, 0) > 0) {
+        if (pfd.revents & (POLLERR | POLLNVAL)) {
+            LOG_WARN("[MRP] event channel socket error");
+            m->event_connected = false;
+            return;
+        }
+        if (!(pfd.revents & POLLIN)) {
+            if (pfd.revents & POLLHUP) {
+                LOG_WARN("[MRP] event channel closed by receiver");
+                m->event_connected = false;
+            }
+            return;
+        }
+
+        int space = (int)sizeof(m->event_rx_enc) - m->event_rx_enc_len;
+        if (space <= 0) {
+            LOG_ERROR("[MRP] event encrypted buffer full");
+            m->event_connected = false;
+            return;
+        }
+        ssize_t n = read(m->event_sock,
+                         m->event_rx_enc + m->event_rx_enc_len,
+                         (size_t)space);
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return;
+        if (n <= 0) {
+            LOG_WARN("[MRP] event channel closed by receiver");
+            m->event_connected = false;
+            return;
+        }
+        m->event_rx_enc_len += (int)n;
+        if (!mrp_drain_channel_frames(
+                m->event_rx_enc, &m->event_rx_enc_len,
+                m->event_plain, &m->event_plain_len,
+                (int)sizeof(m->event_plain),
+                m->event_in_key, &m->event_in_counter, "event channel") ||
+            !mrp_process_event_requests(m)) {
+            m->event_connected = false;
+            return;
+        }
+        pfd.revents = 0;
+    }
+}
+
 /* ---- Public API ---- */
 
 struct ap2_mrp_ctx *ap2_mrp_create(const char *host, int port,
@@ -875,6 +1118,7 @@ struct ap2_mrp_ctx *ap2_mrp_create(const char *host, int port,
     m->playback_state = AP2_MRP_PLAYBACK_PAUSED;
     m->elapsed_set_at = mrp_cf_now();
     m->sock = -1;
+    m->event_sock = -1;
     pthread_mutex_init(&m->send_lock, NULL);
 
     if (reuse_shared_secret) {
@@ -899,6 +1143,8 @@ void ap2_mrp_destroy(struct ap2_mrp_ctx *m)
     OPENSSL_cleanse(m->shared_secret, sizeof(m->shared_secret));
     OPENSSL_cleanse(m->out_key, sizeof(m->out_key));
     OPENSSL_cleanse(m->in_key, sizeof(m->in_key));
+    OPENSSL_cleanse(m->event_out_key, sizeof(m->event_out_key));
+    OPENSSL_cleanse(m->event_in_key, sizeof(m->event_in_key));
     free(m->host);
     free(m->auth_credentials);
     free(m->dacp_id);
@@ -911,6 +1157,34 @@ void ap2_mrp_destroy(struct ap2_mrp_ctx *m)
     free(m->artwork_mime);
     free(m->artwork);
     free(m);
+}
+
+bool ap2_mrp_attach_events(struct ap2_mrp_ctx *m, int event_sock)
+{
+    if (!m || event_sock < 0) return false;
+    if (!m->have_secret) {
+        LOG_ERROR("[MRP] event channel requires the pairing shared secret");
+        return false;
+    }
+    /* The receiver is the logical writer on this reverse channel, so the key
+     * labels are swapped from our perspective (pyatv EventChannel). */
+    if (!mrp_hkdf_sha512(m->shared_secret, MRP_KEY_SIZE, MRP_EVENTS_SALT,
+                         MRP_EVENTS_READ_INFO,
+                         m->event_out_key, MRP_KEY_SIZE) ||
+        !mrp_hkdf_sha512(m->shared_secret, MRP_KEY_SIZE, MRP_EVENTS_SALT,
+                         MRP_EVENTS_WRITE_INFO,
+                         m->event_in_key, MRP_KEY_SIZE)) {
+        LOG_ERROR("[MRP] event channel key derivation failed");
+        return false;
+    }
+    m->event_sock = event_sock;
+    m->event_connected = true;
+    m->event_out_counter = 0;
+    m->event_in_counter = 0;
+    m->event_rx_enc_len = 0;
+    m->event_plain_len = 0;
+    LOG_INFO("[MRP] encrypted event channel attached");
+    return true;
 }
 
 bool ap2_mrp_attach(struct ap2_mrp_ctx *m, int data_port, uint64_t seed)
@@ -1013,8 +1287,12 @@ void ap2_mrp_stop(struct ap2_mrp_ctx *m)
         close(m->sock);
         m->sock = -1;
     }
+    m->event_connected = false;
+    m->event_sock = -1;
     m->rx_enc_len = 0;
     m->rx_msg_len = 0;
+    m->event_rx_enc_len = 0;
+    m->event_plain_len = 0;
 }
 
 bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
@@ -1105,7 +1383,9 @@ bool ap2_mrp_set_stopped(struct ap2_mrp_ctx *m)
 
 void ap2_mrp_tick(struct ap2_mrp_ctx *m)
 {
-    if (!m || !m->connected || m->sock < 0) return;
+    if (!m) return;
+    mrp_tick_events(m);
+    if (!m->connected || m->sock < 0) return;
 
     /* Drain inbound bytes without blocking */
     struct pollfd pfd = { .fd = m->sock, .events = POLLIN };

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -203,9 +203,13 @@ struct ap2_mrp_ctx {
     int artwork_len;
     char artwork_id[17];      /* 16-hex ArtworkIdentifier for the current art */
     bool artwork_sent;        /* bytes already pushed once (then ref by id) */
+    uint64_t artwork_generation;
     uint64_t np_uid;          /* per-track now-playing UniqueIdentifier */
 
     time_t last_state_push;
+    uint64_t state_generation;
+    bool state_dirty;
+    bool state_include_artwork;
 };
 
 /* ---- Small helpers ---- */
@@ -1148,6 +1152,8 @@ struct ap2_mrp_ctx *ap2_mrp_create(const char *host, int port,
     mrp_identity_uuid(m->dacp_id, m->device_uuid);
     m->playback_state = AP2_MRP_PLAYBACK_PAUSED;
     m->elapsed_set_at = mrp_cf_now();
+    m->state_generation = 1;
+    m->state_dirty = true;
     m->sock = -1;
     m->event_sock = -1;
     pthread_mutex_init(&m->send_lock, NULL);
@@ -1281,6 +1287,10 @@ bool ap2_mrp_attach(struct ap2_mrp_ctx *m, int data_port, uint64_t seed)
     ok = ok && build_set_now_playing_client(m, &msg) && mrp_send_protobuf(m, &msg);
     mbuf_free(&msg);
     ok = ok && mrp_push_state(m, m->artwork_len > 0);
+    if (ok) {
+        m->state_dirty = false;
+        m->state_include_artwork = false;
+    }
 
     if (!ok) {
         LOG_ERROR("[MRP] handshake push failed");
@@ -1339,8 +1349,9 @@ bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
     uint64_t uid = 0;
     RAND_bytes((uint8_t *)&uid, sizeof(uid));
     m->np_uid = uid & 0x7FFFFFFFFFFFFFFFULL;
-    if (!m->connected) return true;
-    return mrp_push_state(m, false);
+    m->state_generation++;
+    m->state_dirty = true;
+    return true;
 }
 
 bool ap2_mrp_set_artwork(struct ap2_mrp_ctx *m, const char *mime,
@@ -1363,8 +1374,11 @@ bool ap2_mrp_set_artwork(struct ap2_mrp_ctx *m, const char *mime,
              "%02x%02x%02x%02x%02x%02x%02x%02x",
              idb[0], idb[1], idb[2], idb[3], idb[4], idb[5], idb[6], idb[7]);
     m->artwork_sent = false;
-    if (!m->connected) return true;
-    return mrp_push_state(m, true);
+    m->artwork_generation++;
+    m->state_generation++;
+    m->state_dirty = true;
+    m->state_include_artwork = true;
+    return true;
 }
 
 bool ap2_mrp_set_progress(struct ap2_mrp_ctx *m, int elapsed_ms,
@@ -1376,10 +1390,9 @@ bool ap2_mrp_set_progress(struct ap2_mrp_ctx *m, int elapsed_ms,
     m->playback_state = playing ? AP2_MRP_PLAYBACK_PLAYING
                                 : AP2_MRP_PLAYBACK_PAUSED;
     m->elapsed_set_at = mrp_cf_now();
-    if (!m->connected) return true;
-    /* The receiver extrapolates position from elapsedTime + timestamp +
-     * playbackRate, so a progress change is a state push, not a stream. */
-    return mrp_push_state(m, false);
+    m->state_generation++;
+    m->state_dirty = true;
+    return true;
 }
 
 bool ap2_mrp_set_playing(struct ap2_mrp_ctx *m, bool playing)
@@ -1397,8 +1410,9 @@ bool ap2_mrp_set_playing(struct ap2_mrp_ctx *m, bool playing)
     m->playback_state = playing ? AP2_MRP_PLAYBACK_PLAYING
                                 : AP2_MRP_PLAYBACK_PAUSED;
     m->elapsed_set_at = now;
-    if (!m->connected) return true;
-    return mrp_push_state(m, false);
+    m->state_generation++;
+    m->state_dirty = true;
+    return true;
 }
 
 bool ap2_mrp_set_stopped(struct ap2_mrp_ctx *m)
@@ -1406,8 +1420,9 @@ bool ap2_mrp_set_stopped(struct ap2_mrp_ctx *m)
     if (!m) return false;
     m->playback_state = AP2_MRP_PLAYBACK_STOPPED;
     m->elapsed_set_at = mrp_cf_now();
-    if (!m->connected) return true;
-    return mrp_push_state(m, false);
+    m->state_generation++;
+    m->state_dirty = true;
+    return true;
 }
 
 void ap2_mrp_tick(struct ap2_mrp_ctx *m)
@@ -1433,11 +1448,47 @@ void ap2_mrp_tick(struct ap2_mrp_ctx *m)
         if (!m->connected) return;
     }
 
-    /* Defensive periodic re-push: keeps the system now-playing session warm
-     * (standby prevention hinges on it, DESIGN.md §8). */
-    if (m->playback_state == AP2_MRP_PLAYBACK_PLAYING &&
-        time(NULL) - m->last_state_push >= MRP_STATE_REPUSH_S)
-        mrp_push_state(m, false);
+}
+
+bool ap2_mrp_prepare_state_push(struct ap2_mrp_ctx *m, uint8_t **out,
+                                int *out_len, uint64_t *generation)
+{
+    if (!m || !out || !out_len || !generation || !m->connected) return false;
+    bool periodic =
+        m->playback_state == AP2_MRP_PLAYBACK_PLAYING &&
+        time(NULL) - m->last_state_push >= MRP_STATE_REPUSH_S;
+    if (!m->state_dirty && !periodic) return false;
+
+    mbuf msg = {0};
+    if (!build_set_state(m, m->state_include_artwork, &msg)) {
+        mbuf_free(&msg);
+        return false;
+    }
+    *out = msg.p;
+    *out_len = (int)msg.len;
+    *generation = m->state_generation;
+    return true;
+}
+
+bool ap2_mrp_send_state_push(struct ap2_mrp_ctx *m,
+                             const uint8_t *data, int len)
+{
+    if (!m || !data || len <= 0 || !m->connected) return false;
+    mbuf msg = { .p = (uint8_t *)data, .len = (size_t)len, .cap = (size_t)len };
+    bool ok = mrp_send_protobuf(m, &msg);
+    LOG_DEBUG("[MRP] queued SET_STATE push -> %s", ok ? "sent" : "failed");
+    return ok;
+}
+
+void ap2_mrp_complete_state_push(struct ap2_mrp_ctx *m,
+                                 uint64_t generation, bool success)
+{
+    if (!m || !success) return;
+    m->last_state_push = time(NULL);
+    if (m->state_generation == generation) {
+        m->state_dirty = false;
+        m->state_include_artwork = false;
+    }
 }
 
 bool ap2_mrp_is_connected(struct ap2_mrp_ctx *m)
@@ -1525,6 +1576,18 @@ void ap2_mrp_mark_artwork_sent(struct ap2_mrp_ctx *m)
 {
     if (m && m->artwork && m->artwork_len > 0)
         m->artwork_sent = true;
+}
+
+uint64_t ap2_mrp_artwork_generation(struct ap2_mrp_ctx *m)
+{
+    return m ? m->artwork_generation : 0;
+}
+
+void ap2_mrp_mark_artwork_sent_if_generation(
+    struct ap2_mrp_ctx *m, uint64_t generation)
+{
+    if (m && m->artwork_generation == generation)
+        ap2_mrp_mark_artwork_sent(m);
 }
 
 /* Wrap a serialized protobuf as the bplist {"params": {"data": <varint length +

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -37,6 +37,7 @@
 #include <openssl/crypto.h>
 
 #include "cross_log.h"
+#include "ap2_io.h"
 #include "ap2_plist.h"
 #include "ap2_mrp.h"
 
@@ -137,6 +138,7 @@ enum mrp_ext_field {
 
 /* Cadence of the defensive state re-push from ap2_mrp_tick (seconds). */
 #define MRP_STATE_REPUSH_S 15
+#define MRP_WRITE_TIMEOUT_MS 1000
 
 struct ap2_mrp_ctx {
     /* Target + identity */
@@ -704,18 +706,8 @@ static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
 
 static bool mrp_write_all(int fd, const uint8_t *data, int len)
 {
-    int off = 0;
-    while (off < len) {
-        ssize_t n = write(fd, data + off, (size_t)(len - off));
-        if (n > 0) {
-            off += (int)n;
-        } else if (n < 0 && errno == EINTR) {
-            continue;
-        } else {
-            return false;
-        }
-    }
-    return true;
+    return ap2_io_write_all_deadline(
+        fd, data, len, ap2_io_monotonic_ms() + MRP_WRITE_TIMEOUT_MS);
 }
 
 /* Write the 32-byte big-endian data-frame header. */
@@ -747,6 +739,12 @@ static bool mrp_send_raw(struct ap2_mrp_ctx *m, const uint8_t *data, int len)
     if (enc_len > 0 && enc)
         ok = mrp_write_all(m->sock, enc, enc_len);
     free(enc);
+    if (!ok) {
+        LOG_ERROR("[MRP] data channel write failed: %s", strerror(errno));
+        m->connected = false;
+        close(m->sock);
+        m->sock = -1;
+    }
     pthread_mutex_unlock(&m->send_lock);
     return ok;
 }
@@ -959,6 +957,11 @@ static bool mrp_event_send_response(struct ap2_mrp_ctx *m,
     bool ok = enc_len > 0 && enc &&
               mrp_write_all(m->event_sock, enc, enc_len);
     free(enc);
+    if (!ok) {
+        LOG_ERROR("[MRP] event channel write failed: %s", strerror(errno));
+        m->event_connected = false;
+        shutdown(m->event_sock, SHUT_RDWR);
+    }
     pthread_mutex_unlock(&m->send_lock);
     return ok;
 }

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <strings.h>
 #include <stdbool.h>
+#include <stdatomic.h>
 #include <unistd.h>
 #include <errno.h>
 #include <time.h>
@@ -176,10 +177,10 @@ struct ap2_mrp_ctx {
     int rx_msg_len;
 
     /* Encrypted reverse event channel. It has independent HKDF keys/counters
-     * from both RTSP control and the optional type-130 data channel. The socket
-     * remains owned by ap2_client. */
+     * from both RTSP control and the optional type-130 data channel. */
     int event_sock;
-    bool event_connected;
+    _Atomic bool event_connected;
+    bool event_attached;
     uint8_t event_out_key[MRP_KEY_SIZE]; /* Events-Read-Encryption-Key */
     uint8_t event_in_key[MRP_KEY_SIZE];  /* Events-Write-Encryption-Key */
     uint64_t event_out_counter;
@@ -676,6 +677,8 @@ static int mrp_channel_encrypt_with(const uint8_t key[MRP_KEY_SIZE],
         memcpy(*out + out_off, len_bytes, 2);
         out_off += 2;
 
+        /* Encryption consumes the nonce even if the eventual write fails.
+         * Callers close the channel on failure rather than retrying ciphertext. */
         uint8_t nonce[MRP_NONCE_SIZE];
         mrp_make_nonce((*counter)++, nonce);
 
@@ -707,7 +710,28 @@ static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
 static bool mrp_write_all(int fd, const uint8_t *data, int len)
 {
     return ap2_io_write_all_deadline(
-        fd, data, len, ap2_io_monotonic_ms() + MRP_WRITE_TIMEOUT_MS);
+        fd, data, (size_t)len,
+        ap2_io_monotonic_ms() + MRP_WRITE_TIMEOUT_MS);
+}
+
+static void mrp_close_data_channel(struct ap2_mrp_ctx *m)
+{
+    m->connected = false;
+    if (m->sock >= 0) {
+        shutdown(m->sock, SHUT_RDWR);
+        close(m->sock);
+        m->sock = -1;
+    }
+}
+
+static void mrp_close_event_channel(struct ap2_mrp_ctx *m)
+{
+    atomic_store(&m->event_connected, false);
+    if (m->event_sock >= 0) {
+        shutdown(m->event_sock, SHUT_RDWR);
+        close(m->event_sock);
+        m->event_sock = -1;
+    }
 }
 
 /* Write the 32-byte big-endian data-frame header. */
@@ -731,8 +755,11 @@ static void mrp_write_data_header(uint8_t hdr[MRP_DATA_HDR_LEN],
 /* Send raw bytes through the encrypted channel (holds send_lock). */
 static bool mrp_send_raw(struct ap2_mrp_ctx *m, const uint8_t *data, int len)
 {
-    if (m->sock < 0) return false;
     pthread_mutex_lock(&m->send_lock);
+    if (m->sock < 0) {
+        pthread_mutex_unlock(&m->send_lock);
+        return false;
+    }
     uint8_t *enc = NULL;
     int enc_len = mrp_channel_encrypt(m, data, len, &enc);
     bool ok = false;
@@ -741,9 +768,7 @@ static bool mrp_send_raw(struct ap2_mrp_ctx *m, const uint8_t *data, int len)
     free(enc);
     if (!ok) {
         LOG_ERROR("[MRP] data channel write failed: %s", strerror(errno));
-        m->connected = false;
-        close(m->sock);
-        m->sock = -1;
+        mrp_close_data_channel(m);
     }
     pthread_mutex_unlock(&m->send_lock);
     return ok;
@@ -867,7 +892,7 @@ static void mrp_drain_encrypted(struct ap2_mrp_ctx *m)
                                   m->rx_msg, &m->rx_msg_len,
                                   (int)sizeof(m->rx_msg),
                                   m->in_key, &m->in_counter, "data channel"))
-        m->connected = false;
+        mrp_close_data_channel(m);
 }
 
 /* Consume complete 32-byte-header data frames from rx_msg. Incoming protobufs
@@ -950,6 +975,10 @@ static bool mrp_event_send_response(struct ap2_mrp_ctx *m,
                                     const uint8_t *response, int response_len)
 {
     pthread_mutex_lock(&m->send_lock);
+    if (!atomic_load(&m->event_connected) || m->event_sock < 0) {
+        pthread_mutex_unlock(&m->send_lock);
+        return false;
+    }
     uint8_t *enc = NULL;
     int enc_len = mrp_channel_encrypt_with(
         m->event_out_key, &m->event_out_counter,
@@ -959,8 +988,7 @@ static bool mrp_event_send_response(struct ap2_mrp_ctx *m,
     free(enc);
     if (!ok) {
         LOG_ERROR("[MRP] event channel write failed: %s", strerror(errno));
-        m->event_connected = false;
-        shutdown(m->event_sock, SHUT_RDWR);
+        mrp_close_event_channel(m);
     }
     pthread_mutex_unlock(&m->send_lock);
     return ok;
@@ -1047,7 +1075,7 @@ static bool mrp_process_event_requests(struct ap2_mrp_ctx *m)
 
 static void mrp_tick_events(struct ap2_mrp_ctx *m)
 {
-    if (!m->event_connected || m->event_sock < 0) return;
+    if (!atomic_load(&m->event_connected) || m->event_sock < 0) return;
 
     struct pollfd pfd = {
         .fd = m->event_sock,
@@ -1056,13 +1084,13 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
     while (poll(&pfd, 1, 0) > 0) {
         if (pfd.revents & (POLLERR | POLLNVAL)) {
             LOG_WARN("[MRP] event channel socket error");
-            m->event_connected = false;
+            mrp_close_event_channel(m);
             return;
         }
         if (!(pfd.revents & POLLIN)) {
             if (pfd.revents & POLLHUP) {
                 LOG_WARN("[MRP] event channel closed by receiver");
-                m->event_connected = false;
+                mrp_close_event_channel(m);
             }
             return;
         }
@@ -1070,7 +1098,7 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
         int space = (int)sizeof(m->event_rx_enc) - m->event_rx_enc_len;
         if (space <= 0) {
             LOG_ERROR("[MRP] event encrypted buffer full");
-            m->event_connected = false;
+            mrp_close_event_channel(m);
             return;
         }
         ssize_t n = read(m->event_sock,
@@ -1079,7 +1107,7 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
         if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return;
         if (n <= 0) {
             LOG_WARN("[MRP] event channel closed by receiver");
-            m->event_connected = false;
+            mrp_close_event_channel(m);
             return;
         }
         m->event_rx_enc_len += (int)n;
@@ -1089,7 +1117,7 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
                 (int)sizeof(m->event_plain),
                 m->event_in_key, &m->event_in_counter, "event channel") ||
             !mrp_process_event_requests(m)) {
-            m->event_connected = false;
+            mrp_close_event_channel(m);
             return;
         }
         pfd.revents = 0;
@@ -1123,6 +1151,7 @@ struct ap2_mrp_ctx *ap2_mrp_create(const char *host, int port,
     m->sock = -1;
     m->event_sock = -1;
     pthread_mutex_init(&m->send_lock, NULL);
+    atomic_init(&m->event_connected, false);
 
     if (reuse_shared_secret) {
         memcpy(m->shared_secret, reuse_shared_secret, MRP_KEY_SIZE);
@@ -1181,7 +1210,8 @@ bool ap2_mrp_attach_events(struct ap2_mrp_ctx *m, int event_sock)
         return false;
     }
     m->event_sock = event_sock;
-    m->event_connected = true;
+    atomic_store(&m->event_connected, true);
+    m->event_attached = true;
     m->event_out_counter = 0;
     m->event_in_counter = 0;
     m->event_rx_enc_len = 0;
@@ -1286,12 +1316,8 @@ void ap2_mrp_stop(struct ap2_mrp_ctx *m)
         mbuf_free(&msg);
         m->connected = false;
     }
-    if (m->sock >= 0) {
-        close(m->sock);
-        m->sock = -1;
-    }
-    m->event_connected = false;
-    m->event_sock = -1;
+    mrp_close_data_channel(m);
+    mrp_close_event_channel(m);
     m->rx_enc_len = 0;
     m->rx_msg_len = 0;
     m->event_rx_enc_len = 0;
@@ -1398,9 +1424,7 @@ void ap2_mrp_tick(struct ap2_mrp_ctx *m)
         ssize_t n = read(m->sock, m->rx_enc + m->rx_enc_len, (size_t)space);
         if (n <= 0) {
             LOG_WARN("[MRP] data channel closed by receiver");
-            m->connected = false;
-            close(m->sock);
-            m->sock = -1;
+            mrp_close_data_channel(m);
             return;
         }
         m->rx_enc_len += (int)n;
@@ -1419,6 +1443,12 @@ void ap2_mrp_tick(struct ap2_mrp_ctx *m)
 bool ap2_mrp_is_connected(struct ap2_mrp_ctx *m)
 {
     return m && m->connected;
+}
+
+int ap2_mrp_event_status(struct ap2_mrp_ctx *m)
+{
+    if (!m || !m->event_attached) return -1;
+    return atomic_load(&m->event_connected) ? 1 : 0;
 }
 
 bool ap2_mrp_build_nowplaying_command(struct ap2_mrp_ctx *m,

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -111,7 +111,7 @@ void ap2_mrp_stop(struct ap2_mrp_ctx *m);
 
 /*
  * Set the now-playing track metadata. Values are copied; NULL is treated as
- * empty. Takes effect on the next state push (immediate when connected).
+ * empty. Takes effect on the next feedback-worker state push.
  *
  * :param duration_ms: track duration in milliseconds (0 = unknown/live).
  */
@@ -143,7 +143,7 @@ bool ap2_mrp_set_progress(struct ap2_mrp_ctx *m, int elapsed_ms,
  * Flip the play/pause state without a fresh elapsed position (pause/resume).
  * Advances the stored elapsed to now so the receiver's extrapolated position
  * (elapsedTime + timestamp + playbackRate) is accurate across the transition.
- * Takes effect on the next state push (immediate when connected).
+ * Takes effect on the next feedback-worker state push.
  *
  * :param playing: true = Playing, false = Paused.
  */
@@ -154,12 +154,23 @@ bool ap2_mrp_set_playing(struct ap2_mrp_ctx *m, bool playing);
 bool ap2_mrp_set_stopped(struct ap2_mrp_ctx *m);
 
 /*
- * Keep-alive tick: answer encrypted event-channel HTTP requests, drain any
- * type-130 frames (answering sync/heartbeat requests), and re-push the current
- * type-130 state when applicable. Call about every 2 s from the caller's
- * existing loop.
+ * Keep-alive tick: answer encrypted event-channel HTTP requests and drain any
+ * type-130 frames (answering sync/heartbeat requests). Call only from the
+ * feedback worker.
  */
 void ap2_mrp_tick(struct ap2_mrp_ctx *m);
+
+/*
+ * Snapshot a pending/periodic type-130 state push while the caller protects
+ * mutable MRP state, then send the owned payload without that state lock.
+ * The feedback worker is the sole sender for these snapshots.
+ */
+bool ap2_mrp_prepare_state_push(struct ap2_mrp_ctx *m, uint8_t **out,
+                                int *out_len, uint64_t *generation);
+bool ap2_mrp_send_state_push(struct ap2_mrp_ctx *m,
+                             const uint8_t *data, int len);
+void ap2_mrp_complete_state_push(struct ap2_mrp_ctx *m,
+                                 uint64_t generation, bool success);
 
 /* True once the data channel is established. */
 bool ap2_mrp_is_connected(struct ap2_mrp_ctx *m);
@@ -181,6 +192,9 @@ bool ap2_mrp_build_nowplaying_command(struct ap2_mrp_ctx *m,
 
 /* Mark the one-shot artwork bytes as accepted after a successful POST. */
 void ap2_mrp_mark_artwork_sent(struct ap2_mrp_ctx *m);
+uint64_t ap2_mrp_artwork_generation(struct ap2_mrp_ctx *m);
+void ap2_mrp_mark_artwork_sent_if_generation(
+    struct ap2_mrp_ctx *m, uint64_t generation);
 
 /*
  * Build the origin-registration bodies a real iPhone POSTs to /command before

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -92,9 +92,9 @@ void ap2_mrp_destroy(struct ap2_mrp_ctx *m);
 bool ap2_mrp_attach(struct ap2_mrp_ctx *m, int data_port, uint64_t seed);
 
 /*
- * Attach the session event socket. The socket stays owned by ap2_client; this
- * derives the independent Events-Salt keys and services encrypted reverse HTTP
- * requests with 200 responses from ap2_mrp_tick().
+ * Attach the session event socket. Ownership transfers to the MRP context on
+ * success. This derives the independent Events-Salt keys and services encrypted
+ * reverse HTTP requests with 200 responses from ap2_mrp_tick().
  */
 bool ap2_mrp_attach_events(struct ap2_mrp_ctx *m, int event_sock);
 
@@ -163,6 +163,9 @@ void ap2_mrp_tick(struct ap2_mrp_ctx *m);
 
 /* True once the data channel is established. */
 bool ap2_mrp_is_connected(struct ap2_mrp_ctx *m);
+
+/* Reverse event-channel status: -1 unattached, 0 closed/failed, 1 active. */
+int ap2_mrp_event_status(struct ap2_mrp_ctx *m);
 
 /*
  * Build a binary-plist body for POST /command on the MAIN encrypted RTSP

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -92,6 +92,13 @@ void ap2_mrp_destroy(struct ap2_mrp_ctx *m);
 bool ap2_mrp_attach(struct ap2_mrp_ctx *m, int data_port, uint64_t seed);
 
 /*
+ * Attach the session event socket. The socket stays owned by ap2_client; this
+ * derives the independent Events-Salt keys and services encrypted reverse HTTP
+ * requests with 200 responses from ap2_mrp_tick().
+ */
+bool ap2_mrp_attach_events(struct ap2_mrp_ctx *m, int event_sock);
+
+/*
  * Bootstrap a standalone remote-control-only session (sidecar model, for the
  * metadata-only display mode): own TCP connection, pair-verify, session SETUP
  * with isRemoteControlOnly=true, event channel, RECORD, type-130 data channel.
@@ -147,10 +154,10 @@ bool ap2_mrp_set_playing(struct ap2_mrp_ctx *m, bool playing);
 bool ap2_mrp_set_stopped(struct ap2_mrp_ctx *m);
 
 /*
- * Keep-alive tick: drain any incoming frames (answering sync/heartbeat
- * requests) and re-push the current now-playing state to hold the system
- * now-playing session open (standby prevention). Call about every 2 s from the
- * caller's existing loop; harmless when not connected.
+ * Keep-alive tick: answer encrypted event-channel HTTP requests, drain any
+ * type-130 frames (answering sync/heartbeat requests), and re-push the current
+ * type-130 state when applicable. Call about every 2 s from the caller's
+ * existing loop.
  */
 void ap2_mrp_tick(struct ap2_mrp_ctx *m);
 

--- a/src/ap2_plist.c
+++ b/src/ap2_plist.c
@@ -12,6 +12,7 @@
  *   0x1 = int (low nibble = log2(byte count): 0=1B, 1=2B, 2=4B, 3=8B)
  *   0x4 = data (low nibble = length, or 0xF + int length)
  *   0x5 = string (ASCII, low nibble = length, or 0xF + int length)
+ *   0x6 = string (UTF-16BE, count is UTF-16 code units)
  *   0xa = array (low nibble = count, or 0xF + int count)
  *   0xd = dict (low nibble = count, or 0xF + int count)
  *
@@ -193,6 +194,90 @@ static void write_size(buf_t *b, uint8_t type_nibble, size_t count) {
     }
 }
 
+/* Binary plist's 0x5 string is strictly ASCII. Encode non-ASCII UTF-8 as
+ * UTF-16BE (0x6); writing raw UTF-8 under an ASCII marker produces mojibake on
+ * tvOS (for example U+2019 becomes "â..."). Invalid UTF-8 is replaced with
+ * U+FFFD so the plist itself remains valid. */
+static uint32_t decode_utf8(const uint8_t *src, size_t len, size_t *consumed)
+{
+    uint8_t c = src[0];
+    *consumed = 1;
+    if (c < 0x80) return c;
+    if (c >= 0xC2 && c <= 0xDF && len >= 2 &&
+        (src[1] & 0xC0) == 0x80) {
+        *consumed = 2;
+        return ((uint32_t)(c & 0x1F) << 6) |
+               (uint32_t)(src[1] & 0x3F);
+    }
+    if (c >= 0xE0 && c <= 0xEF && len >= 3 &&
+        (src[1] & 0xC0) == 0x80 && (src[2] & 0xC0) == 0x80 &&
+        !(c == 0xE0 && src[1] < 0xA0) &&
+        !(c == 0xED && src[1] >= 0xA0)) {
+        *consumed = 3;
+        return ((uint32_t)(c & 0x0F) << 12) |
+               ((uint32_t)(src[1] & 0x3F) << 6) |
+               (uint32_t)(src[2] & 0x3F);
+    }
+    if (c >= 0xF0 && c <= 0xF4 && len >= 4 &&
+        (src[1] & 0xC0) == 0x80 && (src[2] & 0xC0) == 0x80 &&
+        (src[3] & 0xC0) == 0x80 &&
+        !(c == 0xF0 && src[1] < 0x90) &&
+        !(c == 0xF4 && src[1] >= 0x90)) {
+        *consumed = 4;
+        return ((uint32_t)(c & 0x07) << 18) |
+               ((uint32_t)(src[1] & 0x3F) << 12) |
+               ((uint32_t)(src[2] & 0x3F) << 6) |
+               (uint32_t)(src[3] & 0x3F);
+    }
+    return 0xFFFD;
+}
+
+static void write_plist_string(buf_t *b, const char *str)
+{
+    const uint8_t *src = (const uint8_t *)(str ? str : "");
+    size_t src_len = strlen((const char *)src);
+    bool ascii = true;
+    for (size_t i = 0; i < src_len; i++) {
+        if (src[i] & 0x80) {
+            ascii = false;
+            break;
+        }
+    }
+    if (ascii) {
+        write_size(b, 0x50, src_len);
+        buf_append(b, src, (int)src_len);
+        return;
+    }
+
+    size_t in = 0, units = 0;
+    while (in < src_len) {
+        size_t consumed;
+        uint32_t cp = decode_utf8(src + in, src_len - in, &consumed);
+        in += consumed;
+        units += cp <= 0xFFFF ? 1 : 2;
+    }
+    write_size(b, 0x60, units);
+
+    in = 0;
+    while (in < src_len) {
+        size_t consumed;
+        uint32_t cp = decode_utf8(src + in, src_len - in, &consumed);
+        in += consumed;
+        if (cp <= 0xFFFF) {
+            buf_append_byte(b, (uint8_t)(cp >> 8));
+            buf_append_byte(b, (uint8_t)cp);
+        } else {
+            cp -= 0x10000;
+            uint16_t high = 0xD800 | (uint16_t)(cp >> 10);
+            uint16_t low = 0xDC00 | (uint16_t)(cp & 0x3FF);
+            buf_append_byte(b, (uint8_t)(high >> 8));
+            buf_append_byte(b, (uint8_t)high);
+            buf_append_byte(b, (uint8_t)(low >> 8));
+            buf_append_byte(b, (uint8_t)low);
+        }
+    }
+}
+
 static void write_int_value(buf_t *b, int64_t val) {
     if (val >= 0 && val <= 0xFF) {
         buf_append_byte(b, 0x10); buf_append_byte(b, (uint8_t)val);
@@ -281,8 +366,7 @@ int ap2_plist_serialize(struct ap2_plist *p, uint8_t **out)
         offsets[key_idx + i] = objs.len;
         objs.data[root_keys_pos + i] = key_idx + i;
         const char *key = p->root_entries[i].key;
-        write_size(&objs, 0x50, strlen(key));
-        buf_append(&objs, key, strlen(key));
+        write_plist_string(&objs, key);
 
         /* Value */
         offsets[val_idx + i] = objs.len;
@@ -290,8 +374,7 @@ int ap2_plist_serialize(struct ap2_plist *p, uint8_t **out)
         object_t *vo = &p->objects[p->root_entries[i].val_obj];
         switch (vo->type) {
             case OBJ_STRING:
-                write_size(&objs, 0x50, strlen(vo->string.val));
-                buf_append(&objs, vo->string.val, strlen(vo->string.val));
+                write_plist_string(&objs, vo->string.val);
                 break;
             case OBJ_INT:
                 write_int_value(&objs, vo->integer.val);
@@ -341,8 +424,7 @@ int ap2_plist_serialize(struct ap2_plist *p, uint8_t **out)
             offsets[skey_start + i] = objs.len;
             objs.data[sdict_keys_pos + i] = skey_start + i;
             const char *key = p->stream_entries[i].key;
-            write_size(&objs, 0x50, strlen(key));
-            buf_append(&objs, key, strlen(key));
+            write_plist_string(&objs, key);
 
             /* Value */
             offsets[sval_start + i] = objs.len;
@@ -350,8 +432,7 @@ int ap2_plist_serialize(struct ap2_plist *p, uint8_t **out)
             object_t *vo = &p->objects[p->stream_entries[i].val_obj];
             switch (vo->type) {
                 case OBJ_STRING:
-                    write_size(&objs, 0x50, strlen(vo->string.val));
-                    buf_append(&objs, vo->string.val, strlen(vo->string.val));
+                    write_plist_string(&objs, vo->string.val);
                     break;
                 case OBJ_INT:
                     write_int_value(&objs, vo->integer.val);
@@ -574,8 +655,7 @@ int ap2_pl_serialize(const ap2_pl_node *root, uint8_t **out)
             for (int k = 0; k < n->n; k++) write_ref(&objs, n->vals[k]->index, ref_size);
             break;
         case PLN_STRING:
-            write_size(&objs, 0x50, strlen(n->str));
-            buf_append(&objs, n->str, strlen(n->str));
+            write_plist_string(&objs, n->str);
             break;
         case PLN_INT:
             write_int_value(&objs, n->ival);

--- a/src/ap2_timeline.h
+++ b/src/ap2_timeline.h
@@ -1,0 +1,48 @@
+#ifndef __AP2_TIMELINE_H_
+#define __AP2_TIMELINE_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    uint64_t head;
+    uint64_t shifted_frames;
+    uint32_t offset;
+} ap2_timeline_recovery_t;
+
+static inline uint64_t ap2_timeline_frames_to_ns(uint64_t frames,
+                                                 uint32_t sample_rate)
+{
+    return (frames / sample_rate) * 1000000000ULL +
+           ((frames % sample_rate) * 1000000000ULL) / sample_rate;
+}
+
+/*
+ * Plan a recovery after PCM starvation exhausted the realtime lead.
+ *
+ * Audio RTP stays contiguous (no content is skipped); the scheduling head is
+ * moved into the future and the effective offset moves backward by the same
+ * amount, preserving the modulo-32-bit invariant:
+ *
+ *     rtp_timestamp == (uint32_t)head + offset
+ */
+static inline bool ap2_timeline_plan_recovery(
+    uint64_t head, uint32_t rtp_timestamp, uint32_t offset,
+    uint64_t now, uint64_t floor, uint64_t recovery_lead,
+    ap2_timeline_recovery_t *plan)
+{
+    if (!plan || head > now + floor) return false;
+    uint64_t desired = now + recovery_lead;
+    if (desired <= head) return false;
+
+    uint64_t shifted = desired - head;
+    uint32_t adjusted = offset - (uint32_t)shifted;
+    if ((uint32_t)desired + adjusted != rtp_timestamp) return false;
+
+    plan->head = desired;
+    plan->shifted_frames = shifted;
+    plan->offset = adjusted;
+    return true;
+}
+
+#endif /* __AP2_TIMELINE_H_ */

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -1,0 +1,683 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "artwork.h"
+
+#define ARTWORK_MAX_BYTES (5 * 1024 * 1024)
+#define HTTP_HEADER_MAX    (64 * 1024)
+#define ARTWORK_FETCH_TIMEOUT_MS 5000
+#define ARTWORK_DNS_TIMEOUT_MS   2000
+#define ARTWORK_IMAGEPROXY_SIZE  512
+
+typedef struct {
+    char host[256];
+    char port[8];
+    char host_header[288];
+    char path[4096];
+} artwork_url_t;
+
+typedef struct {
+    pthread_mutex_t lock;
+    pthread_cond_t ready;
+    bool done;
+    bool abandoned;
+    int status;
+    struct addrinfo *addresses;
+    char host[256];
+    char port[8];
+} artwork_resolver_t;
+
+static void artwork_error(char *error, size_t error_size, const char *fmt, ...)
+{
+    if (!error || !error_size) return;
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(error, error_size, fmt, args);
+    va_end(args);
+}
+
+static bool artwork_detect_type(const uint8_t *data, size_t size,
+                                char content_type[32])
+{
+    const char *mime = NULL;
+    if (size >= 3 && data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF) {
+        mime = "image/jpeg";
+    } else if (size >= 8 &&
+               memcmp(data, "\x89PNG\r\n\x1a\n", 8) == 0) {
+        mime = "image/png";
+    } else if (size >= 6 &&
+               (memcmp(data, "GIF87a", 6) == 0 ||
+                memcmp(data, "GIF89a", 6) == 0)) {
+        mime = "image/gif";
+    } else if (size >= 12 && memcmp(data, "RIFF", 4) == 0 &&
+               memcmp(data + 8, "WEBP", 4) == 0) {
+        mime = "image/webp";
+    }
+    if (!mime) return false;
+    snprintf(content_type, 32, "%s", mime);
+    return true;
+}
+
+static bool artwork_normalize_imageproxy_path(char path[4096],
+                                              char *error, size_t error_size)
+{
+    if (!strstr(path, "/imageproxy/")) return true;
+
+    char normalized[4096];
+    const char *query = strchr(path, '?');
+    size_t base_len = query ? (size_t)(query - path) : strlen(path);
+    if (base_len >= sizeof(normalized)) goto too_long;
+    memcpy(normalized, path, base_len);
+    size_t used = base_len;
+    bool have_param = false;
+
+    if (query) {
+        const char *param = query + 1;
+        while (*param) {
+            const char *end = strchr(param, '&');
+            if (!end) end = param + strlen(param);
+            const char *equals = memchr(param, '=', (size_t)(end - param));
+            size_t key_len = (size_t)((equals ? equals : end) - param);
+            bool replace = (key_len == 4 && strncmp(param, "size", 4) == 0) ||
+                           (key_len == 3 && strncmp(param, "fmt", 3) == 0);
+            if (!replace && end > param) {
+                size_t param_len = (size_t)(end - param);
+                if (used + 1 + param_len >= sizeof(normalized)) goto too_long;
+                normalized[used++] = have_param ? '&' : '?';
+                memcpy(normalized + used, param, param_len);
+                used += param_len;
+                have_param = true;
+            }
+            param = *end ? end + 1 : end;
+        }
+    }
+
+    int appended = snprintf(
+        normalized + used, sizeof(normalized) - used,
+        "%csize=%d&fmt=jpeg", have_param ? '&' : '?',
+        ARTWORK_IMAGEPROXY_SIZE);
+    if (appended <= 0 || (size_t)appended >= sizeof(normalized) - used)
+        goto too_long;
+    snprintf(path, 4096, "%s", normalized);
+    return true;
+
+too_long:
+    artwork_error(error, error_size, "normalized imageproxy URL is too long");
+    return false;
+}
+
+static bool artwork_parse_url(const char *url, artwork_url_t *parsed,
+                              char *error, size_t error_size)
+{
+    if (strncmp(url, "http://", 7) != 0) {
+        artwork_error(error, error_size,
+                      "only local files and http:// artwork URLs are supported");
+        return false;
+    }
+    const char *authority = url + 7;
+    const char *path = strchr(authority, '/');
+    const char *authority_end = path ? path : url + strlen(url);
+    if (authority == authority_end ||
+        memchr(authority, '@', (size_t)(authority_end - authority))) {
+        artwork_error(error, error_size, "invalid artwork URL authority");
+        return false;
+    }
+
+    const char *host_start = authority;
+    const char *host_end = authority_end;
+    const char *port_start = NULL;
+    if (*host_start == '[') {
+        const char *close = memchr(host_start, ']',
+                                   (size_t)(authority_end - host_start));
+        if (!close) {
+            artwork_error(error, error_size, "invalid bracketed artwork host");
+            return false;
+        }
+        host_start++;
+        host_end = close;
+        if (close + 1 < authority_end) {
+            if (close[1] != ':') {
+                artwork_error(error, error_size, "invalid artwork URL port");
+                return false;
+            }
+            port_start = close + 2;
+        }
+    } else {
+        const char *colon = memchr(authority, ':',
+                                   (size_t)(authority_end - authority));
+        if (colon) {
+            host_end = colon;
+            port_start = colon + 1;
+        }
+    }
+
+    size_t host_len = (size_t)(host_end - host_start);
+    if (!host_len || host_len >= sizeof(parsed->host)) {
+        artwork_error(error, error_size, "artwork URL host is too long");
+        return false;
+    }
+    memcpy(parsed->host, host_start, host_len);
+    parsed->host[host_len] = '\0';
+
+    if (port_start) {
+        size_t port_len = (size_t)(authority_end - port_start);
+        if (!port_len || port_len >= sizeof(parsed->port)) {
+            artwork_error(error, error_size, "invalid artwork URL port");
+            return false;
+        }
+        for (size_t i = 0; i < port_len; i++) {
+            if (port_start[i] < '0' || port_start[i] > '9') {
+                artwork_error(error, error_size, "invalid artwork URL port");
+                return false;
+            }
+        }
+        memcpy(parsed->port, port_start, port_len);
+        parsed->port[port_len] = '\0';
+    } else {
+        snprintf(parsed->port, sizeof(parsed->port), "80");
+    }
+
+    size_t authority_len = (size_t)(authority_end - authority);
+    if (authority_len >= sizeof(parsed->host_header)) {
+        artwork_error(error, error_size, "artwork URL authority is too long");
+        return false;
+    }
+    memcpy(parsed->host_header, authority, authority_len);
+    parsed->host_header[authority_len] = '\0';
+
+    const char *request_path = path ? path : "/";
+    size_t path_len = strcspn(request_path, "#");
+    if (!path_len || path_len >= sizeof(parsed->path)) {
+        artwork_error(error, error_size, "artwork URL path is too long");
+        return false;
+    }
+    memcpy(parsed->path, request_path, path_len);
+    parsed->path[path_len] = '\0';
+    return artwork_normalize_imageproxy_path(parsed->path, error, error_size);
+}
+
+static int64_t artwork_now_ms(void)
+{
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return (int64_t)now.tv_sec * 1000 + now.tv_nsec / 1000000;
+}
+
+static int artwork_remaining_ms(int64_t deadline_ms)
+{
+    int64_t remaining = deadline_ms - artwork_now_ms();
+    if (remaining <= 0) return 0;
+    return remaining > 0x7fffffff ? 0x7fffffff : (int)remaining;
+}
+
+static void *artwork_resolver_thread(void *arg)
+{
+    artwork_resolver_t *job = arg;
+    struct addrinfo hints = {0}, *addresses = NULL;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    int status = getaddrinfo(job->host, job->port, &hints, &addresses);
+
+    pthread_mutex_lock(&job->lock);
+    if (job->abandoned) {
+        pthread_mutex_unlock(&job->lock);
+        if (addresses) freeaddrinfo(addresses);
+        pthread_cond_destroy(&job->ready);
+        pthread_mutex_destroy(&job->lock);
+        free(job);
+        return NULL;
+    }
+    job->status = status;
+    job->addresses = addresses;
+    job->done = true;
+    pthread_cond_signal(&job->ready);
+    pthread_mutex_unlock(&job->lock);
+    return NULL;
+}
+
+static bool artwork_resolve(const artwork_url_t *url,
+                            struct addrinfo **addresses,
+                            int64_t deadline_ms,
+                            char *error, size_t error_size)
+{
+    artwork_resolver_t *job = calloc(1, sizeof(*job));
+    if (!job) {
+        artwork_error(error, error_size, "out of memory resolving artwork host");
+        return false;
+    }
+    pthread_mutex_init(&job->lock, NULL);
+    pthread_cond_init(&job->ready, NULL);
+    snprintf(job->host, sizeof(job->host), "%s", url->host);
+    snprintf(job->port, sizeof(job->port), "%s", url->port);
+
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, artwork_resolver_thread, job) != 0) {
+        pthread_cond_destroy(&job->ready);
+        pthread_mutex_destroy(&job->lock);
+        free(job);
+        artwork_error(error, error_size, "cannot start artwork DNS lookup");
+        return false;
+    }
+
+    int remaining = artwork_remaining_ms(deadline_ms);
+    if (remaining > ARTWORK_DNS_TIMEOUT_MS) remaining = ARTWORK_DNS_TIMEOUT_MS;
+    struct timespec timeout;
+    clock_gettime(CLOCK_REALTIME, &timeout);
+    timeout.tv_sec += remaining / 1000;
+    timeout.tv_nsec += (long)(remaining % 1000) * 1000000L;
+    if (timeout.tv_nsec >= 1000000000L) {
+        timeout.tv_sec++;
+        timeout.tv_nsec -= 1000000000L;
+    }
+
+    pthread_mutex_lock(&job->lock);
+    int wait_status = 0;
+    while (!job->done && wait_status == 0)
+        wait_status = pthread_cond_timedwait(&job->ready, &job->lock, &timeout);
+    if (!job->done) {
+        job->abandoned = true;
+        pthread_mutex_unlock(&job->lock);
+        pthread_detach(thread);
+        artwork_error(error, error_size, "artwork DNS lookup timed out");
+        return false;
+    }
+    pthread_mutex_unlock(&job->lock);
+    pthread_join(thread, NULL);
+
+    bool ok = job->status == 0 && job->addresses;
+    if (ok) {
+        *addresses = job->addresses;
+    } else {
+        if (job->addresses) freeaddrinfo(job->addresses);
+        artwork_error(error, error_size, "cannot resolve artwork host");
+    }
+    pthread_cond_destroy(&job->ready);
+    pthread_mutex_destroy(&job->lock);
+    free(job);
+    return ok;
+}
+
+static bool artwork_wait_fd(int fd, short events, int64_t deadline_ms)
+{
+    while (true) {
+        int remaining = artwork_remaining_ms(deadline_ms);
+        if (!remaining) return false;
+        struct pollfd pfd = {.fd = fd, .events = events};
+        int status = poll(&pfd, 1, remaining);
+        if (status > 0) {
+            if (pfd.revents & (POLLERR | POLLNVAL)) return false;
+            if (pfd.revents & events) return true;
+            if ((events & POLLIN) && (pfd.revents & POLLHUP)) return true;
+            return false;
+        }
+        if (status < 0 && errno == EINTR) continue;
+        return false;
+    }
+}
+
+static int artwork_connect(const artwork_url_t *url, int64_t deadline_ms,
+                           char *error, size_t error_size)
+{
+    struct addrinfo *addresses = NULL;
+    if (!artwork_resolve(url, &addresses, deadline_ms, error, error_size))
+        return -1;
+
+    int fd = -1;
+    for (struct addrinfo *addr = addresses; addr; addr = addr->ai_next) {
+        if (!artwork_remaining_ms(deadline_ms)) break;
+        fd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+        if (fd < 0) continue;
+#ifdef SO_NOSIGPIPE
+        int one = 1;
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
+#endif
+        int flags = fcntl(fd, F_GETFL, 0);
+        if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+            close(fd);
+            fd = -1;
+            continue;
+        }
+        int status = connect(fd, addr->ai_addr, addr->ai_addrlen);
+        if (status == 0) break;
+        if (errno == EINPROGRESS &&
+            artwork_wait_fd(fd, POLLOUT, deadline_ms)) {
+            int socket_error = 0;
+            socklen_t error_len = sizeof(socket_error);
+            if (getsockopt(fd, SOL_SOCKET, SO_ERROR,
+                           &socket_error, &error_len) == 0 &&
+                socket_error == 0)
+                break;
+        }
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(addresses);
+    if (fd < 0)
+        artwork_error(error, error_size, "cannot connect to artwork host");
+    return fd;
+}
+
+static bool artwork_write_all(int fd, const uint8_t *data, size_t size,
+                              int64_t deadline_ms)
+{
+    size_t off = 0;
+    while (off < size) {
+        if (!artwork_wait_fd(fd, POLLOUT, deadline_ms)) return false;
+#ifdef MSG_NOSIGNAL
+        ssize_t written = send(fd, data + off, size - off, MSG_NOSIGNAL);
+#else
+        ssize_t written = send(fd, data + off, size - off, 0);
+#endif
+        if (written > 0) {
+            off += (size_t)written;
+        } else if (written < 0 &&
+                   (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)) {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+static size_t artwork_header_end(const uint8_t *data, size_t size)
+{
+    for (size_t i = 0; i + 3 < size; i++) {
+        if (data[i] == '\r' && data[i + 1] == '\n' &&
+            data[i + 2] == '\r' && data[i + 3] == '\n')
+            return i + 4;
+    }
+    return 0;
+}
+
+static bool artwork_header_value(const char *header, const char *name,
+                                 char *out, size_t out_size)
+{
+    size_t name_len = strlen(name);
+    const char *line = strstr(header, "\r\n");
+    if (!line) return false;
+    line += 2;
+    while (*line) {
+        const char *end = strstr(line, "\r\n");
+        if (!end || end == line) break;
+        size_t line_len = (size_t)(end - line);
+        if (line_len > name_len && line[name_len] == ':' &&
+            strncasecmp(line, name, name_len) == 0) {
+            const char *value = line + name_len + 1;
+            while (value < end && (*value == ' ' || *value == '\t')) value++;
+            while (end > value && (end[-1] == ' ' || end[-1] == '\t')) end--;
+            size_t value_len = (size_t)(end - value);
+            if (value_len >= out_size) value_len = out_size - 1;
+            memcpy(out, value, value_len);
+            out[value_len] = '\0';
+            return true;
+        }
+        line = end + 2;
+    }
+    return false;
+}
+
+static bool artwork_decode_chunked(const uint8_t *body, size_t body_size,
+                                   uint8_t **decoded, size_t *decoded_size,
+                                   char *error, size_t error_size)
+{
+    uint8_t *out = malloc(ARTWORK_MAX_BYTES);
+    if (!out) {
+        artwork_error(error, error_size, "out of memory decoding artwork");
+        return false;
+    }
+    size_t in = 0, used = 0;
+    while (in < body_size) {
+        size_t line_end = in;
+        while (line_end + 1 < body_size &&
+               !(body[line_end] == '\r' && body[line_end + 1] == '\n'))
+            line_end++;
+        if (line_end + 1 >= body_size || line_end - in >= 32) goto malformed;
+
+        char size_text[33];
+        size_t size_len = line_end - in;
+        memcpy(size_text, body + in, size_len);
+        size_text[size_len] = '\0';
+        char *extension = strchr(size_text, ';');
+        if (extension) *extension = '\0';
+        char *end = NULL;
+        unsigned long chunk = strtoul(size_text, &end, 16);
+        if (!end || end == size_text || *end != '\0') goto malformed;
+        in = line_end + 2;
+        if (chunk == 0) {
+            *decoded = out;
+            *decoded_size = used;
+            return true;
+        }
+        if (chunk > ARTWORK_MAX_BYTES - used ||
+            chunk > body_size - in ||
+            in + chunk + 2 > body_size ||
+            body[in + chunk] != '\r' || body[in + chunk + 1] != '\n')
+            goto malformed;
+        memcpy(out + used, body + in, chunk);
+        used += chunk;
+        in += chunk + 2;
+    }
+
+malformed:
+    free(out);
+    artwork_error(error, error_size, "malformed chunked artwork response");
+    return false;
+}
+
+static bool artwork_fetch_http(const char *source, uint8_t **data, size_t *size,
+                               char content_type[32],
+                               char *error, size_t error_size)
+{
+    artwork_url_t url = {0};
+    if (!artwork_parse_url(source, &url, error, error_size)) return false;
+    int64_t deadline_ms = artwork_now_ms() + ARTWORK_FETCH_TIMEOUT_MS;
+    int fd = artwork_connect(&url, deadline_ms, error, error_size);
+    if (fd < 0) return false;
+
+    char request[4608];
+    int request_len = snprintf(
+        request, sizeof(request),
+        "GET %s HTTP/1.1\r\n"
+        "Host: %s\r\n"
+        "Accept: image/jpeg, image/png, image/*;q=0.8\r\n"
+        "Connection: close\r\n"
+        "User-Agent: cliairplay/0.1\r\n\r\n",
+        url.path, url.host_header);
+    if (request_len <= 0 || request_len >= (int)sizeof(request) ||
+        !artwork_write_all(fd, (const uint8_t *)request,
+                           (size_t)request_len, deadline_ms)) {
+        artwork_error(error, error_size, "cannot send artwork request");
+        close(fd);
+        return false;
+    }
+
+    size_t cap = HTTP_HEADER_MAX;
+    size_t used = 0;
+    uint8_t *response = malloc(cap);
+    bool ok = false;
+    while (response) {
+        if (used == cap) {
+            if (cap >= ARTWORK_MAX_BYTES + HTTP_HEADER_MAX) break;
+            size_t next = cap * 2;
+            if (next > ARTWORK_MAX_BYTES + HTTP_HEADER_MAX)
+                next = ARTWORK_MAX_BYTES + HTTP_HEADER_MAX;
+            uint8_t *grown = realloc(response, next);
+            if (!grown) break;
+            response = grown;
+            cap = next;
+        }
+        if (!artwork_wait_fd(fd, POLLIN, deadline_ms)) break;
+        ssize_t got = recv(fd, response + used, cap - used, 0);
+        if (got > 0) {
+            used += (size_t)got;
+        } else if (got == 0) {
+            ok = true;
+            break;
+        } else if (errno != EINTR && errno != EAGAIN &&
+                   errno != EWOULDBLOCK) {
+            break;
+        }
+    }
+    close(fd);
+    if (!ok || !response) {
+        free(response);
+        artwork_error(error, error_size, "incomplete artwork HTTP response");
+        return false;
+    }
+
+    size_t header_len = artwork_header_end(response, used);
+    if (!header_len || header_len >= HTTP_HEADER_MAX) {
+        free(response);
+        artwork_error(error, error_size, "invalid artwork HTTP response");
+        return false;
+    }
+    char *header = malloc(header_len + 1);
+    if (!header) {
+        free(response);
+        artwork_error(error, error_size, "out of memory parsing artwork");
+        return false;
+    }
+    memcpy(header, response, header_len);
+    header[header_len] = '\0';
+    int status = 0;
+    if (sscanf(header, "HTTP/%*s %d", &status) != 1 || status != 200) {
+        free(header);
+        free(response);
+        artwork_error(error, error_size, "artwork HTTP status %d", status);
+        return false;
+    }
+
+    uint8_t *body = response + header_len;
+    size_t body_size = used - header_len;
+    char value[128];
+    uint8_t *image = NULL;
+    size_t image_size = 0;
+    if (artwork_header_value(header, "Transfer-Encoding",
+                             value, sizeof(value)) &&
+        strcasestr(value, "chunked")) {
+        if (!artwork_decode_chunked(body, body_size, &image, &image_size,
+                                    error, error_size)) {
+            free(header);
+            free(response);
+            return false;
+        }
+    } else {
+        if (artwork_header_value(header, "Content-Length",
+                                 value, sizeof(value))) {
+            char *end = NULL;
+            unsigned long declared = strtoul(value, &end, 10);
+            if (!end || end == value || *end != '\0' ||
+                declared > ARTWORK_MAX_BYTES || declared > body_size) {
+                free(header);
+                free(response);
+                artwork_error(error, error_size,
+                              "invalid artwork Content-Length");
+                return false;
+            }
+            body_size = (size_t)declared;
+        }
+        if (!body_size || body_size > ARTWORK_MAX_BYTES) {
+            free(header);
+            free(response);
+            artwork_error(error, error_size, "artwork response is empty or too large");
+            return false;
+        }
+        image = malloc(body_size);
+        if (image) memcpy(image, body, body_size);
+        image_size = body_size;
+    }
+    free(header);
+    free(response);
+    if (!image) {
+        artwork_error(error, error_size, "out of memory loading artwork");
+        return false;
+    }
+    if (!artwork_detect_type(image, image_size, content_type)) {
+        free(image);
+        artwork_error(error, error_size, "artwork response is not a supported image");
+        return false;
+    }
+    *data = image;
+    *size = image_size;
+    return true;
+}
+
+static bool artwork_load_file(const char *path, uint8_t **data, size_t *size,
+                              char content_type[32],
+                              char *error, size_t error_size)
+{
+    FILE *file = fopen(path, "rb");
+    if (!file) {
+        artwork_error(error, error_size, "cannot open artwork file: %s",
+                      strerror(errno));
+        return false;
+    }
+    if (fseek(file, 0, SEEK_END) != 0) goto read_error;
+    long file_size = ftell(file);
+    if (file_size <= 0 || file_size > ARTWORK_MAX_BYTES) {
+        artwork_error(error, error_size, "artwork file is empty or too large");
+        fclose(file);
+        return false;
+    }
+    if (fseek(file, 0, SEEK_SET) != 0) goto read_error;
+    uint8_t *image = malloc((size_t)file_size);
+    if (!image) {
+        artwork_error(error, error_size, "out of memory loading artwork");
+        fclose(file);
+        return false;
+    }
+    if (fread(image, 1, (size_t)file_size, file) != (size_t)file_size) {
+        free(image);
+        goto read_error;
+    }
+    fclose(file);
+    if (!artwork_detect_type(image, (size_t)file_size, content_type)) {
+        free(image);
+        artwork_error(error, error_size, "artwork file is not a supported image");
+        return false;
+    }
+    *data = image;
+    *size = (size_t)file_size;
+    return true;
+
+read_error:
+    artwork_error(error, error_size, "cannot read artwork file");
+    fclose(file);
+    return false;
+}
+
+bool artwork_load(const char *source, uint8_t **data, size_t *size,
+                  char content_type[32], char *error, size_t error_size)
+{
+    if (!source || !*source || !data || !size || !content_type) {
+        artwork_error(error, error_size, "invalid artwork source");
+        return false;
+    }
+    *data = NULL;
+    *size = 0;
+    content_type[0] = '\0';
+    if (strncmp(source, "http://", 7) == 0)
+        return artwork_fetch_http(source, data, size, content_type,
+                                  error, error_size);
+    if (strncmp(source, "https://", 8) == 0) {
+        artwork_error(error, error_size,
+                      "https artwork URLs are not supported; use MA's local imageproxy");
+        return false;
+    }
+    return artwork_load_file(source, data, size, content_type,
+                             error, error_size);
+}

--- a/src/artwork.h
+++ b/src/artwork.h
@@ -1,0 +1,17 @@
+#ifndef __ARTWORK_H_
+#define __ARTWORK_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Load artwork from a local path or an http:// URL.
+ *
+ * The returned byte buffer is owned by the caller. content_type is inferred
+ * from the image signature rather than a filename or HTTP header.
+ */
+bool artwork_load(const char *source, uint8_t **data, size_t *size,
+                  char content_type[32], char *error, size_t error_size);
+
+#endif /* __ARTWORK_H_ */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -353,14 +353,8 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         size_t image_size = 0;
         char content_type[32];
         char error[160];
-        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
-            ap2cl_is_connected(g_ap2cl))
-            ap2cl_feedback(g_ap2cl);
         bool loaded = artwork_load(value, &image, &image_size, content_type,
                                    error, sizeof(error));
-        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
-            ap2cl_is_connected(g_ap2cl))
-            ap2cl_feedback(g_ap2cl);
         if (!loaded) {
             LOG_WARN("Cannot load artwork: %s", error);
         } else {
@@ -452,7 +446,6 @@ static void *cmdpipe_reader_thread(void *arg)
 {
     cli_config_t *cfg = (cli_config_t *)arg;
     uint64_t last_keepalive = raopcl_get_ntp(NULL);
-    uint64_t last_feedback = last_keepalive;
 
     g_cmdpipe_fd = open(cfg->cmdpipe, O_RDWR | O_NONBLOCK);
     if (g_cmdpipe_fd == -1) {
@@ -471,15 +464,6 @@ static void *cmdpipe_reader_thread(void *arg)
             raopcl_keepalive(g_raopcl);
             last_keepalive = now;
         }
-        /* Native AP2 keepalive: real senders POST /feedback about every 2 s
-         * and long sessions can hit receiver-side idle timeouts without it
-         * (no-op for the RAOP-compat flow, which libraop keeps alive). */
-        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl && ap2cl_is_connected(g_ap2cl) &&
-            now - last_feedback >= MS2NTP(2000)) {
-            ap2cl_feedback(g_ap2cl);
-            last_feedback = now;
-        }
-
         if (n <= 0 || !(pfds.revents & POLLIN)) continue;
 
         ssize_t bytes_read = read(g_cmdpipe_fd, g_cmdpipe_buf, sizeof(g_cmdpipe_buf) - 1);
@@ -775,6 +759,11 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     while (g_status != STATUS_STOPPED && (!got_eof || ap2cl_is_playing(g_ap2cl))) {
         uint64_t now = raopcl_get_ntp(NULL);
 
+        if (!ap2cl_is_connected(g_ap2cl)) {
+            status_error("AirPlay 2 control channel failed");
+            break;
+        }
+
         /* After EOF, drain for at most latency + 2 seconds then stop */
         if (got_eof && eof_time && now - eof_time > MS2NTP(cfg->latency_ms + 2000)) {
             LOG_INFO("Drain timeout reached, ending stream");
@@ -813,7 +802,10 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                 truncate_32to24(buf, n, ap2_alac_buf);
                 send = ap2_alac_buf;
             }
-            ap2cl_send_chunk(g_ap2cl, send, af);
+            if (!ap2cl_send_chunk(g_ap2cl, send, af)) {
+                status_error("AirPlay 2 realtime send failed");
+                break;
+            }
             frames += af;
         } else {
             usleep(1000);

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -326,7 +326,11 @@ static int input_ring_read(uint8_t *buf, size_t want)
     if (n) pthread_cond_broadcast(&g_inring.can_write);
     int error = g_inring.error;
     pthread_mutex_unlock(&g_inring.lock);
-    return n ? (int)n : (error ? -1 : 0);
+    if (!n && error) {
+        errno = error;
+        return -1;
+    }
+    return (int)n;
 }
 
 enum { INPUT_RING_TIMEOUT = -2 };
@@ -367,7 +371,11 @@ static int input_ring_read_timed(uint8_t *buf, size_t want, int timeout_ms)
     if (n) pthread_cond_broadcast(&g_inring.can_write);
     int error = g_inring.error;
     pthread_mutex_unlock(&g_inring.lock);
-    return n ? (int)n : (error ? -1 : 0);
+    if (!n && error) {
+        errno = error;
+        return -1;
+    }
+    return (int)n;
 }
 
 /* ---- Command pipe handler ---- */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -239,6 +239,7 @@ static struct {
     size_t rd, wr, fill;
     size_t max_fill;
     bool eof;
+    int error;
     bool started;
     int fd;
     pthread_t thread;
@@ -256,9 +257,13 @@ static void *input_ring_thread(void *arg)
     while (g_running) {
         ssize_t n = read(g_inring.fd, chunk, sizeof(chunk));
         if (n < 0 && errno == EINTR) continue;
+        int read_error = n < 0 ? errno : 0;
         pthread_mutex_lock(&g_inring.lock);
         if (n <= 0) {
-            g_inring.eof = true;
+            if (n == 0)
+                g_inring.eof = true;
+            else
+                g_inring.error = read_error;
             pthread_cond_broadcast(&g_inring.can_read);
             pthread_mutex_unlock(&g_inring.lock);
             break;
@@ -294,6 +299,9 @@ static void input_ring_start(int fd, unsigned byte_rate, int cap_ms)
      * the pre-start prefill (latency) plus margin. */
     uint64_t cap = (uint64_t)byte_rate * (uint64_t)cap_ms / 1000;
     g_inring.max_fill = (cap && cap < INPUT_RING_BYTES) ? (size_t)cap : INPUT_RING_BYTES;
+    g_inring.rd = g_inring.wr = g_inring.fill = 0;
+    g_inring.eof = false;
+    g_inring.error = 0;
     g_inring.started = true;
     pthread_create(&g_inring.thread, NULL, input_ring_thread, NULL);
 }
@@ -302,7 +310,7 @@ static void input_ring_start(int fd, unsigned byte_rate, int cap_ms)
 static int input_ring_read(uint8_t *buf, size_t want)
 {
     pthread_mutex_lock(&g_inring.lock);
-    while (g_inring.fill == 0 && !g_inring.eof && g_running)
+    while (g_inring.fill == 0 && !g_inring.eof && !g_inring.error && g_running)
         pthread_cond_wait(&g_inring.can_read, &g_inring.lock);
     size_t n = g_inring.fill < want ? g_inring.fill : want;
     size_t got = 0;
@@ -316,8 +324,50 @@ static int input_ring_read(uint8_t *buf, size_t want)
     }
     g_inring.fill -= n;
     if (n) pthread_cond_broadcast(&g_inring.can_write);
+    int error = g_inring.error;
     pthread_mutex_unlock(&g_inring.lock);
-    return (int)n;
+    return n ? (int)n : (error ? -1 : 0);
+}
+
+enum { INPUT_RING_TIMEOUT = -2 };
+
+/* Read with a bounded wait so native control failures remain observable while
+ * the PCM producer is stalled. */
+static int input_ring_read_timed(uint8_t *buf, size_t want, int timeout_ms)
+{
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += timeout_ms / 1000;
+    deadline.tv_nsec += (long)(timeout_ms % 1000) * 1000000L;
+    if (deadline.tv_nsec >= 1000000000L) {
+        deadline.tv_sec++;
+        deadline.tv_nsec -= 1000000000L;
+    }
+
+    pthread_mutex_lock(&g_inring.lock);
+    while (g_inring.fill == 0 && !g_inring.eof && !g_inring.error && g_running) {
+        int rc = pthread_cond_timedwait(&g_inring.can_read, &g_inring.lock,
+                                        &deadline);
+        if (rc == ETIMEDOUT) {
+            pthread_mutex_unlock(&g_inring.lock);
+            return INPUT_RING_TIMEOUT;
+        }
+    }
+    size_t n = g_inring.fill < want ? g_inring.fill : want;
+    size_t got = 0;
+    while (got < n) {
+        size_t to_end = INPUT_RING_BYTES - g_inring.rd;
+        size_t chunk_len = n - got;
+        if (chunk_len > to_end) chunk_len = to_end;
+        memcpy(buf + got, g_inring.data + g_inring.rd, chunk_len);
+        g_inring.rd = (g_inring.rd + chunk_len) % INPUT_RING_BYTES;
+        got += chunk_len;
+    }
+    g_inring.fill -= n;
+    if (n) pthread_cond_broadcast(&g_inring.can_write);
+    int error = g_inring.error;
+    pthread_mutex_unlock(&g_inring.lock);
+    return n ? (int)n : (error ? -1 : 0);
 }
 
 /* ---- Command pipe handler ---- */
@@ -731,12 +781,17 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     }
 
     /* Schedule start time */
+    bool started;
     if (cfg->ntp_start) {
-        ap2cl_start_at(g_ap2cl, cfg->ntp_start);
+        started = ap2cl_start_at(g_ap2cl, cfg->ntp_start);
     } else {
         uint64_t now = raopcl_get_ntp(NULL);
         uint64_t start_at = now + MS2NTP(cfg->latency_ms);
-        ap2cl_start_at(g_ap2cl, start_at);
+        started = ap2cl_start_at(g_ap2cl, start_at);
+    }
+    if (!started) {
+        status_error("Cannot start AirPlay 2 stream");
+        return 1;
     }
 
     /* Placeholder metadata must follow ap2cl_start_at: that call sets the RTP
@@ -752,6 +807,9 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     uint8_t *buf = malloc(AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
     uint8_t *ap2_alac_buf = (cfg->bit_depth > 16) ? malloc(AP2_FRAMES_PER_CHUNK * ap2_alac_bpf) : NULL;
     bool got_eof = false;
+    bool playback_failed = false;
+    bool starving = false;
+    uint64_t starvation_started = 0;
 
     uint64_t eof_time = 0;
 
@@ -759,8 +817,10 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     while (g_status != STATUS_STOPPED && (!got_eof || ap2cl_is_playing(g_ap2cl))) {
         uint64_t now = raopcl_get_ntp(NULL);
 
-        if (!ap2cl_is_connected(g_ap2cl)) {
+        if (!ap2cl_is_connected(g_ap2cl) ||
+            !ap2cl_control_healthy(g_ap2cl)) {
             status_error("AirPlay 2 control channel failed");
+            playback_failed = true;
             break;
         }
 
@@ -783,9 +843,21 @@ static int run_airplay2(cli_config_t *cfg, int infile)
 
         /* Send audio chunk */
         if (g_status == STATUS_PLAYING && ap2cl_accept_frames(g_ap2cl)) {
-            int n = input_ring_read(buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
+            int n = input_ring_read_timed(
+                buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf, 250);
+            if (n == INPUT_RING_TIMEOUT) {
+                if (!starving) {
+                    starving = true;
+                    starvation_started = raopcl_get_ntp(NULL);
+                    LOG_WARN("[AP2] PCM input starved; waiting in 250 ms intervals");
+                    ap2cl_log_diagnostics(g_ap2cl);
+                }
+                ap2cl_recover_input_gap(g_ap2cl);
+                continue;
+            }
             if (n < 0) {
                 status_error("Error reading from audio source");
+                playback_failed = true;
                 break;
             } else if (n == 0) {
                 if (!got_eof) {
@@ -795,6 +867,14 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                 }
                 continue;
             }
+            if (starving) {
+                uint32_t stalled_ms =
+                    (uint32_t)NTP2MS(raopcl_get_ntp(NULL) -
+                                     starvation_started);
+                LOG_INFO("[AP2] PCM input recovered after %u ms", stalled_ms);
+                ap2cl_log_diagnostics(g_ap2cl);
+                starving = false;
+            }
 
             int af = n / ap2_input_bpf;
             uint8_t *send = buf;
@@ -802,8 +882,11 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                 truncate_32to24(buf, n, ap2_alac_buf);
                 send = ap2_alac_buf;
             }
-            if (!ap2cl_send_chunk(g_ap2cl, send, af)) {
+            ap2_send_result_t result =
+                ap2cl_send_chunk(g_ap2cl, send, af);
+            if (result == AP2_SEND_FATAL) {
                 status_error("AirPlay 2 realtime send failed");
+                playback_failed = true;
                 break;
             }
             frames += af;
@@ -812,11 +895,11 @@ static int run_airplay2(cli_config_t *cfg, int infile)
         }
     }
 
-    status_eof();
+    if (got_eof && !playback_failed) status_eof();
     g_running = false;
     free(buf);
     free(ap2_alac_buf);
-    return 0;
+    return playback_failed ? 1 : 0;
 }
 
 

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -36,6 +36,7 @@
 #include "ap2_client.h"
 #include "ap2_ptp.h"
 #include "ap2_hap.h"
+#include "artwork.h"
 
 #define VERSION "0.1.0"
 #define AP2_FRAMES_PER_CHUNK 352
@@ -348,26 +349,31 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
             mrp_status_report(ap2cl_mrp_push(g_ap2cl));
         }
     } else if (strcmp(key, "ARTWORK") == 0) {
-        if (access(value, F_OK) == 0) {
-            /* Local file artwork */
-            FILE *artfile = fopen(value, "r");
-            if (artfile) {
-                fseek(artfile, 0L, SEEK_END);
-                long numbytes = ftell(artfile);
-                fseek(artfile, 0L, SEEK_SET);
-                char *buffer = (char *)calloc(numbytes, sizeof(char));
-                fread(buffer, sizeof(char), numbytes, artfile);
-                fclose(artfile);
-                if (cfg->protocol == PROTO_RAOP && g_raopcl) {
-                    raopcl_set_artwork(g_raopcl, "image/jpg", numbytes, buffer);
-                } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
-                    ap2cl_set_artwork(g_ap2cl, "image/jpeg", numbytes, buffer);
-                    mrp_status_report(ap2cl_mrp_push(g_ap2cl));
-                }
-                free(buffer);
-            }
+        uint8_t *image = NULL;
+        size_t image_size = 0;
+        char content_type[32];
+        char error[160];
+        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
+            ap2cl_is_connected(g_ap2cl))
+            ap2cl_feedback(g_ap2cl);
+        bool loaded = artwork_load(value, &image, &image_size, content_type,
+                                   error, sizeof(error));
+        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
+            ap2cl_is_connected(g_ap2cl))
+            ap2cl_feedback(g_ap2cl);
+        if (!loaded) {
+            LOG_WARN("Cannot load artwork: %s", error);
         } else {
-            LOG_DEBUG("Artwork URL not supported in binary, skipping: %s", value);
+            LOG_INFO("Loaded artwork (%zu bytes, %s)", image_size, content_type);
+            if (cfg->protocol == PROTO_RAOP && g_raopcl) {
+                raopcl_set_artwork(g_raopcl, content_type,
+                                   (int)image_size, (char *)image);
+            } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
+                ap2cl_set_artwork(g_ap2cl, content_type,
+                                  (int)image_size, (const char *)image);
+                mrp_status_report(ap2cl_mrp_push(g_ap2cl));
+            }
+            free(image);
         }
     } else if (strcmp(key, "VOLUME") == 0) {
         int vol = atoi(value);
@@ -581,8 +587,6 @@ static int run_raop(cli_config_t *cfg, int infile)
     LOG_INFO("Connecting to %s:%d via RAOP", inet_ntoa(player_addr), cfg->port);
     if (!raopcl_connect(g_raopcl, player_addr, cfg->port, cfg->volume > 0)) {
         status_error("Cannot connect to AirPlay device");
-        raopcl_destroy(g_raopcl);
-        g_raopcl = NULL;
         return 1;
     }
 
@@ -658,9 +662,6 @@ static int run_raop(cli_config_t *cfg, int infile)
     g_running = false;
     free(buf);
     free(alac_buf);
-    raopcl_disconnect(g_raopcl);
-    raopcl_destroy(g_raopcl);
-    g_raopcl = NULL;
     return 0;
 }
 
@@ -707,8 +708,6 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     LOG_INFO("Connecting to %s:%d via AirPlay 2", cfg->host, cfg->port);
     if (!ap2cl_connect(g_ap2cl)) {
         status_error("Cannot connect to AirPlay 2 device");
-        ap2cl_destroy(g_ap2cl);
-        g_ap2cl = NULL;
         return 1;
     }
 
@@ -825,8 +824,6 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     g_running = false;
     free(buf);
     free(ap2_alac_buf);
-    ap2cl_destroy(g_ap2cl);
-    g_ap2cl = NULL;
     return 0;
 }
 
@@ -1288,6 +1285,16 @@ int main(int argc, char *argv[])
         pthread_join(g_cmdpipe_thread, NULL);
         if (g_cmdpipe_fd >= 0) close(g_cmdpipe_fd);
         unlink(cfg.cmdpipe);
+    }
+    /* The command thread owns metadata/feedback/event-channel calls. Destroy
+     * protocol clients only after it is fully quiesced. */
+    if (g_ap2cl) {
+        ap2cl_destroy(g_ap2cl);
+        g_ap2cl = NULL;
+    }
+    if (g_raopcl) {
+        raopcl_destroy(g_raopcl);
+        g_raopcl = NULL;
     }
     if (infile >= 0 && infile != fileno(stdin)) close(infile);
     netsock_close();

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -1,0 +1,66 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "ap2_client.h"
+#include "cross_log.h"
+
+static log_level test_log_level = lSILENCE;
+log_level *loglevel = &test_log_level;
+log_level util_loglevel = lSILENCE;
+log_level raop_loglevel = lSILENCE;
+
+void ap2cl_test_lock_mrp(struct ap2cl_s *p);
+void ap2cl_test_unlock_mrp(struct ap2cl_s *p);
+
+typedef struct {
+    struct ap2cl_s *client;
+    atomic_bool done;
+    bool healthy;
+} health_check_t;
+
+static void *run_health_check(void *arg)
+{
+    health_check_t *check = arg;
+    check->healthy = ap2cl_control_healthy(check->client);
+    atomic_store(&check->done, true);
+    return NULL;
+}
+
+int main(void)
+{
+    ap2_device_info_t device = {
+        .name = "test",
+        .address = "127.0.0.1",
+        .port = 7000,
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+
+    health_check_t check = {
+        .client = client,
+    };
+    atomic_init(&check.done, false);
+    ap2cl_test_lock_mrp(client);
+    pthread_t thread;
+    assert(pthread_create(&thread, NULL, run_health_check, &check) == 0);
+    usleep(50000);
+    assert(atomic_load(&check.done));
+    assert(check.healthy);
+    ap2cl_test_unlock_mrp(client);
+    assert(pthread_join(thread, NULL) == 0);
+
+    assert(ap2cl_destroy(client));
+    puts("ap2_client health snapshot test passed");
+    return 0;
+}

--- a/tests/test_ap2_event.c
+++ b/tests/test_ap2_event.c
@@ -1,0 +1,216 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
+
+#include "ap2_mrp.h"
+#include "cross_log.h"
+
+#define KEY_SIZE 32
+#define TAG_SIZE 16
+
+static log_level test_log_level = lSILENCE;
+log_level *loglevel = &test_log_level;
+
+static void derive_key(const uint8_t secret[KEY_SIZE], const char *info,
+                       uint8_t key[KEY_SIZE])
+{
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
+    size_t len = KEY_SIZE;
+    assert(ctx);
+    assert(EVP_PKEY_derive_init(ctx) > 0);
+    assert(EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_sha512()) > 0);
+    assert(EVP_PKEY_CTX_set1_hkdf_salt(
+               ctx, (const unsigned char *)"Events-Salt", 11) > 0);
+    assert(EVP_PKEY_CTX_set1_hkdf_key(ctx, secret, KEY_SIZE) > 0);
+    assert(EVP_PKEY_CTX_add1_hkdf_info(
+               ctx, (const unsigned char *)info, strlen(info)) > 0);
+    assert(EVP_PKEY_derive(ctx, key, &len) > 0);
+    EVP_PKEY_CTX_free(ctx);
+}
+
+static void make_nonce(uint64_t counter, uint8_t nonce[12])
+{
+    memset(nonce, 0, 12);
+    for (int i = 0; i < 8; i++)
+        nonce[4 + i] = (uint8_t)(counter >> (i * 8));
+}
+
+static int encrypt_frame(const uint8_t key[KEY_SIZE], uint64_t counter,
+                         const uint8_t *plain, int plain_len, uint8_t *frame)
+{
+    uint8_t aad[2] = {plain_len & 0xff, (plain_len >> 8) & 0xff};
+    uint8_t nonce[12];
+    make_nonce(counter, nonce);
+    memcpy(frame, aad, 2);
+
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    int len = 0, total = 0;
+    assert(ctx);
+    assert(EVP_EncryptInit_ex(
+               ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) > 0);
+    assert(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) > 0);
+    assert(EVP_EncryptInit_ex(ctx, NULL, NULL, key, nonce) > 0);
+    assert(EVP_EncryptUpdate(ctx, NULL, &len, aad, 2) > 0);
+    assert(EVP_EncryptUpdate(
+               ctx, frame + 2, &len, plain, plain_len) > 0);
+    total = len;
+    assert(EVP_EncryptFinal_ex(ctx, frame + 2 + total, &len) > 0);
+    total += len;
+    assert(EVP_CIPHER_CTX_ctrl(
+               ctx, EVP_CTRL_AEAD_GET_TAG, TAG_SIZE,
+               frame + 2 + total) > 0);
+    EVP_CIPHER_CTX_free(ctx);
+    return total + 2 + TAG_SIZE;
+}
+
+static int decrypt_frame(const uint8_t key[KEY_SIZE], uint64_t counter,
+                         const uint8_t *frame, int frame_len, uint8_t *plain)
+{
+    assert(frame_len >= 2 + TAG_SIZE);
+    int cipher_len = frame[0] | (frame[1] << 8);
+    assert(frame_len == cipher_len + 2 + TAG_SIZE);
+    uint8_t nonce[12];
+    make_nonce(counter, nonce);
+
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    int len = 0, total = 0;
+    assert(ctx);
+    assert(EVP_DecryptInit_ex(
+               ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) > 0);
+    assert(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) > 0);
+    assert(EVP_DecryptInit_ex(ctx, NULL, NULL, key, nonce) > 0);
+    assert(EVP_DecryptUpdate(ctx, NULL, &len, frame, 2) > 0);
+    assert(EVP_DecryptUpdate(
+               ctx, plain, &len, frame + 2, cipher_len) > 0);
+    total = len;
+    assert(EVP_CIPHER_CTX_ctrl(
+               ctx, EVP_CTRL_AEAD_SET_TAG, TAG_SIZE,
+               (void *)(frame + 2 + cipher_len)) > 0);
+    assert(EVP_DecryptFinal_ex(ctx, plain + total, &len) > 0);
+    total += len;
+    EVP_CIPHER_CTX_free(ctx);
+    return total;
+}
+
+static struct ap2_mrp_ctx *create_mrp(const uint8_t secret[KEY_SIZE],
+                                      int event_sock)
+{
+    struct ap2_mrp_ctx *mrp = ap2_mrp_create(
+        "127.0.0.1", 7000, NULL, "1A2B3D4EA1B2C3D4",
+        "Music Assistant", "11111111-2222-4333-8444-555555555555",
+        "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE", secret);
+    assert(mrp);
+    assert(ap2_mrp_attach_events(mrp, event_sock));
+    assert(ap2_mrp_event_status(mrp) == 1);
+    return mrp;
+}
+
+static void send_request(int fd, const uint8_t key[KEY_SIZE],
+                         uint64_t counter, int cseq)
+{
+    char request[256];
+    int request_len = snprintf(
+        request, sizeof(request),
+        "POST /command RTSP/1.0\r\n"
+        "CSeq: %d\r\n"
+        "Server: AirTunes/1.0\r\n"
+        "Content-Length: 4\r\n\r\n"
+        "test",
+        cseq);
+    assert(request_len > 0 && request_len < (int)sizeof(request));
+    uint8_t encrypted[512];
+    int encrypted_len = encrypt_frame(
+        key, counter, (const uint8_t *)request, request_len, encrypted);
+    assert(write(fd, encrypted, (size_t)encrypted_len) == encrypted_len);
+}
+
+static void read_response(int fd, const uint8_t key[KEY_SIZE],
+                          uint64_t counter, int cseq)
+{
+    uint8_t response_frame[2048], response[2048];
+    assert(recv(fd, response_frame, 2, MSG_WAITALL) == 2);
+    int cipher_len = response_frame[0] | (response_frame[1] << 8);
+    int remaining = cipher_len + TAG_SIZE;
+    assert(recv(fd, response_frame + 2, (size_t)remaining, MSG_WAITALL) ==
+           remaining);
+    int response_len = decrypt_frame(
+        key, counter, response_frame, remaining + 2, response);
+    response[response_len] = '\0';
+    char expected_cseq[32];
+    snprintf(expected_cseq, sizeof(expected_cseq), "CSeq: %d\r\n", cseq);
+    assert(strstr((char *)response, "RTSP/1.0 200 OK\r\n"));
+    assert(strstr((char *)response, "Content-Length: 0\r\n"));
+    assert(strstr((char *)response, "Audio-Latency: 0\r\n"));
+    assert(strstr((char *)response, "Server: AirTunes/1.0\r\n"));
+    assert(strstr((char *)response, expected_cseq));
+}
+
+int main(void)
+{
+    uint8_t secret[KEY_SIZE];
+    for (int i = 0; i < KEY_SIZE; i++) secret[i] = (uint8_t)i;
+    uint8_t receiver_key[KEY_SIZE], sender_key[KEY_SIZE];
+    derive_key(secret, "Events-Write-Encryption-Key", receiver_key);
+    derive_key(secret, "Events-Read-Encryption-Key", sender_key);
+
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    struct timeval timeout = {.tv_sec = 2};
+    assert(setsockopt(sockets[1], SOL_SOCKET, SO_RCVTIMEO,
+                      &timeout, sizeof(timeout)) == 0);
+    struct ap2_mrp_ctx *mrp = create_mrp(secret, sockets[0]);
+
+    char request[256];
+    int request_len = snprintf(
+        request, sizeof(request),
+        "POST /command RTSP/1.0\r\nCSeq: 42\r\n"
+        "Server: AirTunes/1.0\r\nContent-Length: 4\r\n\r\ntest");
+    uint8_t encrypted[512];
+    int encrypted_len = encrypt_frame(
+        receiver_key, 0, (const uint8_t *)request, request_len, encrypted);
+    assert(write(sockets[1], encrypted, 1) == 1);
+    ap2_mrp_tick(mrp);
+    assert(write(sockets[1], encrypted + 1,
+                 (size_t)(encrypted_len - 1)) == encrypted_len - 1);
+    send_request(sockets[1], receiver_key, 1, 43);
+    ap2_mrp_tick(mrp);
+    read_response(sockets[1], sender_key, 0, 42);
+    read_response(sockets[1], sender_key, 1, 43);
+    ap2_mrp_destroy(mrp);
+    close(sockets[1]);
+
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    mrp = create_mrp(secret, sockets[0]);
+    close(sockets[1]);
+    ap2_mrp_tick(mrp);
+    assert(ap2_mrp_event_status(mrp) == 0);
+    ap2_mrp_destroy(mrp);
+
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    int small_buffer = 1024;
+    assert(setsockopt(sockets[0], SOL_SOCKET, SO_SNDBUF,
+                     &small_buffer, sizeof(small_buffer)) == 0);
+    assert(setsockopt(sockets[1], SOL_SOCKET, SO_RCVBUF,
+                     &small_buffer, sizeof(small_buffer)) == 0);
+    mrp = create_mrp(secret, sockets[0]);
+    uint64_t counter = 0;
+    for (int batch = 0;
+         batch < 20 && ap2_mrp_event_status(mrp) == 1;
+         batch++) {
+        for (int i = 0; i < 10; i++, counter++)
+            send_request(sockets[1], receiver_key, counter,
+                         100 + (int)counter);
+        ap2_mrp_tick(mrp);
+    }
+    assert(ap2_mrp_event_status(mrp) == 0);
+    ap2_mrp_destroy(mrp);
+    close(sockets[1]);
+    return 0;
+}

--- a/tests/test_ap2_event.c
+++ b/tests/test_ap2_event.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -152,6 +153,65 @@ static void read_response(int fd, const uint8_t key[KEY_SIZE],
     assert(strstr((char *)response, expected_cseq));
 }
 
+static bool contains_bytes(const uint8_t *haystack, int haystack_len,
+                           const uint8_t *needle, int needle_len)
+{
+    for (int i = 0; i + needle_len <= haystack_len; i++) {
+        if (memcmp(haystack + i, needle, (size_t)needle_len) == 0)
+            return true;
+    }
+    return false;
+}
+
+static void test_artwork_snapshot_generation(const uint8_t secret[KEY_SIZE])
+{
+    static const uint8_t first_art[] =
+        {0xf1, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x7f};
+    static const uint8_t second_art[] =
+        {0xe2, 0x91, 0x82, 0x73, 0x64, 0x55, 0x46, 0x3e};
+    struct ap2_mrp_ctx *mrp = ap2_mrp_create(
+        "127.0.0.1", 7000, NULL, "1A2B3D4EA1B2C3D4",
+        "Music Assistant", "11111111-2222-4333-8444-555555555555",
+        "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE", secret);
+    assert(mrp);
+
+    assert(ap2_mrp_set_artwork(
+        mrp, "image/test", first_art, (int)sizeof(first_art)));
+    uint64_t first_generation = ap2_mrp_artwork_generation(mrp);
+    uint8_t *first_snapshot = NULL;
+    int first_len = 0;
+    assert(ap2_mrp_build_nowplaying_command(
+        mrp, &first_snapshot, &first_len));
+    assert(contains_bytes(
+        first_snapshot, first_len, first_art, (int)sizeof(first_art)));
+
+    assert(ap2_mrp_set_artwork(
+        mrp, "image/test", second_art, (int)sizeof(second_art)));
+    ap2_mrp_mark_artwork_sent_if_generation(mrp, first_generation);
+
+    uint8_t *second_snapshot = NULL;
+    int second_len = 0;
+    assert(ap2_mrp_build_nowplaying_command(
+        mrp, &second_snapshot, &second_len));
+    assert(contains_bytes(
+        second_snapshot, second_len, second_art, (int)sizeof(second_art)));
+
+    uint64_t second_generation = ap2_mrp_artwork_generation(mrp);
+    ap2_mrp_mark_artwork_sent_if_generation(mrp, second_generation);
+    uint8_t *reference_snapshot = NULL;
+    int reference_len = 0;
+    assert(ap2_mrp_build_nowplaying_command(
+        mrp, &reference_snapshot, &reference_len));
+    assert(!contains_bytes(
+        reference_snapshot, reference_len,
+        second_art, (int)sizeof(second_art)));
+
+    free(first_snapshot);
+    free(second_snapshot);
+    free(reference_snapshot);
+    ap2_mrp_destroy(mrp);
+}
+
 int main(void)
 {
     uint8_t secret[KEY_SIZE];
@@ -159,6 +219,7 @@ int main(void)
     uint8_t receiver_key[KEY_SIZE], sender_key[KEY_SIZE];
     derive_key(secret, "Events-Write-Encryption-Key", receiver_key);
     derive_key(secret, "Events-Read-Encryption-Key", sender_key);
+    test_artwork_snapshot_generation(secret);
 
     int sockets[2];
     assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -1,0 +1,107 @@
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "ap2_io.h"
+
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        return false; \
+    } \
+} while (0)
+
+static bool test_fake_peer_response(void)
+{
+    int pair[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
+    const char response[] =
+        "RTSP/1.0 200 OK\r\nCSeq: 7\r\nContent-Length: 0\r\n\r\n";
+    CHECK(write(pair[1], response, sizeof(response) - 1) ==
+          (ssize_t)(sizeof(response) - 1));
+
+    uint8_t buf[128] = {0};
+    ssize_t n = ap2_io_read_deadline(
+        pair[0], buf, sizeof(buf), ap2_io_monotonic_ms() + 100);
+    CHECK(n == (ssize_t)(sizeof(response) - 1));
+    CHECK(memcmp(buf, response, sizeof(response) - 1) == 0);
+    close(pair[0]);
+    close(pair[1]);
+    return true;
+}
+
+static bool test_read_timeout_is_bounded(void)
+{
+    int pair[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
+    uint8_t byte;
+    uint64_t started = ap2_io_monotonic_ms();
+    errno = 0;
+    ssize_t n = ap2_io_read_deadline(pair[0], &byte, 1, started + 80);
+    uint64_t elapsed = ap2_io_monotonic_ms() - started;
+    CHECK(n < 0);
+    CHECK(errno == ETIMEDOUT);
+    CHECK(elapsed >= 50 && elapsed < 500);
+    close(pair[0]);
+    close(pair[1]);
+    return true;
+}
+
+static bool test_stalled_write_is_bounded(void)
+{
+    int pair[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
+    int sendbuf = 4096;
+    CHECK(setsockopt(pair[0], SOL_SOCKET, SO_SNDBUF,
+                     &sendbuf, sizeof(sendbuf)) == 0);
+
+    int len = 4 * 1024 * 1024;
+    uint8_t *payload = malloc((size_t)len);
+    CHECK(payload != NULL);
+    memset(payload, 0x5a, (size_t)len);
+    uint64_t started = ap2_io_monotonic_ms();
+    errno = 0;
+    bool ok = ap2_io_write_all_deadline(
+        pair[0], payload, len, started + 100);
+    uint64_t elapsed = ap2_io_monotonic_ms() - started;
+    CHECK(!ok);
+    CHECK(errno == ETIMEDOUT);
+    CHECK(elapsed >= 50 && elapsed < 1000);
+    free(payload);
+    close(pair[0]);
+    close(pair[1]);
+    return true;
+}
+
+static bool test_closed_peer_is_visible(void)
+{
+    int pair[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
+    close(pair[1]);
+    uint8_t byte;
+    errno = 0;
+    ssize_t n = ap2_io_read_deadline(
+        pair[0], &byte, 1, ap2_io_monotonic_ms() + 100);
+    CHECK(n == 0);
+    CHECK(errno == ECONNRESET);
+    close(pair[0]);
+    return true;
+}
+
+int main(void)
+{
+    if (!test_fake_peer_response()) return 1;
+    fprintf(stderr, "fake peer response passed\n");
+    if (!test_read_timeout_is_bounded()) return 1;
+    fprintf(stderr, "read timeout passed\n");
+    if (!test_stalled_write_is_bounded()) return 1;
+    fprintf(stderr, "stalled write passed\n");
+    if (!test_closed_peer_is_visible()) return 1;
+    fprintf(stderr, "closed peer passed\n");
+    puts("ap2_io tests passed");
+    return 0;
+}

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -34,6 +34,30 @@ static bool test_fake_peer_response(void)
     return true;
 }
 
+static bool test_rtsp_parser(void)
+{
+    static const uint8_t response[] =
+        "RTSP/1.0 200 OK\r\n"
+        "CSeq: 17\r\n"
+        "Content-Length: 4\r\n\r\n"
+        "test";
+    ap2_rtsp_response_t parsed;
+    CHECK(ap2_io_parse_rtsp_response(
+              response, sizeof(response) - 2, &parsed) == 0);
+    CHECK(ap2_io_parse_rtsp_response(
+              response, sizeof(response) - 1, &parsed) == 1);
+    CHECK(parsed.status == 200);
+    CHECK(parsed.cseq == 17);
+    CHECK(parsed.body_len == 4);
+    CHECK(parsed.message_len == sizeof(response) - 1);
+
+    static const uint8_t malformed[] =
+        "RTSP/1.0 200 OK\r\nCSeq: nope\r\nContent-Length: 0\r\n\r\n";
+    CHECK(ap2_io_parse_rtsp_response(
+              malformed, sizeof(malformed) - 1, &parsed) == -1);
+    return true;
+}
+
 static bool test_read_timeout_is_bounded(void)
 {
     int pair[2];
@@ -92,16 +116,46 @@ static bool test_closed_peer_is_visible(void)
     return true;
 }
 
+static bool test_datagram_outcomes(void)
+{
+    int pair[2];
+    CHECK(socketpair(AF_UNIX, SOCK_DGRAM, 0, pair) == 0);
+    uint8_t payload[1024] = {0};
+    CHECK(ap2_io_send_datagram_deadline(
+              pair[0], payload, sizeof(payload), NULL, 0,
+              ap2_io_monotonic_ms() + 40) == AP2_SEND_SENT);
+
+    int sendbuf = 2048;
+    CHECK(setsockopt(pair[0], SOL_SOCKET, SO_SNDBUF,
+                     &sendbuf, sizeof(sendbuf)) == 0);
+    while (send(pair[0], payload, sizeof(payload), MSG_DONTWAIT) >= 0) {}
+    CHECK(errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS);
+    CHECK(ap2_io_send_datagram_deadline(
+              pair[0], payload, sizeof(payload), NULL, 0,
+              ap2_io_monotonic_ms() + 40) == AP2_SEND_DROPPED);
+
+    close(pair[0]);
+    CHECK(ap2_io_send_datagram_deadline(
+              pair[0], payload, sizeof(payload), NULL, 0,
+              ap2_io_monotonic_ms() + 40) == AP2_SEND_FATAL);
+    close(pair[1]);
+    return true;
+}
+
 int main(void)
 {
     if (!test_fake_peer_response()) return 1;
     fprintf(stderr, "fake peer response passed\n");
+    if (!test_rtsp_parser()) return 1;
+    fprintf(stderr, "RTSP parser passed\n");
     if (!test_read_timeout_is_bounded()) return 1;
     fprintf(stderr, "read timeout passed\n");
     if (!test_stalled_write_is_bounded()) return 1;
     fprintf(stderr, "stalled write passed\n");
     if (!test_closed_peer_is_visible()) return 1;
     fprintf(stderr, "closed peer passed\n");
+    if (!test_datagram_outcomes()) return 1;
+    fprintf(stderr, "datagram outcomes passed\n");
     puts("ap2_io tests passed");
     return 0;
 }

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -157,16 +157,24 @@ static bool test_rtsp_lock_timeout_preserves_request_state(void)
         .rtsp_lock = &rtsp_lock,
         .channel_fd = channel[0],
     };
-    pthread_t thread;
-    CHECK(pthread_create(
-              &thread, NULL, run_rtsp_transaction, &transaction) == 0);
-    CHECK(pthread_join(thread, NULL) == 0);
-    CHECK(transaction.lock_result == 0);
-    CHECK(transaction.lock_errno == ETIMEDOUT);
-    CHECK(transaction.elapsed_ms >= 30 && transaction.elapsed_ms < 500);
-    CHECK(transaction.cseq == 0);
-    CHECK(transaction.nonce == 0);
-    CHECK(transaction.channel_touches == 0);
+    unsigned feedback_failures = 0;
+    for (int tick = 0; tick < 3; tick++) {
+        pthread_t thread;
+        CHECK(pthread_create(
+                  &thread, NULL, run_rtsp_transaction, &transaction) == 0);
+        CHECK(pthread_join(thread, NULL) == 0);
+        CHECK(transaction.lock_result == 0);
+        CHECK(transaction.lock_errno == ETIMEDOUT);
+        CHECK(transaction.elapsed_ms >= 30 && transaction.elapsed_ms < 500);
+        CHECK(transaction.cseq == 0);
+        CHECK(transaction.nonce == 0);
+        CHECK(transaction.channel_touches == 0);
+        ap2_feedback_result_t result =
+            ap2_io_feedback_result(-ETIMEDOUT, false);
+        if (result == AP2_FEEDBACK_FAILED) feedback_failures++;
+        CHECK(result == AP2_FEEDBACK_SKIPPED);
+        CHECK(feedback_failures == 0);
+    }
 
     uint8_t byte;
     errno = 0;
@@ -179,6 +187,8 @@ static bool test_rtsp_lock_timeout_preserves_request_state(void)
     CHECK(transaction.cseq == 1);
     CHECK(transaction.nonce == 1);
     CHECK(transaction.channel_touches == 1);
+    CHECK(ap2_io_feedback_result(200, true) ==
+          AP2_FEEDBACK_SUCCEEDED);
     CHECK(recv(channel[1], &byte, 1, MSG_DONTWAIT) == 1);
     CHECK(byte == 'R');
 
@@ -214,6 +224,26 @@ static bool test_datagram_outcomes(void)
     return true;
 }
 
+static bool test_feedback_lock_timeouts_are_skipped(void)
+{
+    unsigned failures = 2;
+    for (int tick = 0; tick < 4; tick++) {
+        ap2_feedback_result_t result =
+            ap2_io_feedback_result(-ETIMEDOUT, false);
+        CHECK(result == AP2_FEEDBACK_SKIPPED);
+        if (result == AP2_FEEDBACK_FAILED) failures++;
+        CHECK(failures == 2);
+    }
+
+    CHECK(ap2_io_feedback_result(-ETIMEDOUT, true) ==
+          AP2_FEEDBACK_FAILED);
+    CHECK(ap2_io_feedback_result(500, true) == AP2_FEEDBACK_FAILED);
+    CHECK(ap2_io_feedback_result(200, true) == AP2_FEEDBACK_SUCCEEDED);
+    failures = 0;
+    CHECK(failures == 0);
+    return true;
+}
+
 int main(void)
 {
     if (!test_fake_peer_response()) return 1;
@@ -230,6 +260,8 @@ int main(void)
     fprintf(stderr, "RTSP lock deadline passed\n");
     if (!test_datagram_outcomes()) return 1;
     fprintf(stderr, "datagram outcomes passed\n");
+    if (!test_feedback_lock_timeouts_are_skipped()) return 1;
+    fprintf(stderr, "feedback contention accounting passed\n");
     puts("ap2_io tests passed");
     return 0;
 }

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -116,6 +117,77 @@ static bool test_closed_peer_is_visible(void)
     return true;
 }
 
+typedef struct {
+    pthread_mutex_t *rtsp_lock;
+    int channel_fd;
+    int cseq;
+    uint64_t nonce;
+    int channel_touches;
+    int lock_result;
+    int lock_errno;
+    uint64_t elapsed_ms;
+} rtsp_transaction_t;
+
+static void *run_rtsp_transaction(void *arg)
+{
+    rtsp_transaction_t *transaction = arg;
+    uint64_t started = ap2_io_monotonic_ms();
+    transaction->lock_result = ap2_io_mutex_lock_deadline(
+        transaction->rtsp_lock, started + 50);
+    transaction->lock_errno = errno;
+    transaction->elapsed_ms = ap2_io_monotonic_ms() - started;
+    if (transaction->lock_result != 1) return NULL;
+
+    transaction->cseq++;
+    transaction->nonce++;
+    if (send(transaction->channel_fd, "R", 1, 0) == 1)
+        transaction->channel_touches++;
+    pthread_mutex_unlock(transaction->rtsp_lock);
+    return NULL;
+}
+
+static bool test_rtsp_lock_timeout_preserves_request_state(void)
+{
+    pthread_mutex_t rtsp_lock = PTHREAD_MUTEX_INITIALIZER;
+    int channel[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, channel) == 0);
+    CHECK(pthread_mutex_lock(&rtsp_lock) == 0);
+
+    rtsp_transaction_t transaction = {
+        .rtsp_lock = &rtsp_lock,
+        .channel_fd = channel[0],
+    };
+    pthread_t thread;
+    CHECK(pthread_create(
+              &thread, NULL, run_rtsp_transaction, &transaction) == 0);
+    CHECK(pthread_join(thread, NULL) == 0);
+    CHECK(transaction.lock_result == 0);
+    CHECK(transaction.lock_errno == ETIMEDOUT);
+    CHECK(transaction.elapsed_ms >= 30 && transaction.elapsed_ms < 500);
+    CHECK(transaction.cseq == 0);
+    CHECK(transaction.nonce == 0);
+    CHECK(transaction.channel_touches == 0);
+
+    uint8_t byte;
+    errno = 0;
+    CHECK(recv(channel[1], &byte, 1, MSG_DONTWAIT) < 0);
+    CHECK(errno == EAGAIN || errno == EWOULDBLOCK);
+
+    CHECK(pthread_mutex_unlock(&rtsp_lock) == 0);
+    run_rtsp_transaction(&transaction);
+    CHECK(transaction.lock_result == 1);
+    CHECK(transaction.cseq == 1);
+    CHECK(transaction.nonce == 1);
+    CHECK(transaction.channel_touches == 1);
+    CHECK(recv(channel[1], &byte, 1, MSG_DONTWAIT) == 1);
+    CHECK(byte == 'R');
+
+    CHECK(pthread_mutex_destroy(&rtsp_lock) == 0);
+    close(channel[0]);
+    close(channel[1]);
+    return true;
+}
+
 static bool test_datagram_outcomes(void)
 {
     int pair[2];
@@ -154,6 +226,8 @@ int main(void)
     fprintf(stderr, "stalled write passed\n");
     if (!test_closed_peer_is_visible()) return 1;
     fprintf(stderr, "closed peer passed\n");
+    if (!test_rtsp_lock_timeout_preserves_request_state()) return 1;
+    fprintf(stderr, "RTSP lock deadline passed\n");
     if (!test_datagram_outcomes()) return 1;
     fprintf(stderr, "datagram outcomes passed\n");
     puts("ap2_io tests passed");

--- a/tests/test_ap2_timeline.c
+++ b/tests/test_ap2_timeline.c
@@ -1,0 +1,45 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "ap2_timeline.h"
+
+int main(void)
+{
+    ap2_timeline_recovery_t plan;
+
+    assert(!ap2_timeline_plan_recovery(
+        200000, 205000, 5000, 100000, 11025, 77175, &plan));
+
+    assert(ap2_timeline_plan_recovery(
+        100000, 105000, 5000, 120000, 11025, 77175, &plan));
+    assert(plan.head == 197175);
+    assert(plan.shifted_frames == 97175);
+    assert((uint32_t)plan.head + plan.offset == 105000);
+
+    uint64_t wrapped_head = 0xFFFFFF00ULL;
+    uint32_t wrapped_offset = 0x00000200U;
+    uint32_t wrapped_rtp = (uint32_t)wrapped_head + wrapped_offset;
+    assert(ap2_timeline_plan_recovery(
+        wrapped_head, wrapped_rtp, wrapped_offset,
+        wrapped_head + 20000, 11025, 77175, &plan));
+    assert((uint32_t)plan.head + plan.offset == wrapped_rtp);
+
+    assert(!ap2_timeline_plan_recovery(
+        100000, 999, 5000, 120000, 11025, 77175, &plan));
+
+    uint64_t head = 100000;
+    uint32_t offset = 5000;
+    uint32_t rtp = 105000;
+    uint64_t anchor_ns = 7000000000ULL;
+    for (int i = 0; i < 5; i++) {
+        assert(ap2_timeline_plan_recovery(
+            head, rtp, offset, head + 20000, 11025, 77175, &plan));
+        anchor_ns += ap2_timeline_frames_to_ns(
+            plan.shifted_frames, 44100);
+        head = plan.head;
+        offset = plan.offset;
+        assert((uint32_t)head + offset == rtp);
+    }
+    assert(anchor_ns > 7000000000ULL);
+    return 0;
+}


### PR DESCRIPTION
## Summary

- keep native Apple TV sessions alive with an always-on feedback and event worker
- bound encrypted control and realtime writes so failures cannot freeze playback
- recover long PCM gaps without leaving RTP/PTP timing permanently late
- add diagnostics and regression coverage for control, event, send, and timeline failures

Validated with continuous playback on a real Apple TV: audio, elapsed status, feedback, reverse events, and now-playing metadata remained stable.