### PR TITLE
Fix Apple TV playback stalls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ${{ matrix.packages }}
       - name: Build
         run: make STATIC=1 CC=${{ matrix.cc }} CXX=${{ matrix.cxx }}
+      - name: Test
+        if: matrix.platform == 'x86_64'
+        run: make test STATIC=1 CC=${{ matrix.cc }} CXX=${{ matrix.cxx }}
       - name: Validate
         run: |
           bin="bin/cliairplay-linux-${{ matrix.platform }}"
@@ -71,6 +74,9 @@ jobs:
           else
             make STATIC=1 CC=clang CXX=clang++
           fi
+      - name: Test
+        if: matrix.platform == 'arm64'
+        run: make test STATIC=1 CC=clang CXX=clang++
       - name: Validate
         run: |
           bin="bin/cliairplay-macos-${{ matrix.platform }}"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -387,6 +387,10 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 - **Socket timeouts** — the RTSP socket, events socket, and the buffered TCP
   socket are receive/send-timeout bounded; a receiver that stops draining
   can never hang the process.
+- **Reverse event channel** — pair-verified sessions derive independent
+  `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
+  `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS
+  to tear down a MediaRemote-active stream after roughly 30 seconds.
 - **Eager input ring** — a dedicated reader drains stdin into a 4 MB ring as
   fast as the source delivers, decoupled from network pacing: the pipeline
   fills before a scheduled start, while a full ring backpressures the pipe.
@@ -396,9 +400,17 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
   caller has not set any (Sonos withholds audio until it has metadata; the
   native flow also requires `RTP-Info` on the metadata request — Sonos 400s
   without it).
-- **MediaRemote now-playing** — pair-verified Apple sessions additionally push
-  now-playing over `POST /command` on the same cadence as `/feedback` (§8);
-  best-effort, audio never gates on it.
+- **Apple MediaRemote metadata** — pair-verified native sessions register a
+  DEVICE_INFO origin, then send `updateMRNowPlayingInfo` followed by supported
+  commands, explicit playback state, and a serialized NowPlayingClient.
+  Start/pause/resume/stop transitions stay synchronized with the audio state.
+  This path is enabled by default (`CLIAIRPLAY_MRP=0` is the diagnostic opt-out);
+  best-effort, audio never gates on it (§8).
+- **Metadata inputs** — UTF-8 strings become UTF-16BE binary-plist strings when
+  needed. `ARTWORK` accepts local files and MA's local HTTP imageproxy URLs;
+  imageproxy requests are normalized to supported `size=512&fmt=jpeg` values,
+  and fetches have a 5-second overall deadline so metadata I/O cannot starve
+  the feedback/event keepalive loop.
 
 ## 11. Device-behavior findings
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -384,6 +384,11 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 - **RTSP serialization** — one mutex serializes the RTSP channel, so the
   keepalive thread and the streaming path can never interleave frames on the
   encrypted channel.
+- **RTSP fail-closed liveness** — reads and writes are bounded to 8 s. A
+  zero-status request shuts down the TCP/HAP stream because a late encrypted
+  response would otherwise be attributed to the next request and desynchronize
+  nonce counters; the process exits with an error so its supervisor can
+  reconnect instead of leaving a zombie UDP sender.
 - **Socket timeouts** — the RTSP socket, events socket, and the buffered TCP
   socket are receive/send-timeout bounded; a receiver that stops draining
   can never hang the process.
@@ -391,6 +396,12 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS
   to tear down a MediaRemote-active stream after roughly 30 seconds.
+- **Realtime send loop** — RTP data/control UDP sockets are non-blocking and
+  account for dropped datagrams, so local network backpressure cannot freeze
+  elapsed-status output. A PCM starvation gap that exhausts the receiver lead
+  shifts the pacing deadline and PTP anchor forward while keeping audio RTP
+  timestamps contiguous, allowing resumed content to render instead of staying
+  permanently late.
 - **Eager input ring** — a dedicated reader drains stdin into a 4 MB ring as
   fast as the source delivers, decoupled from network pacing: the pipeline
   fills before a scheduled start, while a full ring backpressures the pipe.
@@ -409,8 +420,11 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 - **Metadata inputs** — UTF-8 strings become UTF-16BE binary-plist strings when
   needed. `ARTWORK` accepts local files and MA's local HTTP imageproxy URLs;
   imageproxy requests are normalized to supported `size=512&fmt=jpeg` values,
-  and fetches have a 5-second overall deadline so metadata I/O cannot starve
-  the feedback/event keepalive loop.
+  and fetches have a 5-second overall deadline while pumping reverse-event
+  replies every 250 ms, so metadata I/O cannot starve session maintenance.
+- **Diagnostics** — `--debug 10` emits `[CLIDIAG]` ring-buffer snapshots,
+  `[AP2DIAG]` RTP/PTP pacing and packet counters, RTSP request durations,
+  feedback failures, event-channel requests, and starvation/re-anchor events.
 
 ## 11. Device-behavior findings
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -384,10 +384,11 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 - **RTSP serialization** — one mutex serializes the RTSP channel, so the
   keepalive thread and the streaming path can never interleave frames on the
   encrypted channel.
-- **RTSP fail-closed liveness** — reads and writes are bounded to 8 s. A
-  zero-status request shuts down the TCP/HAP stream because a late encrypted
-  response would otherwise be attributed to the next request and desynchronize
-  nonce counters; the process exits with an error so its supervisor can
+- **RTSP fail-closed liveness** — absolute monotonic deadlines bound every
+  request/response cycle: feedback/control requests are short, metadata is
+  longer, and artwork gets the largest window. Incomplete writes/responses or a
+  mismatched `CSeq` close the TCP/HAP stream because advanced encryption nonces
+  cannot be reused; the process exits with an error so its supervisor can
   reconnect instead of leaving a zombie UDP sender.
 - **Socket timeouts** — the RTSP socket, events socket, and the buffered TCP
   socket are receive/send-timeout bounded; a receiver that stops draining
@@ -396,6 +397,10 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS
   to tear down a MediaRemote-active stream after roughly 30 seconds.
+- **Dedicated maintenance worker** — every native session, including sessions
+  without a command pipe, runs one monotonic ~2 s feedback worker. It is the
+  sole reverse-event/DataStream tick owner, serializes MediaRemote state, and is
+  stopped and joined before encrypted channels are torn down.
 - **Realtime send loop** — RTP data/control UDP sockets are non-blocking and
   account for dropped datagrams, so local network backpressure cannot freeze
   elapsed-status output. A PCM starvation gap that exhausts the receiver lead
@@ -420,8 +425,8 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 - **Metadata inputs** — UTF-8 strings become UTF-16BE binary-plist strings when
   needed. `ARTWORK` accepts local files and MA's local HTTP imageproxy URLs;
   imageproxy requests are normalized to supported `size=512&fmt=jpeg` values,
-  and fetches have a 5-second overall deadline while pumping reverse-event
-  replies every 250 ms, so metadata I/O cannot starve session maintenance.
+  and fetches have a 5-second overall deadline. The independent maintenance
+  worker keeps feedback and reverse-event replies live during metadata I/O.
 - **Diagnostics** — `--debug 10` emits `[CLIDIAG]` ring-buffer snapshots,
   `[AP2DIAG]` RTP/PTP pacing and packet counters, RTSP request durations,
   feedback failures, event-channel requests, and starvation/re-anchor events.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -380,8 +380,9 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 
 - **Keepalive** — every native AP2 session starts a dedicated worker that POSTs
   `/feedback` every ~2 s, including sessions without `--cmdpipe`. The same
-  worker is the sole owner of reverse-event and type-130 servicing. RAOP paths
-  use libraop's keepalive (~20 s).
+  worker is the sole owner of reverse-event and type-130 servicing; both native
+  workers are stopped and joined before encrypted channels are destroyed. RAOP
+  paths use libraop's keepalive (~20 s).
 - **MediaRemote publication** — a separate worker coalesces pending
   registration, metadata, and playback-state updates. Callers only mutate a
   locked state snapshot and queue work, so optional `/command` I/O never delays
@@ -404,10 +405,6 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS
   to tear down a MediaRemote-active stream after roughly 30 seconds.
-- **Dedicated maintenance worker** — every native session, including sessions
-  without a command pipe, runs one monotonic ~2 s feedback worker. It is the
-  sole reverse-event/DataStream tick owner, serializes MediaRemote state, and is
-  stopped and joined before encrypted channels are torn down.
 - **Realtime send loop** — RTP data/control UDP sockets are non-blocking and
   distinguish a transient queue drop from a fatal encoder/key/socket failure.
   A dropped datagram advances sequence and RTP time, so local network

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -378,21 +378,28 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
 
 ## 10. Session robustness
 
-- **Keepalive** — native AP2 sessions POST `/feedback` every ~2 s (real
-  senders do; receivers idle-time-out long sessions without it). RAOP paths
+- **Keepalive** — every native AP2 session starts a dedicated worker that POSTs
+  `/feedback` every ~2 s, including sessions without `--cmdpipe`. The same
+  worker is the sole owner of reverse-event and type-130 servicing. RAOP paths
   use libraop's keepalive (~20 s).
+- **MediaRemote publication** — a separate worker coalesces pending
+  registration, metadata, and playback-state updates. Callers only mutate a
+  locked state snapshot and queue work, so optional `/command` I/O never delays
+  audio startup, RTP transmission, pause, or resume. Feedback waiting on the
+  RTSP channel takes priority between metadata requests.
 - **RTSP serialization** — one mutex serializes the RTSP channel, so the
-  keepalive thread and the streaming path can never interleave frames on the
-  encrypted channel.
-- **RTSP fail-closed liveness** — absolute monotonic deadlines bound every
-  request/response cycle: feedback/control requests are short, metadata is
-  longer, and artwork gets the largest window. Incomplete writes/responses or a
-  mismatched `CSeq` close the TCP/HAP stream because advanced encryption nonces
-  cannot be reused; the process exits with an error so its supervisor can
-  reconnect instead of leaving a zombie UDP sender.
-- **Socket timeouts** — the RTSP socket, events socket, and the buffered TCP
-  socket are receive/send-timeout bounded; a receiver that stops draining
-  can never hang the process.
+  keepalive and metadata paths can never interleave frames on the encrypted
+  channel. CSeq assignment, HAP nonce advancement, I/O, response decryption,
+  and response-CSeq validation form one transaction.
+- **RTSP fail-closed liveness** — cumulative request deadlines are 8 s during
+  setup, 1.5 s for feedback, 3 s for ordinary control, and 5 s for
+  metadata/artwork. A partial encrypted write or incomplete response shuts
+  down the TCP/HAP stream because the advanced nonce and CSeq can never be
+  reused safely. The process exits with an error so its supervisor reconnects
+  instead of leaving a zombie UDP sender.
+- **Bounded channel I/O** — reverse-event, type-130 DataStream, and buffered
+  audio writes have absolute deadlines. A failed encrypted channel is closed
+  rather than reused with an already-advanced nonce.
 - **Reverse event channel** — pair-verified sessions derive independent
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS
@@ -402,10 +409,12 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
   sole reverse-event/DataStream tick owner, serializes MediaRemote state, and is
   stopped and joined before encrypted channels are torn down.
 - **Realtime send loop** — RTP data/control UDP sockets are non-blocking and
-  account for dropped datagrams, so local network backpressure cannot freeze
-  elapsed-status output. A PCM starvation gap that exhausts the receiver lead
-  shifts the pacing deadline and PTP anchor forward while keeping audio RTP
-  timestamps contiguous, allowing resumed content to render instead of staying
+  distinguish a transient queue drop from a fatal encoder/key/socket failure.
+  A dropped datagram advances sequence and RTP time, so local network
+  backpressure cannot freeze elapsed-status output or replay a stale packet.
+  A PCM starvation gap that exhausts the receiver lead shifts the pacing
+  deadline and PTP anchor forward while keeping audio RTP timestamps
+  contiguous, allowing resumed content to render instead of staying
   permanently late.
 - **Eager input ring** — a dedicated reader drains stdin into a 4 MB ring as
   fast as the source delivers, decoupled from network pacing: the pipeline
@@ -421,12 +430,14 @@ not rendered — iOS buffered streams carry AAC). Reachable only via
   commands, explicit playback state, and a serialized NowPlayingClient.
   Start/pause/resume/stop transitions stay synchronized with the audio state.
   This path is enabled by default (`CLIAIRPLAY_MRP=0` is the diagnostic opt-out);
-  best-effort, audio never gates on it (§8).
+  best-effort, audio never gates on it (§8). Rapid updates are coalesced and
+  artwork completion is generation-checked so an in-flight old cover cannot
+  mark a newer cover as already delivered.
 - **Metadata inputs** — UTF-8 strings become UTF-16BE binary-plist strings when
   needed. `ARTWORK` accepts local files and MA's local HTTP imageproxy URLs;
   imageproxy requests are normalized to supported `size=512&fmt=jpeg` values,
-  and fetches have a 5-second overall deadline. The independent maintenance
-  worker keeps feedback and reverse-event replies live during metadata I/O.
+  and fetches have a 5-second overall deadline. The dedicated keepalive worker
+  services reverse events independently of artwork loading.
 - **Diagnostics** — `--debug 10` emits `[CLIDIAG]` ring-buffer snapshots,
   `[AP2DIAG]` RTP/PTP pacing and packet counters, RTSP request durations,
   feedback failures, event-channel requests, and starvation/re-anchor events.

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ EXECUTABLE  = $(BINDIR)/cliairplay-$(HOST)-$(PLATFORM)
 TIMELINE_TEST = $(BUILDDIR)/test-ap2-timeline
 EVENT_TEST = $(BUILDDIR)/test-ap2-event
 IO_TEST = $(BUILDDIR)/test-ap2-io
+FEEDBACK_TEST = $(BUILDDIR)/test-ap2-feedback
 
 # Compiler flags
 DEFINES  = -DNDEBUG -D_GNU_SOURCE -DOPENSSL_SUPPRESS_DEPRECATED
@@ -94,8 +95,8 @@ RAOP_SOURCES = raop_client.c rtsp_client.c \
 	alac.c
 
 # AirPlay 2 sources (new)
-AP2_SOURCES = ap2_client.c ap2_feedback.c ap2_hap.c ap2_io.c ap2_ptp.c \
-	ap2_ptp_shm.c ap2_plist.c ap2_mrp.c
+AP2_SOURCES = ap2_client.c ap2_hap.c ap2_io.c ap2_ptp.c ap2_ptp_shm.c \
+	ap2_plist.c ap2_mrp.c
 
 # Common/CLI sources
 CLI_SOURCES = cross_log.c cross_ssl.c cross_util.c cross_net.c platform.c \
@@ -122,13 +123,20 @@ OBJECTS_CLI  = $(patsubst %.c,$(BUILDDIR)/%.o,$(filter %.c,$(CLI_SOURCES)))
 OBJECTS_CLI += $(patsubst %.cpp,$(BUILDDIR)/%.o,$(filter %.cpp,$(CLI_SOURCES)))
 
 OBJECTS_ALL = $(OBJECTS_RAOP) $(OBJECTS_AP2) $(OBJECTS_CLI)
+FEEDBACK_CLIENT_OBJECT = $(BUILDDIR)/ap2_client_test.o
+FEEDBACK_TEST_MAIN = $(BUILDDIR)/test_ap2_feedback.o
+FEEDBACK_TEST_OBJECTS = $(OBJECTS_RAOP) \
+	$(filter-out $(BUILDDIR)/ap2_client.o,$(OBJECTS_AP2)) \
+	$(filter-out $(BUILDDIR)/cliairplay.o $(BUILDDIR)/artwork.o,$(OBJECTS_CLI)) \
+	$(FEEDBACK_CLIENT_OBJECT) $(FEEDBACK_TEST_MAIN)
 
 all: directory $(EXECUTABLE)
 
-test: directory $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST)
+test: directory $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(FEEDBACK_TEST)
 	$(TIMELINE_TEST)
 	$(EVENT_TEST)
 	$(IO_TEST)
+	$(FEEDBACK_TEST)
 
 directory:
 	@mkdir -p $(BUILDDIR)
@@ -149,21 +157,29 @@ $(BUILDDIR)/%.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) $< -c -o $@
 
 $(TIMELINE_TEST): tests/test_ap2_timeline.c src/ap2_timeline.h Makefile
-	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) -Isrc $< -o $@
+	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) $(EXTRA_CFLAGS) -Isrc \
+		$< $(EXTRA_LDFLAGS) -o $@
 
 $(EVENT_TEST): tests/test_ap2_event.c $(BUILDDIR)/ap2_mrp.o \
-		$(BUILDDIR)/ap2_io.o \
-		$(BUILDDIR)/ap2_plist.o $(BUILDDIR)/cross_log.o Makefile
-	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) $(INCLUDE) \
+		$(BUILDDIR)/ap2_io.o $(BUILDDIR)/ap2_plist.o \
+		$(BUILDDIR)/cross_log.o Makefile
+	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) $(EXTRA_CFLAGS) $(INCLUDE) \
 		$< $(BUILDDIR)/ap2_mrp.o $(BUILDDIR)/ap2_io.o \
 		$(BUILDDIR)/ap2_plist.o \
 		$(BUILDDIR)/cross_log.o $(OPENSSL)/libopenssl.a $(LDFLAGS) -o $@
 
-$(IO_TEST): tests/test_ap2_io.c src/ap2_io.c src/ap2_io.h \
-		src/ap2_feedback.c src/ap2_feedback.h Makefile
-	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) -Isrc \
-		tests/test_ap2_io.c src/ap2_io.c src/ap2_feedback.c \
-		-lpthread -o $@
+$(IO_TEST): tests/test_ap2_io.c $(BUILDDIR)/ap2_io.o Makefile
+	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) $(EXTRA_CFLAGS) -Isrc \
+		$< $(BUILDDIR)/ap2_io.o $(EXTRA_LDFLAGS) -o $@
+
+$(FEEDBACK_CLIENT_OBJECT): src/ap2_client.c Makefile
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) -DAP2_TESTING $< -c -o $@
+
+$(FEEDBACK_TEST_MAIN): tests/test_ap2_feedback.c Makefile
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) -DAP2_TESTING $< -c -o $@
+
+$(FEEDBACK_TEST): $(FEEDBACK_TEST_OBJECTS) $(LIBCODECS_PATCHED)
+	$(CXX) $(FEEDBACK_TEST_OBJECTS) $(LIBRARY) $(LDFLAGS) -o $@
 
 clean:
 	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED)

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ AP2_SOURCES = ap2_client.c ap2_hap.c ap2_ptp.c ap2_ptp_shm.c ap2_plist.c ap2_mrp
 
 # Common/CLI sources
 CLI_SOURCES = cross_log.c cross_ssl.c cross_util.c cross_net.c platform.c \
-	cliairplay.c pairing.cpp bplist.cpp ap2_bplist.cpp alac_ext.cpp
+	cliairplay.c artwork.c pairing.cpp bplist.cpp ap2_bplist.cpp alac_ext.cpp
 
 # Pre-built static libraries
 # We use a patched copy of libcodecs.a with the buggy alac_create_encoder removed,

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ BINDIR      = bin
 EXECUTABLE  = $(BINDIR)/cliairplay-$(HOST)-$(PLATFORM)
 TIMELINE_TEST = $(BUILDDIR)/test-ap2-timeline
 EVENT_TEST = $(BUILDDIR)/test-ap2-event
+IO_TEST = $(BUILDDIR)/test-ap2-io
 
 # Compiler flags
 DEFINES  = -DNDEBUG -D_GNU_SOURCE -DOPENSSL_SUPPRESS_DEPRECATED
@@ -93,7 +94,8 @@ RAOP_SOURCES = raop_client.c rtsp_client.c \
 	alac.c
 
 # AirPlay 2 sources (new)
-AP2_SOURCES = ap2_client.c ap2_hap.c ap2_ptp.c ap2_ptp_shm.c ap2_plist.c ap2_mrp.c
+AP2_SOURCES = ap2_client.c ap2_feedback.c ap2_hap.c ap2_io.c ap2_ptp.c \
+	ap2_ptp_shm.c ap2_plist.c ap2_mrp.c
 
 # Common/CLI sources
 CLI_SOURCES = cross_log.c cross_ssl.c cross_util.c cross_net.c platform.c \
@@ -123,9 +125,10 @@ OBJECTS_ALL = $(OBJECTS_RAOP) $(OBJECTS_AP2) $(OBJECTS_CLI)
 
 all: directory $(EXECUTABLE)
 
-test: directory $(TIMELINE_TEST) $(EVENT_TEST)
+test: directory $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST)
 	$(TIMELINE_TEST)
 	$(EVENT_TEST)
+	$(IO_TEST)
 
 directory:
 	@mkdir -p $(BUILDDIR)
@@ -149,10 +152,18 @@ $(TIMELINE_TEST): tests/test_ap2_timeline.c src/ap2_timeline.h Makefile
 	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) -Isrc $< -o $@
 
 $(EVENT_TEST): tests/test_ap2_event.c $(BUILDDIR)/ap2_mrp.o \
+		$(BUILDDIR)/ap2_io.o \
 		$(BUILDDIR)/ap2_plist.o $(BUILDDIR)/cross_log.o Makefile
 	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) $(INCLUDE) \
-		$< $(BUILDDIR)/ap2_mrp.o $(BUILDDIR)/ap2_plist.o \
+		$< $(BUILDDIR)/ap2_mrp.o $(BUILDDIR)/ap2_io.o \
+		$(BUILDDIR)/ap2_plist.o \
 		$(BUILDDIR)/cross_log.o $(OPENSSL)/libopenssl.a $(LDFLAGS) -o $@
+
+$(IO_TEST): tests/test_ap2_io.c src/ap2_io.c src/ap2_io.h \
+		src/ap2_feedback.c src/ap2_feedback.h Makefile
+	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) -Isrc \
+		tests/test_ap2_io.c src/ap2_io.c src/ap2_feedback.c \
+		-lpthread -o $@
 
 clean:
 	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED)

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ RAOP_SOURCES = raop_client.c rtsp_client.c \
 	alac.c
 
 # AirPlay 2 sources (new)
-AP2_SOURCES = ap2_client.c ap2_hap.c ap2_io.c ap2_ptp.c ap2_ptp_shm.c \
-	ap2_plist.c ap2_mrp.c
+AP2_SOURCES = ap2_client.c ap2_feedback.c ap2_hap.c ap2_io.c ap2_ptp.c \
+	ap2_ptp_shm.c ap2_plist.c ap2_mrp.c
 
 # Common/CLI sources
 CLI_SOURCES = cross_log.c cross_ssl.c cross_util.c cross_net.c platform.c \
@@ -125,10 +125,12 @@ OBJECTS_CLI += $(patsubst %.cpp,$(BUILDDIR)/%.o,$(filter %.cpp,$(CLI_SOURCES)))
 OBJECTS_ALL = $(OBJECTS_RAOP) $(OBJECTS_AP2) $(OBJECTS_CLI)
 FEEDBACK_CLIENT_OBJECT = $(BUILDDIR)/ap2_client_test.o
 FEEDBACK_TEST_MAIN = $(BUILDDIR)/test_ap2_feedback.o
+FEEDBACK_CROSS_SSL_OBJECT = $(BUILDDIR)/cross_ssl_test.o
 FEEDBACK_TEST_OBJECTS = $(OBJECTS_RAOP) \
 	$(filter-out $(BUILDDIR)/ap2_client.o,$(OBJECTS_AP2)) \
-	$(filter-out $(BUILDDIR)/cliairplay.o $(BUILDDIR)/artwork.o,$(OBJECTS_CLI)) \
-	$(FEEDBACK_CLIENT_OBJECT) $(FEEDBACK_TEST_MAIN)
+	$(filter-out $(BUILDDIR)/cliairplay.o $(BUILDDIR)/artwork.o \
+		$(BUILDDIR)/cross_ssl.o,$(OBJECTS_CLI)) \
+	$(FEEDBACK_CROSS_SSL_OBJECT) $(FEEDBACK_CLIENT_OBJECT) $(FEEDBACK_TEST_MAIN)
 
 all: directory $(EXECUTABLE)
 
@@ -178,8 +180,13 @@ $(FEEDBACK_CLIENT_OBJECT): src/ap2_client.c Makefile
 $(FEEDBACK_TEST_MAIN): tests/test_ap2_feedback.c Makefile
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) -DAP2_TESTING $< -c -o $@
 
+$(FEEDBACK_CROSS_SSL_OBJECT): $(TOOLS)/cross_ssl.c Makefile
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) -DSSL_STATIC_LIB $< -c -o $@
+
 $(FEEDBACK_TEST): $(FEEDBACK_TEST_OBJECTS) $(LIBCODECS_PATCHED)
-	$(CXX) $(FEEDBACK_TEST_OBJECTS) $(LIBRARY) $(LDFLAGS) -o $@
+	$(CXX) $(FEEDBACK_TEST_OBJECTS) \
+		$(filter-out $(OPENSSL)/libopenssl.a,$(LIBRARY)) \
+		$(OPENSSL)/libopenssl.a $(LDFLAGS) -o $@
 
 clean:
 	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED)

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ BINDIR      = bin
 
 # Output binary
 EXECUTABLE  = $(BINDIR)/cliairplay-$(HOST)-$(PLATFORM)
+TIMELINE_TEST = $(BUILDDIR)/test-ap2-timeline
+EVENT_TEST = $(BUILDDIR)/test-ap2-event
 
 # Compiler flags
 DEFINES  = -DNDEBUG -D_GNU_SOURCE -DOPENSSL_SUPPRESS_DEPRECATED
@@ -121,6 +123,10 @@ OBJECTS_ALL = $(OBJECTS_RAOP) $(OBJECTS_AP2) $(OBJECTS_CLI)
 
 all: directory $(EXECUTABLE)
 
+test: directory $(TIMELINE_TEST) $(EVENT_TEST)
+	$(TIMELINE_TEST)
+	$(EVENT_TEST)
+
 directory:
 	@mkdir -p $(BUILDDIR)
 	@mkdir -p $(BINDIR)
@@ -139,7 +145,16 @@ $(BUILDDIR)/%.o: %.c
 $(BUILDDIR)/%.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) $< -c -o $@
 
+$(TIMELINE_TEST): tests/test_ap2_timeline.c src/ap2_timeline.h Makefile
+	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) -Isrc $< -o $@
+
+$(EVENT_TEST): tests/test_ap2_event.c $(BUILDDIR)/ap2_mrp.o \
+		$(BUILDDIR)/ap2_plist.o $(BUILDDIR)/cross_log.o Makefile
+	$(CC) -Wall -Wextra -Werror -O2 $(CPPFLAGS) $(INCLUDE) \
+		$< $(BUILDDIR)/ap2_mrp.o $(BUILDDIR)/ap2_plist.o \
+		$(BUILDDIR)/cross_log.o $(OPENSSL)/libopenssl.a $(LDFLAGS) -o $@
+
 clean:
 	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED)
 
-.PHONY: all directory clean
+.PHONY: all test directory clean

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ make STATIC=1
 # Linux cross-compile (example)
 make HOST=linux PLATFORM=aarch64 CC=aarch64-linux-gnu-gcc STATIC=1
 
-# Focused timeline, event-channel, deadline, and worker tests
-make test
+# Focused timeline, channel-I/O, and event-channel tests
+make test STATIC=1
 ```
 
 Requires the libraop submodule with pre-built static libraries (OpenSSL,

--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ Metadata strings are encoded as Unicode binary-plist strings; artwork is
 signature-checked and capped at 5 MiB. MA imageproxy URLs are normalized to a
 supported `size=512&fmt=jpeg` request.
 
+For a native-AP2 stall capture, run with `--debug 10` and retain the final
+minute before/after the failure. `[CLIDIAG]` reports PCM ring fill,
+`[AP2DIAG]` reports pacing/PTP anchors and RTP drop counters, and the RTSP/MRP
+lines report feedback status, request duration, and reverse-event replies.
+
 ## Building
 
 ```bash
@@ -199,6 +204,9 @@ make STATIC=1
 
 # Linux cross-compile (example)
 make HOST=linux PLATFORM=aarch64 CC=aarch64-linux-gnu-gcc STATIC=1
+
+# Focused timeline/event-channel tests
+make test
 ```
 
 Requires the libraop submodule with pre-built static libraries (OpenSSL,

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ make STATIC=1
 # Linux cross-compile (example)
 make HOST=linux PLATFORM=aarch64 CC=aarch64-linux-gnu-gcc STATIC=1
 
-# Focused timeline/event-channel tests
+# Focused timeline, event-channel, deadline, and worker tests
 make test
 ```
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ running stream:
 - `VOLUME=<0-100>`
 - `ACTION=PLAY|PAUSE|STOP`
 - Metadata: `TITLE=`, `ARTIST=`, `ALBUM=`, `DURATION=<s>`, `PROGRESS=<s>`,
-  `ARTWORK=<local file path>` (URLs are ignored), followed by
+  `ARTWORK=<local file path or http:// imageproxy URL>`, followed by
   `ACTION=SENDMETA` to push the set.
 
 Some receivers (notably Sonos) do not emit audio until they have received
@@ -187,6 +187,9 @@ audio starts regardless of whether the caller ever sends `SENDMETA`.
 Pair-verified native Apple sessions additionally mirror these updates over
 MediaRemote `POST /command`, including explicit play/pause/stop state. Set
 `CLIAIRPLAY_MRP=0` only to disable that path for comparison or diagnosis.
+Metadata strings are encoded as Unicode binary-plist strings; artwork is
+signature-checked and capped at 5 MiB. MA imageproxy URLs are normalized to a
+supported `size=512&fmt=jpeg` request.
 
 ## Building
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,12 @@
 
 Genuinely open work only. Completed work lives in git history.
 
+- [ ] **Apple TV native-AP2 stall soak.** Run a 30+ minute `--debug 10` stream
+      on real hardware and retain the final minute around any failure. Confirm
+      reverse-event replies continue, `/feedback` stays 200, `audio_dropped` and
+      `sync_dropped` remain zero, and `[CLIDIAG]` distinguishes PCM starvation
+      from PTP pacing. The deterministic event/timeline tests cover sender
+      behavior, but cannot reproduce tvOS teardown locally.
 - [ ] **Apple TV artwork for non-public images.** Now-playing text and artwork
       render on the Apple TV via MediaRemote, but cover art that is only
       reachable through Music Assistant's imageproxy (e.g. filesystem-provider

--- a/TODO.md
+++ b/TODO.md
@@ -2,12 +2,6 @@
 
 Genuinely open work only. Completed work lives in git history.
 
-- [ ] **Apple TV native-AP2 stall soak.** Run a 30+ minute `--debug 10` stream
-      on real hardware and retain the final minute around any failure. Confirm
-      reverse-event replies continue, `/feedback` stays 200, `audio_dropped` and
-      `sync_dropped` remain zero, and `[CLIDIAG]` distinguishes PCM starvation
-      from PTP pacing. The deterministic event/timeline tests cover sender
-      behavior, but cannot reproduce tvOS teardown locally.
 - [ ] **Apple TV artwork for non-public images.** Now-playing text and artwork
       render on the Apple TV via MediaRemote, but cover art that is only
       reachable through Music Assistant's imageproxy (e.g. filesystem-provider

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -561,6 +561,12 @@ static void ap2_native_setup_mrp(struct ap2cl_s *p)
                                 p->session_uuid, p->group_uuid,
                                 ap2_hap_get_shared_secret(p->hap));
     if (!p->mrp) return;
+    if (!ap2_mrp_attach_events(p->mrp, p->events_sock)) {
+        LOG_WARN("[MRP] event-channel attach failed; degrading to no-MRP");
+        ap2_mrp_destroy(p->mrp);
+        p->mrp = NULL;
+        return;
+    }
 
     if (!ap2_mrp_attach(p->mrp, data_port, seed)) {
         LOG_WARN("[MRP] data-channel attach failed; degrading to no-MRP");
@@ -826,10 +832,12 @@ static bool ap2_native_connect(struct ap2cl_s *p)
             inet_pton(AF_INET, p->device.address, &ev_addr.sin_addr);
             struct timeval etv = {.tv_sec = 3};
             setsockopt(events_sock, SOL_SOCKET, SO_RCVTIMEO, &etv, sizeof(etv));
+            setsockopt(events_sock, SOL_SOCKET, SO_SNDTIMEO, &etv, sizeof(etv));
             if (connect(events_sock, (struct sockaddr *)&ev_addr, sizeof(ev_addr)) == 0) {
                 LOG_INFO("[AP2] Events connection OK");
-                /* Keep the socket open - we don't need to read from it, just
-                 * keep it alive; closed again on disconnect/destroy. */
+                int one = 1;
+                setsockopt(events_sock, IPPROTO_TCP, TCP_NODELAY,
+                           &one, sizeof(one));
                 p->events_sock = events_sock;
             } else {
                 LOG_WARN("[AP2] Events connect failed");
@@ -1845,10 +1853,8 @@ bool ap2cl_feedback(struct ap2cl_s *p)
      * is raopcl_keepalive(). The response body carries stream status we do
      * not need; the POST itself is what resets the receiver's idle timer. */
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return false;
-    /* Ride the same 2s cadence for the MRP data channel (DESIGN.md §8):
-     * drain inbound frames (answer sync keep-alives) and re-push SET_STATE
-     * periodically to hold the now-playing session open. Separate socket from
-     * the RTSP /feedback POST; best-effort, harmless when no channel is up. */
+    /* Ride the same 2s cadence to answer encrypted reverse event requests and,
+     * when enabled, drain the type-130 channel. */
     if (p->mrp) ap2_mrp_tick(p->mrp);
     uint8_t *resp = NULL; int resp_len = 0;
     int status = ap2_rtsp_send(p, "POST", "/feedback", NULL, 0, NULL, &resp, &resp_len);
@@ -1933,15 +1939,14 @@ static bool ap2_native_send_metadata(struct ap2cl_s *p, const char *title,
     return status >= 200 && status < 300;
 }
 
-/* Lazily create the MediaRemote state carrier for pair-verified native
- * sessions. With no shared secret it only drives the source-side /command
- * metadata path; the optional type-130 channel supplies the secret itself.
+/* Lazily create MediaRemote for pair-verified native sessions and attach the
+ * encrypted reverse event channel before advertising any controllable state.
  * Transient-paired third-party speakers never receive these Apple-specific
  * messages. Set CLIAIRPLAY_MRP=0 to disable the path for diagnosis. */
 static void ap2_mrp_ready(struct ap2cl_s *p)
 {
     if (p->mrp || p->flow != FLOW_NATIVE_AP2 || !p->auth_credentials ||
-        p->sock_fd < 0 || !p->session_uuid[0])
+        p->sock_fd < 0 || p->events_sock < 0 || !p->session_uuid[0])
         return;
     const char *setting = getenv("CLIAIRPLAY_MRP");
     if (setting && (!strcmp(setting, "0") || !strcmp(setting, "false") ||
@@ -1949,9 +1954,16 @@ static void ap2_mrp_ready(struct ap2cl_s *p)
         return;
     p->mrp = ap2_mrp_create(p->device.address, p->device.port, p->auth_credentials,
                             p->dacp_id, p->device.name,
-                            p->session_uuid, p->group_uuid, NULL);
-    if (p->mrp)
-        ap2_mrp_set_playing(p->mrp, p->state == AP2_STREAMING);
+                            p->session_uuid, p->group_uuid,
+                            ap2_hap_get_shared_secret(p->hap));
+    if (!p->mrp) return;
+    if (!ap2_mrp_attach_events(p->mrp, p->events_sock)) {
+        LOG_WARN("[MRP] event-channel attach failed; MediaRemote disabled");
+        ap2_mrp_destroy(p->mrp);
+        p->mrp = NULL;
+        return;
+    }
+    ap2_mrp_set_playing(p->mrp, p->state == AP2_STREAMING);
 }
 
 /* Log an RTSP response body for diagnosis: a printable-text view (control bytes

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -48,12 +48,21 @@
 #include "ap2_bplist.h"
 #include "ap2_ptp.h"
 #include "ap2_timeline.h"
+#include "ap2_io.h"
+#include "ap2_feedback.h"
 
 extern log_level *loglevel;
 
 #define AP2_FRAMES_PER_CHUNK 352
 #define AP2_CHACHA_TAG_SIZE  16
-#define AP2_RTSP_TIMEOUT_S 8
+#define AP2_RTSP_SETUP_TIMEOUT_MS   8000
+#define AP2_RTSP_CONTROL_TIMEOUT_MS 2000
+#define AP2_RTSP_FEEDBACK_TIMEOUT_MS 1500
+#define AP2_RTSP_METADATA_TIMEOUT_MS 5000
+#define AP2_RTSP_ARTWORK_TIMEOUT_MS 15000
+#define AP2_FEEDBACK_INTERVAL_MS    2000
+#define AP2_UDP_SEND_TIMEOUT_MS     20
+#define AP2_BUFFERED_WRITE_TIMEOUT_MS 8000
 
 typedef enum {
     FLOW_RAOP_COMPAT = 0,
@@ -97,11 +106,16 @@ struct ap2cl_s {
      * the wrong request and the HAP nonce sequence stays intact. */
     pthread_mutex_t rtsp_lock;
     _Atomic bool rtsp_healthy;
+    _Atomic bool media_healthy;
+    bool rtsp_established;
+    ap2_periodic_worker_t feedback_worker;
+    uint64_t feedback_last_tick_ms;
     struct ap2_hap_ctx *hap;      /* HAP encryption context */
     struct ap2_ptp_ctx *ptp;      /* Timing */
     /* MRP now-playing over POST /command (path A, see DESIGN.md §8):
      * state carrier + body builder; only on pair-verified native sessions. */
     struct ap2_mrp_ctx *mrp;
+    pthread_mutex_t mrp_lock;
     bool mrp_device_registered;
     bool mrp_extended_registered;
     int mrp_last_playback_state;
@@ -162,31 +176,34 @@ static int ap2_mrp_send_playback_state(struct ap2cl_s *p,
 
 /* ---- Native AP2 RTSP I/O ---- */
 
-static uint64_t ap2_monotonic_ms(void)
+static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
+                               const char *uri, const char *phase,
+                               uint64_t elapsed_ms)
 {
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    return (uint64_t)now.tv_sec * 1000 + now.tv_nsec / 1000000;
-}
-
-static bool ap2_write_all(int fd, const uint8_t *data, int len)
-{
-    int off = 0;
-    while (off < len) {
-#ifdef MSG_NOSIGNAL
-        ssize_t written = send(fd, data + off, (size_t)(len - off), MSG_NOSIGNAL);
-#else
-        ssize_t written = send(fd, data + off, (size_t)(len - off), 0);
-#endif
-        if (written > 0) {
-            off += (int)written;
-        } else if (written < 0 && errno == EINTR) {
-            continue;
-        } else {
-            return false;
+    int saved_errno = errno ? errno : EIO;
+    if (atomic_exchange(&p->rtsp_healthy, false)) {
+        LOG_ERROR("[AP2] RTSP channel failed during %s %s %s after %" PRIu64
+                  "ms: %s; terminating native session",
+                  method, uri, phase, elapsed_ms, strerror(saved_errno));
+        if (p->sock_fd >= 0) {
+            shutdown(p->sock_fd, SHUT_RDWR);
+            close(p->sock_fd);
+            p->sock_fd = -1;
         }
     }
-    return true;
+    errno = saved_errno;
+}
+
+static int ap2_rtsp_timeout_ms(struct ap2cl_s *p, const char *method,
+                               const char *uri, const char *content_type)
+{
+    if (!p->rtsp_established) return AP2_RTSP_SETUP_TIMEOUT_MS;
+    if (!strcmp(uri, "/feedback")) return AP2_RTSP_FEEDBACK_TIMEOUT_MS;
+    if (content_type && !strncasecmp(content_type, "image/", 6))
+        return AP2_RTSP_ARTWORK_TIMEOUT_MS;
+    if (!strcmp(uri, "/command") || !strcmp(method, "SET_PARAMETER"))
+        return AP2_RTSP_METADATA_TIMEOUT_MS;
+    return AP2_RTSP_CONTROL_TIMEOUT_MS;
 }
 
 static bool ap2_set_nonblocking(int fd)
@@ -200,12 +217,19 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
                           const char *extra_hdr,
                           uint8_t **resp_body, int *resp_len)
 {
+    if (!atomic_load(&p->rtsp_healthy) || p->sock_fd < 0) {
+        *resp_body = NULL;
+        *resp_len = 0;
+        errno = ENOTCONN;
+        return 0;
+    }
+    int cseq = p->cseq++;
     char hdr[1024];
     int hdr_len = snprintf(hdr, sizeof(hdr),
         "%s %s RTSP/1.0\r\nCSeq: %d\r\nUser-Agent: AirPlay/670.6.2\r\n"
         "DACP-ID: %s\r\nActive-Remote: %s\r\n%s%s%s%s"
         "Content-Length: %d\r\n\r\n",
-        method, uri, p->cseq++,
+        method, uri, cseq,
         p->dacp_id ? p->dacp_id : "0",
         p->active_remote ? p->active_remote : "0",
         ct ? "Content-Type: " : "", ct ? ct : "", ct ? "\r\n" : "",
@@ -213,6 +237,8 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         body_len);
     if (hdr_len <= 0 || hdr_len >= (int)sizeof(hdr)) {
         LOG_ERROR("[AP2] RTSP request headers too large for %s %s", method, uri);
+        errno = EMSGSIZE;
+        ap2_mark_rtsp_dead(p, method, uri, "construct", 0);
         return 0;
     }
 
@@ -223,24 +249,43 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         /* Encrypt RTSP via HAP framing */
         int raw_len = hdr_len + body_len;
         uint8_t *raw = malloc(raw_len);
-        if (!raw) return 0;
+        if (!raw) {
+            errno = ENOMEM;
+            ap2_mark_rtsp_dead(p, method, uri, "allocate", 0);
+            return 0;
+        }
         memcpy(raw, hdr, hdr_len);
         if (body && body_len > 0) memcpy(raw + hdr_len, body, body_len);
         msg_len = ap2_hap_encrypt(p->hap, raw, raw_len, &msg);
         free(raw);
-        if (msg_len <= 0) { free(msg); return 0; }
+        if (msg_len <= 0) {
+            free(msg);
+            errno = EPROTO;
+            ap2_mark_rtsp_dead(p, method, uri, "encrypt", 0);
+            return 0;
+        }
     } else {
         msg_len = hdr_len + body_len;
         msg = malloc(msg_len);
-        if (!msg) return 0;
+        if (!msg) {
+            errno = ENOMEM;
+            ap2_mark_rtsp_dead(p, method, uri, "allocate", 0);
+            return 0;
+        }
         memcpy(msg, hdr, hdr_len);
         if (body && body_len > 0) memcpy(msg + hdr_len, body, body_len);
     }
 
-    if (!ap2_write_all(p->sock_fd, msg, msg_len)) {
-        LOG_ERROR("[AP2] RTSP write failed for %s %s: %s",
-                  method, uri, strerror(errno));
+    int timeout_ms = ap2_rtsp_timeout_ms(p, method, uri, ct);
+    uint64_t started_ms = ap2_io_monotonic_ms();
+    uint64_t deadline_ms = started_ms + (uint64_t)timeout_ms;
+    LOG_DEBUG("[AP2] RTSP TX cseq=%d %s %s body=%d wire=%d timeout=%dms",
+              cseq, method, uri, body_len, msg_len, timeout_ms);
+    if (!ap2_io_write_all_deadline(
+            p->sock_fd, msg, (size_t)msg_len, deadline_ms)) {
         free(msg);
+        ap2_mark_rtsp_dead(p, method, uri, "write",
+                           ap2_io_monotonic_ms() - started_ms);
         return 0;
     }
     free(msg);
@@ -248,110 +293,130 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
     /* Read encrypted response.
      * HAP framing: [2-byte LE length][encrypted chunk + 16-byte tag]
      * We accumulate raw bytes, then decrypt complete frames. */
-    uint8_t buf[16384];
+    uint8_t buf[16384] = {0};
     int total = 0;
-    struct timeval tv = {.tv_sec = AP2_RTSP_TIMEOUT_S};
-    setsockopt(p->sock_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
     if (!p->hap) {
-        /* Unencrypted: simple read */
-        while (total < (int)sizeof(buf) - 1) {
-            int n = read(p->sock_fd, buf + total,
-                         sizeof(buf) - 1 - (size_t)total);
+        while (total < (int)sizeof(buf)) {
+            int n = (int)ap2_io_read_deadline(
+                p->sock_fd, buf + total, sizeof(buf) - (size_t)total,
+                deadline_ms);
             if (n <= 0) break;
             total += n;
-            buf[total] = '\0';
-            char *end = strstr((char *)buf, "\r\n\r\n");
-            if (end) {
-                int h_len = (end - (char *)buf) + 4;
-                int cl = 0;
-                char *clh = strcasestr((char *)buf, "Content-Length:");
-                if (clh) cl = atoi(clh + 15);
-                if (total >= h_len + cl) break;
+            ap2_rtsp_response_t parsed;
+            int parse_status = ap2_io_parse_rtsp_response(
+                buf, (size_t)total, &parsed);
+            if (parse_status < 0) {
+                errno = EPROTO;
+                break;
+            }
+            if (parse_status > 0) {
+                if (parsed.message_len != (size_t)total) {
+                    LOG_ERROR("[AP2] RTSP response for %s %s contained "
+                              "unexpected trailing data",
+                              method, uri);
+                    errno = EPROTO;
+                    break;
+                }
+                if (parsed.cseq != cseq) {
+                    LOG_ERROR("[AP2] RTSP CSeq mismatch for %s %s: sent=%d got=%d",
+                              method, uri, cseq, parsed.cseq);
+                    errno = EPROTO;
+                    break;
+                }
+                *resp_len = (int)parsed.body_len;
+                *resp_body = parsed.body_len ? malloc(parsed.body_len) : NULL;
+                if (parsed.body_len && !*resp_body) {
+                    errno = ENOMEM;
+                    break;
+                }
+                if (*resp_body)
+                    memcpy(*resp_body, buf + parsed.header_len, parsed.body_len);
+                LOG_DEBUG("[AP2] RTSP RX cseq=%d %s %s status=%d body=%d "
+                          "elapsed=%" PRIu64 "ms",
+                          cseq, method, uri, parsed.status, *resp_len,
+                          ap2_io_monotonic_ms() - started_ms);
+                return parsed.status;
             }
         }
-        if (total > 0 && strstr((char *)buf, "\r\n\r\n")) {
-            int h_len = (strstr((char *)buf, "\r\n\r\n") - (char *)buf) + 4;
-            int status = 0;
-            sscanf((char *)buf, "%*s %d", &status);
-            *resp_len = total - h_len;
-            *resp_body = (*resp_len > 0) ? malloc(*resp_len) : NULL;
-            if (*resp_body) memcpy(*resp_body, buf + h_len, *resp_len);
-            return status;
-        }
-        *resp_body = NULL; *resp_len = 0;
+        ap2_mark_rtsp_dead(p, method, uri, "read",
+                           ap2_io_monotonic_ms() - started_ms);
+        *resp_body = NULL;
+        *resp_len = 0;
         return 0;
     }
 
-    /* Encrypted: read all HAP frames, then decrypt */
-    while (total < (int)sizeof(buf) - 1) {
-        int n = read(p->sock_fd, buf + total,
-                     sizeof(buf) - 1 - (size_t)total);
+    while (total < (int)sizeof(buf)) {
+        int n = (int)ap2_io_read_deadline(
+            p->sock_fd, buf + total, sizeof(buf) - (size_t)total,
+            deadline_ms);
         if (n <= 0) break;
         total += n;
-        buf[total] = '\0';
 
-        /* Check if we have at least one complete HAP frame to peek at */
         if (total >= 2) {
             int frame_len = buf[0] | (buf[1] << 8);
             if (total >= 2 + frame_len + 16) {
-                /* We have at least one frame. Try decrypting all available frames. */
                 uint8_t *dec = NULL;
-                /* Save nonce counter in case we need to retry */
                 uint64_t saved_counter = ap2_hap_save_read_counter(p->hap);
                 int dec_len = ap2_hap_decrypt(p->hap, buf, total, &dec);
                 if (dec_len > 0 && dec) {
-                    uint8_t *terminated = realloc(dec, (size_t)dec_len + 1);
-                    if (!terminated) {
+                    ap2_rtsp_response_t parsed;
+                    int parse_status = ap2_io_parse_rtsp_response(
+                        dec, (size_t)dec_len, &parsed);
+                    if (parse_status < 0) {
                         free(dec);
-                        ap2_hap_restore_read_counter(p->hap, saved_counter);
+                        errno = EPROTO;
                         break;
                     }
-                    dec = terminated;
-                    dec[dec_len] = '\0';
-                    /* Check if decrypted data contains a complete RTSP response */
-                    if (strstr((char *)dec, "\r\n\r\n")) {
-                        int h_len = (strstr((char *)dec, "\r\n\r\n") - (char *)dec) + 4;
-                        int cl = 0;
-                        char *clh = strcasestr((char *)dec, "Content-Length:");
-                        if (clh) cl = atoi(clh + 15);
-                        if (dec_len >= h_len + cl) {
-                            int status = 0;
-                            sscanf((char *)dec, "%*s %d", &status);
-                            *resp_len = dec_len - h_len;
-                            *resp_body = (*resp_len > 0) ? malloc(*resp_len) : NULL;
-                            if (*resp_body) memcpy(*resp_body, dec + h_len, *resp_len);
+                    if (parse_status > 0) {
+                        if (parsed.message_len != (size_t)dec_len) {
+                            LOG_ERROR("[AP2] RTSP response for %s %s contained "
+                                      "unexpected trailing data",
+                                      method, uri);
                             free(dec);
-                            return status;
+                            errno = EPROTO;
+                            break;
                         }
+                        if (parsed.cseq != cseq) {
+                            LOG_ERROR("[AP2] RTSP CSeq mismatch for %s %s: "
+                                      "sent=%d got=%d",
+                                      method, uri, cseq, parsed.cseq);
+                            free(dec);
+                            errno = EPROTO;
+                            break;
+                        }
+                        *resp_len = (int)parsed.body_len;
+                        *resp_body = parsed.body_len ? malloc(parsed.body_len) : NULL;
+                        if (parsed.body_len && !*resp_body) {
+                            free(dec);
+                            errno = ENOMEM;
+                            break;
+                        }
+                        if (*resp_body)
+                            memcpy(*resp_body, dec + parsed.header_len,
+                                   parsed.body_len);
+                        int status = parsed.status;
+                        free(dec);
+                        LOG_DEBUG("[AP2] RTSP RX cseq=%d %s %s status=%d "
+                                  "body=%d elapsed=%" PRIu64 "ms",
+                                  cseq, method, uri, status, *resp_len,
+                                  ap2_io_monotonic_ms() - started_ms);
+                        return status;
                     }
                     free(dec);
-                    /* Incomplete RTSP response, need more HAP frames */
-                    /* Restore nonce counter since we'll re-decrypt with more data */
                     ap2_hap_restore_read_counter(p->hap, saved_counter);
                 } else {
                     free(dec);
-                    /* Decrypt failed - might need more data or broken frame */
                     ap2_hap_restore_read_counter(p->hap, saved_counter);
                 }
             }
         }
     }
 
-    LOG_ERROR("[AP2] Encrypted response read failed (total=%d bytes)", total);
-    if (total > 0) {
-        int dump = total < 64 ? total : 64;
-        char hex[200];
-        for (int i = 0; i < dump; i++) sprintf(hex + i*3, "%02x ", buf[i]);
-        hex[dump*3] = '\0';
-        LOG_ERROR("[AP2] Raw: %s", hex);
-        /* First 2 bytes = HAP frame length */
-        if (total >= 2) {
-            int fl = buf[0] | (buf[1] << 8);
-            LOG_ERROR("[AP2] HAP frame_len=%d, have=%d, need=%d", fl, total, 2 + fl + 16);
-        }
-    }
-    *resp_body = NULL; *resp_len = 0;
+    ap2_mark_rtsp_dead(p, method, uri, "read",
+                       ap2_io_monotonic_ms() - started_ms);
+    *resp_body = NULL;
+    *resp_len = 0;
     return 0;
 }
 
@@ -362,7 +427,7 @@ static int ap2_rtsp_send_ex(struct ap2cl_s *p, const char *method, const char *u
                           const char *extra_hdr,
                           uint8_t **resp_body, int *resp_len)
 {
-    uint64_t started_ms = ap2_monotonic_ms();
+    uint64_t started_ms = ap2_io_monotonic_ms();
     if (resp_body) *resp_body = NULL;
     if (resp_len) *resp_len = 0;
     if (!atomic_load(&p->rtsp_healthy)) return 0;
@@ -371,21 +436,11 @@ static int ap2_rtsp_send_ex(struct ap2cl_s *p, const char *method, const char *u
     if (atomic_load(&p->rtsp_healthy)) {
         status = ap2_rtsp_send_ex_unlocked(p, method, uri, body, body_len, ct,
                                            extra_hdr, resp_body, resp_len);
-        if (status == 0) {
-            /* A timed-out request may still have a late encrypted response in
-             * flight. Reusing this TCP/HAP stream would misattribute that
-             * response and desynchronize nonce counters, so fail it closed. */
-            atomic_store(&p->rtsp_healthy, false);
-            shutdown(p->sock_fd, SHUT_RDWR);
-        }
     }
     pthread_mutex_unlock(&p->rtsp_lock);
-    uint64_t duration_ms = ap2_monotonic_ms() - started_ms;
+    uint64_t duration_ms = ap2_io_monotonic_ms() - started_ms;
     LOG_SDEBUG("[AP2DIAG] RTSP %s %s -> %d duration_ms=%" PRIu64,
                method, uri, status, duration_ms);
-    if (duration_ms >= (uint64_t)AP2_RTSP_TIMEOUT_S * 1000)
-        LOG_WARN("[AP2] Slow RTSP %s %s: status=%d duration=%" PRIu64 "ms",
-                 method, uri, status, duration_ms);
     return status;
 }
 
@@ -396,6 +451,24 @@ static int ap2_rtsp_send(struct ap2cl_s *p, const char *method, const char *uri,
 {
     return ap2_rtsp_send_ex(p, method, uri, body, body_len, ct, NULL,
                             resp_body, resp_len);
+}
+
+static bool ap2_feedback_worker_tick(void *arg)
+{
+    struct ap2cl_s *p = arg;
+    uint64_t now = ap2_io_monotonic_ms();
+    uint64_t gap = p->feedback_last_tick_ms
+                       ? now - p->feedback_last_tick_ms
+                       : AP2_FEEDBACK_INTERVAL_MS;
+    p->feedback_last_tick_ms = now;
+    if (gap > AP2_FEEDBACK_INTERVAL_MS + 500)
+        LOG_WARN("[AP2] feedback cadence delayed: %" PRIu64 "ms", gap);
+
+    ap2cl_feedback(p);
+    pthread_mutex_lock(&p->mrp_lock);
+    if (p->mrp) ap2_mrp_tick(p->mrp);
+    pthread_mutex_unlock(&p->mrp_lock);
+    return atomic_load(&p->rtsp_healthy);
 }
 
 /* ---- Native AP2 connect helpers ---- */
@@ -655,6 +728,7 @@ static void ap2_native_setup_mrp(struct ap2cl_s *p)
         p->mrp = NULL;
         return;
     }
+    p->events_sock = -1; /* ownership transferred to the MRP context */
 
     if (!ap2_mrp_attach(p->mrp, data_port, seed)) {
         LOG_WARN("[MRP] data-channel attach failed; degrading to no-MRP");
@@ -699,9 +773,6 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     }
     freeaddrinfo(res);
     atomic_store(&p->rtsp_healthy, true);
-    struct timeval rtsp_tv = {.tv_sec = AP2_RTSP_TIMEOUT_S};
-    setsockopt(p->sock_fd, SOL_SOCKET, SO_SNDTIMEO, &rtsp_tv, sizeof(rtsp_tv));
-    setsockopt(p->sock_fd, SOL_SOCKET, SO_RCVTIMEO, &rtsp_tv, sizeof(rtsp_tv));
 #ifdef SO_NOSIGPIPE
     int no_sigpipe = 1;
     setsockopt(p->sock_fd, SOL_SOCKET, SO_NOSIGPIPE,
@@ -1200,9 +1271,21 @@ static bool ap2_native_connect(struct ap2cl_s *p)
                                    p->format.sample_rate,
                                    p->format.bit_depth,
                                    p->format.channels);
+    if (!p->alac) {
+        LOG_ERROR("[AP2] Cannot create ALAC encoder");
+        return false;
+    }
 
     p->first_packet = true;
+    p->rtsp_established = true;
     p->state = AP2_CONNECTED;
+    p->feedback_last_tick_ms = ap2_io_monotonic_ms();
+    if (!ap2_periodic_worker_start(&p->feedback_worker)) {
+        LOG_ERROR("[AP2] Cannot start feedback worker: %s", strerror(errno));
+        errno = EIO;
+        ap2_mark_rtsp_dead(p, "POST", "/feedback", "worker-start", 0);
+        return false;
+    }
     LOG_INFO("[AP2] Native AP2 session ready");
     return true;
 }
@@ -1218,9 +1301,13 @@ static bool ap2_native_connect(struct ap2cl_s *p)
  *   bytes 12-15: NTP fraction (network order)
  *   bytes 16-19: current RTP timestamp (network order)
  * Sent unencrypted on the control UDP socket. */
-static void ap2_send_sync_packet(struct ap2cl_s *p, bool first)
+static ap2_send_result_t ap2_send_sync_packet(struct ap2cl_s *p, bool first)
 {
-    if (p->ctrl_sock < 0) return;
+    if (p->ctrl_sock < 0) {
+        LOG_ERROR("[AP2] NTP sync socket is unavailable");
+        atomic_store(&p->media_healthy, false);
+        return AP2_SEND_FATAL;
+    }
 
     uint8_t pkt[20];
     pkt[0] = first ? 0x90 : 0x80;
@@ -1244,17 +1331,23 @@ static void ap2_send_sync_packet(struct ap2cl_s *p, bool first)
     uint32_t cur_ts_be = htonl(p->rtp_timestamp);
     memcpy(pkt + 16, &cur_ts_be, 4);
 
-    ssize_t sent = sendto(p->ctrl_sock, pkt, sizeof(pkt), 0,
-                          (struct sockaddr *)&p->ctrl_addr,
-                          sizeof(p->ctrl_addr));
-    if (sent == (ssize_t)sizeof(pkt)) {
+    ap2_send_result_t result = ap2_io_send_datagram_deadline(
+        p->ctrl_sock, pkt, sizeof(pkt),
+        (const struct sockaddr *)&p->ctrl_addr, sizeof(p->ctrl_addr),
+        ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS);
+    if (result == AP2_SEND_SENT) {
         p->sync_packets_sent++;
     } else {
         p->sync_packets_dropped++;
-        if (p->sync_packets_dropped <= 3 ||
-            (p->sync_packets_dropped % 100) == 0)
-            LOG_WARN("[AP2] NTP sync send dropped: %s", strerror(errno));
+        if (result == AP2_SEND_FATAL) {
+            atomic_store(&p->media_healthy, false);
+            LOG_ERROR("[AP2] NTP sync send failed: %s", strerror(errno));
+        } else if (p->sync_packets_dropped <= 3 ||
+                   (p->sync_packets_dropped % 100) == 0) {
+            LOG_WARN("[AP2] NTP sync send transiently dropped");
+        }
     }
+    return result;
 }
 
 /* Send AP2 PTP sync (anchor) packet (28 bytes) to the control port.
@@ -1267,9 +1360,13 @@ static void ap2_send_sync_packet(struct ap2cl_s *p, bool first)
  *   bytes 20-27: our PTP clock identity (BE64)
  * The wall-clock ns and the clock identity come from the PTP grandmaster so the
  * receiver, slaved to that clock, can place the anchor precisely. */
-static void ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
+static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
 {
-    if (p->ctrl_sock < 0) return;
+    if (p->ctrl_sock < 0) {
+        LOG_ERROR("[AP2] PTP sync socket is unavailable");
+        atomic_store(&p->media_healthy, false);
+        return AP2_SEND_FATAL;
+    }
 
     uint8_t pkt[28];
     pkt[0] = first ? 0x90 : 0x80;
@@ -1330,22 +1427,56 @@ static void ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
     memcpy(pkt + 20, &cid_hi, 4);
     memcpy(pkt + 24, &cid_lo, 4);
 
-    ssize_t sent = sendto(p->ctrl_sock, pkt, sizeof(pkt), 0,
-                          (struct sockaddr *)&p->ctrl_addr,
-                          sizeof(p->ctrl_addr));
-    if (sent == (ssize_t)sizeof(pkt)) {
+    ap2_send_result_t result = ap2_io_send_datagram_deadline(
+        p->ctrl_sock, pkt, sizeof(pkt),
+        (const struct sockaddr *)&p->ctrl_addr, sizeof(p->ctrl_addr),
+        ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS);
+    if (result == AP2_SEND_SENT) {
         p->sync_packets_sent++;
     } else {
         p->sync_packets_dropped++;
-        if (p->sync_packets_dropped <= 3 ||
-            (p->sync_packets_dropped % 100) == 0)
-            LOG_WARN("[AP2] PTP sync send dropped: %s", strerror(errno));
+        if (result == AP2_SEND_FATAL) {
+            atomic_store(&p->media_healthy, false);
+            LOG_ERROR("[AP2] PTP sync send failed: %s", strerror(errno));
+        } else if (p->sync_packets_dropped <= 3 ||
+                   (p->sync_packets_dropped % 100) == 0) {
+            LOG_WARN("[AP2] PTP sync send transiently dropped");
+        }
     }
     LOG_DEBUG("[AP2] TX PTP sync %s play_pos=%u wall=%" PRIu64 "ns",
               first ? "(initial)" : "", play_pos, wall);
+    return result;
 }
 
 /* ---- Native AP2 buffered audio (type 103) ---- */
+
+static bool ap2_encrypt_audio(const uint8_t key[32], const uint8_t nonce[12],
+                              const uint8_t aad[8], const uint8_t *plain,
+                              int plain_len, uint8_t *cipher,
+                              int *cipher_len, uint8_t tag[AP2_CHACHA_TAG_SIZE])
+{
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    if (!ctx) return false;
+    int len = 0;
+    int total = 0;
+    bool ok =
+        EVP_EncryptInit_ex(ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) > 0 &&
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) > 0 &&
+        EVP_EncryptInit_ex(ctx, NULL, NULL, key, nonce) > 0 &&
+        EVP_EncryptUpdate(ctx, NULL, &len, aad, 8) > 0 &&
+        EVP_EncryptUpdate(ctx, cipher, &len, plain, plain_len) > 0;
+    if (ok) {
+        total = len;
+        ok = EVP_EncryptFinal_ex(ctx, cipher + total, &len) > 0;
+        total += len;
+    }
+    if (ok)
+        ok = EVP_CIPHER_CTX_ctrl(
+                 ctx, EVP_CTRL_AEAD_GET_TAG, AP2_CHACHA_TAG_SIZE, tag) > 0;
+    EVP_CIPHER_CTX_free(ctx);
+    if (ok) *cipher_len = total;
+    return ok;
+}
 
 /* Send the SETRATEANCHORTIME anchor. It pins an RTP sample number to a point on
  * the PTP timeline at a playback rate, so the receiver can schedule every
@@ -1416,21 +1547,29 @@ static bool ap2_send_flushbuffered(struct ap2cl_s *p)
 /* Push one encoded chunk over the buffered TCP data connection. The wire frame
  * is a 2-byte big-endian length prefix followed by the encrypted RTP packet
  * [12B hdr][ciphertext][16B tag][8B nonce]. TCP provides reliability and, via
- * backpressure on the blocking write, flow control (no resend logic). */
-static bool ap2_buffered_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames)
+ * bounded backpressure, flow control (no resend logic). */
+static ap2_send_result_t ap2_buffered_send_chunk(
+    struct ap2cl_s *p, uint8_t *sample, int frames)
 {
-    if (p->buffered_sock < 0 || !p->alac) return false;
+    if (p->buffered_sock < 0 || !p->alac) {
+        LOG_ERROR("[AP2] Buffered audio channel is unavailable");
+        return AP2_SEND_FATAL;
+    }
 
     uint8_t *encoded = NULL;
     int enc_size = 0;
     pcm_to_alac(p->alac, sample, frames, &encoded, &enc_size);
-    if (!encoded || enc_size <= 0) { free(encoded); return false; }
+    if (!encoded || enc_size <= 0) {
+        LOG_ERROR("[AP2] ALAC encoder failed for buffered audio");
+        free(encoded);
+        return AP2_SEND_FATAL;
+    }
 
     const uint8_t *audio_key = ap2_hap_get_shared_secret(p->hap);
     if (!audio_key) {
         LOG_ERROR("[AP2] No shared secret for audio encryption");
         free(encoded);
-        return false;
+        return AP2_SEND_FATAL;
     }
 
     /* RTP header (12 bytes). Payload type = stream type (103), marker bit set on
@@ -1444,35 +1583,39 @@ static bool ap2_buffered_send_chunk(struct ap2cl_s *p, uint8_t *sample, int fram
     memcpy(rtp_hdr + 4, &ts_be, 4);
     uint32_t ssrc_be = htonl(p->ssrc);
     memcpy(rtp_hdr + 8, &ssrc_be, 4);
-    p->first_packet = false;
 
     /* Nonce = 4 zero bytes + an 8-byte little-endian per-packet counter placed at
      * offset 4 (matching the realtime nonce layout). The same 8 counter bytes are
      * appended to the packet so the receiver reconstructs the nonce explicitly.
      * AAD = RTP header bytes 4..11 (timestamp + ssrc), as in the realtime path. */
-    uint64_t counter = p->audio_nonce_counter++;
+    uint64_t counter = p->audio_nonce_counter;
     uint8_t nonce[12];
     memset(nonce, 0, 12);
     for (int i = 0; i < 8; i++) nonce[4 + i] = (uint8_t)((counter >> (8 * i)) & 0xFF);
 
     int cap = 2 + 12 + enc_size + AP2_CHACHA_TAG_SIZE + 8;
     uint8_t *frame = malloc(cap);
+    if (!frame) {
+        LOG_ERROR("[AP2] Cannot allocate buffered RTP packet");
+        free(encoded);
+        return AP2_SEND_FATAL;
+    }
     uint8_t *pkt = frame + 2;   /* payload starts after the 2-byte length prefix */
     memcpy(pkt, rtp_hdr, 12);
 
-    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
-    int len;
-    EVP_EncryptInit_ex(ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL);
-    EVP_EncryptInit_ex(ctx, NULL, NULL, audio_key, nonce);
-    EVP_EncryptUpdate(ctx, NULL, &len, rtp_hdr + 4, 8);  /* AAD = timestamp + ssrc */
-    EVP_EncryptUpdate(ctx, pkt + 12, &len, encoded, enc_size);
-    int ct_len = len;
-    EVP_EncryptFinal_ex(ctx, pkt + 12 + ct_len, &len);
-    ct_len += len;
-    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, AP2_CHACHA_TAG_SIZE, pkt + 12 + ct_len);
-    EVP_CIPHER_CTX_free(ctx);
+    int ct_len = 0;
+    uint8_t tag[AP2_CHACHA_TAG_SIZE];
+    bool encrypted_ok = ap2_encrypt_audio(
+        audio_key, nonce, rtp_hdr + 4, encoded, enc_size,
+        pkt + 12, &ct_len, tag);
     free(encoded);
+    if (!encrypted_ok) {
+        LOG_ERROR("[AP2] Buffered audio encryption failed");
+        free(frame);
+        return AP2_SEND_FATAL;
+    }
+    memcpy(pkt + 12 + ct_len, tag, sizeof(tag));
+    p->audio_nonce_counter++;
 
     int payload_len = 12 + ct_len + AP2_CHACHA_TAG_SIZE;
     memcpy(pkt + payload_len, nonce + 4, 8);   /* trailing nonce (nonce[4..11]) */
@@ -1485,48 +1628,57 @@ static bool ap2_buffered_send_chunk(struct ap2cl_s *p, uint8_t *sample, int fram
     frame[0] = (uint8_t)((total >> 8) & 0xFF);
     frame[1] = (uint8_t)(total & 0xFF);
 
-    int off = 0;
-    bool ok = true;
-    while (off < total) {
-        ssize_t w = write(p->buffered_sock, frame + off, total - off);
-        if (w > 0) { off += w; continue; }
-        if (w < 0 && errno == EINTR) continue;
-        ok = false;   /* SO_SNDTIMEO expiry or a hard error: receiver stalled/gone */
-        break;
-    }
+    bool ok = ap2_io_write_all_deadline(
+        p->buffered_sock, frame, (size_t)total,
+        ap2_io_monotonic_ms() + AP2_BUFFERED_WRITE_TIMEOUT_MS);
     free(frame);
 
     if (ok) {
+        p->first_packet = false;
         p->seq_number++;
         p->rtp_timestamp += frames;
         p->head_ts += frames;
     } else {
         LOG_ERROR("[AP2] Buffered TCP write failed: %s", strerror(errno));
+        shutdown(p->buffered_sock, SHUT_RDWR);
+        close(p->buffered_sock);
+        p->buffered_sock = -1;
+        return AP2_SEND_FATAL;
     }
-    return ok;
+    return AP2_SEND_SENT;
 }
 
-static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames)
+static ap2_send_result_t ap2_native_send_chunk(
+    struct ap2cl_s *p, uint8_t *sample, int frames)
 {
     if (p->use_buffered) return ap2_buffered_send_chunk(p, sample, frames);
-    if (p->data_sock < 0 || !p->alac) return false;
+    if (p->data_sock < 0 || !p->alac || !p->hap) {
+        LOG_ERROR("[AP2] Realtime audio session is incomplete");
+        return AP2_SEND_FATAL;
+    }
 
     /* Send initial sync/anchor packet before the very first audio packet, then
      * periodically every ~100 chunks (~0.8s at 352fpp/44.1kHz). PTP sessions use
      * the 28-byte anchor form; NTP sessions the 20-byte form. */
+    ap2_send_result_t sync_result = AP2_SEND_SENT;
     if (p->first_packet) {
-        if (p->use_ptp) ap2_send_sync_packet_ptp(p, true);
-        else ap2_send_sync_packet(p, true);
+        sync_result = p->use_ptp ? ap2_send_sync_packet_ptp(p, true)
+                                 : ap2_send_sync_packet(p, true);
     } else if ((p->seq_number % 100) == 0) {
-        if (p->use_ptp) ap2_send_sync_packet_ptp(p, false);
-        else ap2_send_sync_packet(p, false);
+        sync_result = p->use_ptp ? ap2_send_sync_packet_ptp(p, false)
+                                 : ap2_send_sync_packet(p, false);
     }
+    if (sync_result == AP2_SEND_FATAL) return AP2_SEND_FATAL;
 
     /* ALAC encode */
     uint8_t *encoded = NULL;
     int enc_size = 0;
     pcm_to_alac(p->alac, sample, frames, &encoded, &enc_size);
-    if (!encoded || enc_size <= 0) { free(encoded); return false; }
+    if (!encoded || enc_size <= 0) {
+        LOG_ERROR("[AP2] ALAC encoder failed for realtime audio");
+        free(encoded);
+        return AP2_SEND_FATAL;
+    }
 
     /* Build RTP header (12 bytes) */
     uint8_t rtp_hdr[12];
@@ -1538,7 +1690,6 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
     memcpy(rtp_hdr + 4, &ts_be, 4);
     uint32_t ssrc_be = htonl(p->ssrc);
     memcpy(rtp_hdr + 8, &ssrc_be, 4);
-    p->first_packet = false;
 
     /* Encrypt the ALAC payload with ChaCha20-Poly1305 (AP2 realtime audio).
      * Key:   the 32-byte pairing audio key (shk) — the raw X25519 secret for
@@ -1551,7 +1702,7 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
     if (!audio_key) {
         LOG_ERROR("[AP2] No shared secret for audio encryption");
         free(encoded);
-        return false;
+        return AP2_SEND_FATAL;
     }
 
     uint8_t nonce[12];
@@ -1563,21 +1714,25 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
 
     int pkt_size = 12 + enc_size + AP2_CHACHA_TAG_SIZE + 8;
     uint8_t *pkt = malloc(pkt_size);
+    if (!pkt) {
+        LOG_ERROR("[AP2] Cannot allocate realtime RTP packet");
+        free(encoded);
+        return AP2_SEND_FATAL;
+    }
     memcpy(pkt, rtp_hdr, 12);
 
-    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
-    int len;
-    EVP_EncryptInit_ex(ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL);
-    EVP_EncryptInit_ex(ctx, NULL, NULL, audio_key, nonce);
-    EVP_EncryptUpdate(ctx, NULL, &len, rtp_hdr + 4, 8);  /* AAD = timestamp + ssrc */
-    EVP_EncryptUpdate(ctx, pkt + 12, &len, encoded, enc_size);
-    int ct_len = len;
-    EVP_EncryptFinal_ex(ctx, pkt + 12 + ct_len, &len);
-    ct_len += len;
-    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, AP2_CHACHA_TAG_SIZE, pkt + 12 + ct_len);
-    EVP_CIPHER_CTX_free(ctx);
+    int ct_len = 0;
+    uint8_t tag[AP2_CHACHA_TAG_SIZE];
+    bool encrypted_ok = ap2_encrypt_audio(
+        audio_key, nonce, rtp_hdr + 4, encoded, enc_size,
+        pkt + 12, &ct_len, tag);
     free(encoded);
+    if (!encrypted_ok) {
+        LOG_ERROR("[AP2] Realtime audio encryption failed");
+        free(pkt);
+        return AP2_SEND_FATAL;
+    }
+    memcpy(pkt + 12 + ct_len, tag, sizeof(tag));
 
     /* Append the 8-byte per-packet nonce (the low 8 bytes of the 12-byte nonce)
      * so the receiver can reconstruct it. AP2 realtime wire format is
@@ -1585,29 +1740,36 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
      * packet fails its auth tag and is silently dropped. */
     memcpy(pkt + 12 + ct_len + AP2_CHACHA_TAG_SIZE, nonce + 4, 8);
     int actual_pkt_size = 12 + ct_len + AP2_CHACHA_TAG_SIZE + 8;
-    ssize_t sent = sendto(p->data_sock, pkt, actual_pkt_size, 0,
-                           (struct sockaddr *)&p->data_addr, sizeof(p->data_addr));
+    ap2_send_result_t result = ap2_io_send_datagram_deadline(
+        p->data_sock, pkt, (size_t)actual_pkt_size,
+        (const struct sockaddr *)&p->data_addr, sizeof(p->data_addr),
+        ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS);
     free(pkt);
 
-    bool delivered = sent == actual_pkt_size;
-    if (delivered) {
+    if (result == AP2_SEND_SENT) {
         p->audio_packets_sent++;
-    } else {
+    } else if (result == AP2_SEND_DROPPED) {
         p->audio_packets_dropped++;
         if (p->audio_packets_dropped <= 3 ||
             (p->audio_packets_dropped % 100) == 0)
-            LOG_WARN("[AP2] RTP send dropped: sent=%zd expected=%d error=%s",
-                     sent, actual_pkt_size,
-                     sent < 0 ? strerror(errno) : "short datagram");
+            LOG_WARN("[AP2] RTP send transiently dropped seq=%u rtptime=%u",
+                     p->seq_number, p->rtp_timestamp);
+    } else {
+        LOG_ERROR("[AP2] Realtime RTP send failed seq=%u rtptime=%u "
+                  "bytes=%d: %s",
+                  p->seq_number, p->rtp_timestamp, actual_pkt_size,
+                  strerror(errno));
+        return AP2_SEND_FATAL;
     }
     /* Realtime RTP follows the wall timeline even when the local UDP queue
      * drops a packet; advancing exposes a sequence gap instead of replaying an
      * old timestamp late. */
+    p->first_packet = false;
     p->seq_number++;
     p->rtp_timestamp += frames;
     p->head_ts += frames;
 
-    return delivered;
+    return result;
 }
 
 /* ---- RAOP-compat connect ---- */
@@ -1676,7 +1838,25 @@ struct ap2cl_s *ap2cl_create(
     p->ctrl_sock = -1;
     p->events_sock = -1;
     p->buffered_sock = -1;
-    pthread_mutex_init(&p->rtsp_lock, NULL);
+    if (pthread_mutex_init(&p->rtsp_lock, NULL) != 0) {
+        free(p);
+        return NULL;
+    }
+    if (pthread_mutex_init(&p->mrp_lock, NULL) != 0) {
+        pthread_mutex_destroy(&p->rtsp_lock);
+        free(p);
+        return NULL;
+    }
+    if (!ap2_periodic_worker_init(&p->feedback_worker,
+                                  AP2_FEEDBACK_INTERVAL_MS,
+                                  ap2_feedback_worker_tick, p)) {
+        pthread_mutex_destroy(&p->mrp_lock);
+        pthread_mutex_destroy(&p->rtsp_lock);
+        free(p);
+        return NULL;
+    }
+    atomic_init(&p->rtsp_healthy, false);
+    atomic_init(&p->media_healthy, true);
     if (dacp_id) p->dacp_id = strdup(dacp_id);
     if (active_remote) p->active_remote = strdup(active_remote);
     if (password) p->password = strdup(password);
@@ -1697,6 +1877,7 @@ struct ap2cl_s *ap2cl_create(
 bool ap2cl_destroy(struct ap2cl_s *p)
 {
     if (!p) return false;
+    ap2_periodic_worker_stop(&p->feedback_worker);
     /* Preserve the on-wire shutdown sequence (final MediaRemote stopped state,
      * MRP disconnect, RTSP TEARDOWN) on the normal EOF path too. */
     if (p->state != AP2_DOWN || p->sock_fd >= 0)
@@ -1704,7 +1885,10 @@ bool ap2cl_destroy(struct ap2cl_s *p)
     if (p->raopcl) raopcl_destroy(p->raopcl);
     if (p->hap) ap2_hap_destroy(p->hap);
     if (p->ptp) ap2_ptp_destroy(p->ptp);
+    pthread_mutex_lock(&p->mrp_lock);
     if (p->mrp) ap2_mrp_destroy(p->mrp);
+    p->mrp = NULL;
+    pthread_mutex_unlock(&p->mrp_lock);
     if (p->alac) alac_delete_encoder(p->alac);
     /* Close the RTSP socket under the lock so an in-flight request/response
      * cycle on another thread finishes first and a later cycle sees -1
@@ -1713,6 +1897,8 @@ bool ap2cl_destroy(struct ap2cl_s *p)
     if (p->sock_fd >= 0) { close(p->sock_fd); p->sock_fd = -1; }
     pthread_mutex_unlock(&p->rtsp_lock);
     pthread_mutex_destroy(&p->rtsp_lock);
+    ap2_periodic_worker_destroy(&p->feedback_worker);
+    pthread_mutex_destroy(&p->mrp_lock);
     if (p->data_sock >= 0) close(p->data_sock);
     if (p->ctrl_sock >= 0) close(p->ctrl_sock);
     if (p->events_sock >= 0) close(p->events_sock);
@@ -1793,13 +1979,18 @@ bool ap2cl_disconnect(struct ap2cl_s *p)
 {
     if (!p) return false;
     if (p->flow == FLOW_NATIVE_AP2) {
+        /* Stop and join the sole feedback/event owner before touching either
+         * encrypted channel. */
+        ap2_periodic_worker_stop(&p->feedback_worker);
         /* Publish the final stopped state before disconnecting MediaRemote,
          * while the encrypted RTSP session is still live. */
+        pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) {
             ap2_mrp_set_stopped(p->mrp);
             ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_STOPPED, true);
             ap2_mrp_stop(p->mrp);
         }
+        pthread_mutex_unlock(&p->mrp_lock);
         if (p->events_sock >= 0) {
             close(p->events_sock);
             p->events_sock = -1;
@@ -1817,6 +2008,7 @@ bool ap2cl_disconnect(struct ap2cl_s *p)
             close(p->sock_fd); p->sock_fd = -1;
             pthread_mutex_unlock(&p->rtsp_lock);
         }
+        p->rtsp_established = false;
     } else if (p->raopcl) {
         raopcl_disconnect(p->raopcl);
     }
@@ -1845,7 +2037,10 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
         p->seq_number = (uint16_t)(getpid() * 40503u);
         p->start_ntp = ntp_start;
         p->state = AP2_STREAMING;
+        atomic_store(&p->media_healthy, true);
+        pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) ap2_mrp_set_playing(p->mrp, true);
+        pthread_mutex_unlock(&p->mrp_lock);
         /* Announce the timeline IMMEDIATELY: with a future ntpstart the first
          * audio chunk (and the anchor coupled to it) would otherwise only go
          * out once pacing releases it, and a receiver that sees no time
@@ -1853,7 +2048,8 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
          * fully determined by ntpstart, so this and the per-chunk announces
          * agree. */
         if (p->use_ptp && !p->use_buffered && p->ctrl_sock >= 0)
-            ap2_send_sync_packet_ptp(p, true);
+            if (ap2_send_sync_packet_ptp(p, true) == AP2_SEND_FATAL)
+                return false;
         /* Buffered playback is scheduled entirely by the anchor: map the
          * current RTP sample to the PTP timeline at the requested start
          * instant. A strict receiver 400s the anchor until it has acquired
@@ -1890,15 +2086,27 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
     return true;
 }
 
-bool ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames)
+ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample,
+                                   int frames)
 {
-    if (!p || p->state != AP2_STREAMING) return false;
-    if (p->flow == FLOW_NATIVE_AP2) {
-        return ap2_native_send_chunk(p, sample, frames);
+    if (!p || p->state != AP2_STREAMING) {
+        LOG_ERROR("[AP2] Audio send attempted outside a streaming session");
+        return AP2_SEND_FATAL;
     }
-    if (!p->raopcl) return false;
+    if (p->flow == FLOW_NATIVE_AP2) {
+        ap2_send_result_t result = ap2_native_send_chunk(p, sample, frames);
+        if (result == AP2_SEND_FATAL)
+            atomic_store(&p->media_healthy, false);
+        return result;
+    }
+    if (!p->raopcl) {
+        LOG_ERROR("[AP2] RAOP-compatible audio session is unavailable");
+        return AP2_SEND_FATAL;
+    }
     uint64_t playtime;
-    return raopcl_send_chunk(p->raopcl, sample, frames, &playtime);
+    return raopcl_send_chunk(p->raopcl, sample, frames, &playtime)
+               ? AP2_SEND_SENT
+               : AP2_SEND_FATAL;
 }
 
 static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
@@ -1963,15 +2171,15 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p)
     p->head_ts = recovery.head;
     atomic_store(&p->rtp_offset, recovery.offset);
     if (p->use_ptp && p->rt_anchor_valid) {
-        uint64_t shift_ns =
-            (shifted_frames / (uint64_t)p->format.sample_rate) * 1000000000ULL +
-            ((shifted_frames % (uint64_t)p->format.sample_rate) *
-             1000000000ULL) / (uint64_t)p->format.sample_rate;
+        uint64_t shift_ns = ap2_timeline_frames_to_ns(
+            shifted_frames, (uint32_t)p->format.sample_rate);
         p->rt_anchor_wall0 += shift_ns;
     }
     p->timeline_reanchors++;
-    if (p->use_ptp) ap2_send_sync_packet_ptp(p, true);
-    else ap2_send_sync_packet(p, true);
+    ap2_send_result_t sync_result =
+        p->use_ptp ? ap2_send_sync_packet_ptp(p, true)
+                   : ap2_send_sync_packet(p, true);
+    if (sync_result == AP2_SEND_FATAL) return false;
     LOG_WARN("[AP2] Re-anchored after PCM starvation: shifted_frames=%" PRIu64
              " lead_frames=%" PRIu64 " count=%" PRIu64,
              shifted_frames, recovery_lead, p->timeline_reanchors);
@@ -2010,19 +2218,23 @@ void ap2cl_pause(struct ap2cl_s *p)
         /* Freeze the buffered timeline in place with a rate-0 anchor. */
         ap2_send_setrateanchortime(p, p->rtp_timestamp, ap2_ptp_master_now_ns(p->ptp), 0);
         p->state = AP2_PAUSED;
+        pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) {
             ap2_mrp_set_playing(p->mrp, false);
             ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PAUSED, true);
         }
+        pthread_mutex_unlock(&p->mrp_lock);
         return;
     }
     if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
     p->rt_anchor_valid = false;    /* resume re-anchors on a fresh line */
     p->state = AP2_PAUSED;
+    pthread_mutex_lock(&p->mrp_lock);
     if (p->mrp) {
         ap2_mrp_set_playing(p->mrp, false);
         ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PAUSED, true);
     }
+    pthread_mutex_unlock(&p->mrp_lock);
 }
 
 void ap2cl_play(struct ap2cl_s *p)
@@ -2033,10 +2245,12 @@ void ap2cl_play(struct ap2cl_s *p)
         uint64_t anchor_ns = ap2_ptp_master_now_ns(p->ptp) + (uint64_t)p->latency_ms * 1000000ULL;
         ap2_send_setrateanchortime(p, p->rtp_timestamp, anchor_ns, 1);
         p->state = AP2_STREAMING;
+        pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) {
             ap2_mrp_set_playing(p->mrp, true);
             ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PLAYING, true);
         }
+        pthread_mutex_unlock(&p->mrp_lock);
         return;
     }
     if (p->raopcl) {
@@ -2045,10 +2259,12 @@ void ap2cl_play(struct ap2cl_s *p)
         raopcl_start_at(p->raopcl, now + MS2NTP(200) - TS2NTP(lat, raopcl_sample_rate(p->raopcl)));
     }
     p->state = AP2_STREAMING;
+    pthread_mutex_lock(&p->mrp_lock);
     if (p->mrp) {
         ap2_mrp_set_playing(p->mrp, true);
         ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PLAYING, true);
     }
+    pthread_mutex_unlock(&p->mrp_lock);
 }
 
 void ap2cl_stop(struct ap2cl_s *p)
@@ -2057,10 +2273,12 @@ void ap2cl_stop(struct ap2cl_s *p)
     if (p->use_buffered && p->buffered_sock >= 0)
         ap2_send_flushbuffered(p);
     if (p->raopcl) raopcl_stop(p->raopcl);
+    pthread_mutex_lock(&p->mrp_lock);
     if (p->mrp) {
         ap2_mrp_set_stopped(p->mrp);
         ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_STOPPED, true);
     }
+    pthread_mutex_unlock(&p->mrp_lock);
     p->rt_anchor_valid = false;
     p->state = AP2_DOWN;
 }
@@ -2089,18 +2307,17 @@ bool ap2cl_feedback(struct ap2cl_s *p)
     return status == 200;
 }
 
-void ap2cl_tick(struct ap2cl_s *p)
-{
-    if (p && p->mrp) ap2_mrp_tick(p->mrp);
-}
-
 bool ap2cl_control_healthy(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2) return true;
     if (!atomic_load(&p->rtsp_healthy) ||
+        !atomic_load(&p->media_healthy) ||
         atomic_load(&p->feedback_failures) >= 3)
         return false;
-    return !p->mrp || ap2_mrp_event_status(p->mrp) != 0;
+    pthread_mutex_lock(&p->mrp_lock);
+    bool healthy = !p->mrp || ap2_mrp_event_status(p->mrp) != 0;
+    pthread_mutex_unlock(&p->mrp_lock);
+    return healthy;
 }
 
 bool ap2cl_set_volume(struct ap2cl_s *p, int volume)
@@ -2183,7 +2400,7 @@ static bool ap2_native_send_metadata(struct ap2cl_s *p, const char *title,
  * encrypted reverse event channel before advertising any controllable state.
  * Transient-paired third-party speakers never receive these Apple-specific
  * messages. Set CLIAIRPLAY_MRP=0 to disable the path for diagnosis. */
-static void ap2_mrp_ready(struct ap2cl_s *p)
+static void ap2_mrp_ready_locked(struct ap2cl_s *p)
 {
     if (p->mrp || p->flow != FLOW_NATIVE_AP2 || !p->auth_credentials ||
         p->sock_fd < 0 || p->events_sock < 0 || !p->session_uuid[0])
@@ -2203,6 +2420,7 @@ static void ap2_mrp_ready(struct ap2cl_s *p)
         p->mrp = NULL;
         return;
     }
+    p->events_sock = -1; /* ownership transferred to the MRP context */
     ap2_mrp_set_playing(p->mrp, p->state == AP2_STREAMING);
 }
 
@@ -2300,13 +2518,15 @@ static int ap2_mrp_send_extended_registration(struct ap2cl_s *p)
     return st_client;
 }
 
-int ap2cl_mrp_push(struct ap2cl_s *p)
+static int ap2cl_mrp_register_locked(struct ap2cl_s *p);
+
+static int ap2cl_mrp_push_locked(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return -1;
-    ap2_mrp_ready(p);
+    ap2_mrp_ready_locked(p);
     if (!p->mrp) return -1;
 
-    if (!p->mrp_device_registered && ap2cl_mrp_register(p) != 1)
+    if (!p->mrp_device_registered && ap2cl_mrp_register_locked(p) != 1)
         return 0;
 
     int status = ap2_mrp_post_command(
@@ -2328,6 +2548,15 @@ int ap2cl_mrp_push(struct ap2cl_s *p)
     return ap2_mrp_status_ok(ext_status) ? status : ext_status;
 }
 
+int ap2cl_mrp_push(struct ap2cl_s *p)
+{
+    if (!p) return -1;
+    pthread_mutex_lock(&p->mrp_lock);
+    int status = ap2cl_mrp_push_locked(p);
+    pthread_mutex_unlock(&p->mrp_lock);
+    return status;
+}
+
 /* MRP data-channel (path B) status for the [STATUS] mrp line:
  *   -1 = not attempted (non-Apple / not pair-verified),
  *    0 = attempted but the channel is not up,
@@ -2339,16 +2568,19 @@ int ap2cl_mrp_channel_status(struct ap2cl_s *p)
      * not attempted, report "not applicable" so the [STATUS] path=channel line
      * is suppressed and only path=command (the active now-playing path) shows. */
     if (!getenv("CLIAIRPLAY_MRP_TYPE130")) return -1;
-    return (p->mrp && ap2_mrp_is_connected(p->mrp)) ? 1 : 0;
+    pthread_mutex_lock(&p->mrp_lock);
+    int status = (p->mrp && ap2_mrp_is_connected(p->mrp)) ? 1 : 0;
+    pthread_mutex_unlock(&p->mrp_lock);
+    return status;
 }
 
 /* Register the sender identity before the first now-playing update. The
  * remaining extended metadata follows updateMRNowPlayingInfo in
  * ap2cl_mrp_push(), matching Apple's current AirPlaySender implementation. */
-int ap2cl_mrp_register(struct ap2cl_s *p)
+static int ap2cl_mrp_register_locked(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return -1;
-    ap2_mrp_ready(p);
+    ap2_mrp_ready_locked(p);
     if (!p->mrp) return -1;
     if (p->mrp_device_registered) return 1;
 
@@ -2359,13 +2591,24 @@ int ap2cl_mrp_register(struct ap2cl_s *p)
     return p->mrp_device_registered ? 1 : 0;
 }
 
+int ap2cl_mrp_register(struct ap2cl_s *p)
+{
+    if (!p) return -1;
+    pthread_mutex_lock(&p->mrp_lock);
+    int status = ap2cl_mrp_register_locked(p);
+    pthread_mutex_unlock(&p->mrp_lock);
+    return status;
+}
+
 bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist,
                         const char *album, int duration)
 {
     if (!p) return false;
-    ap2_mrp_ready(p);
+    pthread_mutex_lock(&p->mrp_lock);
+    ap2_mrp_ready_locked(p);
     if (p->mrp)
         ap2_mrp_set_metadata(p->mrp, title, artist, album, duration * 1000);
+    pthread_mutex_unlock(&p->mrp_lock);
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0)
         return ap2_native_send_metadata(p, title, artist, album);
     if (p->raopcl)
@@ -2377,9 +2620,11 @@ bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist
 bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size, const char *data)
 {
     if (!p) return false;
-    ap2_mrp_ready(p);
+    pthread_mutex_lock(&p->mrp_lock);
+    ap2_mrp_ready_locked(p);
     if (p->mrp)
         ap2_mrp_set_artwork(p->mrp, content_type, (const uint8_t *)data, size);
+    pthread_mutex_unlock(&p->mrp_lock);
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
         /* Same shape as the RAOP path: the image bytes as the SET_PARAMETER
          * body with its image content type, anchored via RTP-Info (receivers
@@ -2402,10 +2647,12 @@ bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size, co
 bool ap2cl_set_progress(struct ap2cl_s *p, int elapsed_s, int duration_s)
 {
     if (!p) return false;
-    ap2_mrp_ready(p);
+    pthread_mutex_lock(&p->mrp_lock);
+    ap2_mrp_ready_locked(p);
     if (p->mrp)
         ap2_mrp_set_progress(p->mrp, elapsed_s * 1000, duration_s * 1000,
                              p->state == AP2_STREAMING);
+    pthread_mutex_unlock(&p->mrp_lock);
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
         /* progress: <start>/<current>/<end>, all in the STREAM's RTP timestamp
          * units (the per-process timeline offset included, so the values match

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdatomic.h>
+#include <limits.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/socket.h>
@@ -44,6 +45,7 @@
 #include "ap2_mrp.h"
 #include "ap2_client.h"
 #include "ap2_hap.h"
+#include "ap2_io.h"
 #include "ap2_plist.h"
 #include "ap2_bplist.h"
 #include "ap2_ptp.h"
@@ -55,14 +57,16 @@ extern log_level *loglevel;
 
 #define AP2_FRAMES_PER_CHUNK 352
 #define AP2_CHACHA_TAG_SIZE  16
-#define AP2_RTSP_SETUP_TIMEOUT_MS   8000
-#define AP2_RTSP_CONTROL_TIMEOUT_MS 2000
-#define AP2_RTSP_FEEDBACK_TIMEOUT_MS 1500
-#define AP2_RTSP_METADATA_TIMEOUT_MS 5000
-#define AP2_RTSP_ARTWORK_TIMEOUT_MS 15000
-#define AP2_FEEDBACK_INTERVAL_MS    2000
-#define AP2_UDP_SEND_TIMEOUT_MS     20
-#define AP2_BUFFERED_WRITE_TIMEOUT_MS 8000
+#define AP2_RTSP_SETUP_TIMEOUT_MS     8000
+#define AP2_RTSP_FEEDBACK_TIMEOUT_MS  1500
+#define AP2_RTSP_CONTROL_TIMEOUT_MS   3000
+#define AP2_RTSP_METADATA_TIMEOUT_MS  5000
+#define AP2_FEEDBACK_INTERVAL_MS      2000
+#define AP2_UDP_SEND_TIMEOUT_MS       20
+#define AP2_HAP_FRAME_MAX             1024
+#define AP2_MRP_PENDING_REGISTER      (1u << 0)
+#define AP2_MRP_PENDING_PUSH          (1u << 1)
+#define AP2_MRP_PENDING_PLAYBACK      (1u << 2)
 
 typedef enum {
     FLOW_RAOP_COMPAT = 0,
@@ -73,7 +77,7 @@ struct ap2cl_s {
     /* Configuration */
     ap2_device_info_t device;
     ap2_audio_format_t format;
-    ap2_state_t state;
+    _Atomic ap2_state_t state;
     int latency_ms;
     uint32_t dev_latency_min;      /* receiver-reported buffering window (frames) */
     uint32_t dev_latency_max;
@@ -101,21 +105,28 @@ struct ap2cl_s {
     int sock_fd;                  /* TCP connection */
     /* The RTSP socket carries whole request/response cycles from multiple
      * threads (streaming thread: SETRATEANCHORTIME/FLUSHBUFFERED/TEARDOWN;
-     * cmdpipe thread: SET_PARAMETER volume/metadata, /feedback keepalive).
+     * command thread: SET_PARAMETER volume/metadata; maintenance worker:
+     * /feedback keepalive).
      * This lock serializes the cycles so a response cannot be attributed to
      * the wrong request and the HAP nonce sequence stays intact. */
     pthread_mutex_t rtsp_lock;
-    _Atomic bool rtsp_healthy;
-    _Atomic bool media_healthy;
-    bool rtsp_established;
-    ap2_periodic_worker_t feedback_worker;
-    uint64_t feedback_last_tick_ms;
+    atomic_bool rtsp_dead;
+    atomic_bool rtsp_established;
+    pthread_t feedback_thread;
+    atomic_bool feedback_stop;
+    atomic_bool feedback_waiting;
+    bool feedback_thread_started;
+    pthread_t mrp_thread;
+    bool mrp_thread_started;
+    int feedback_interval_ms;
     struct ap2_hap_ctx *hap;      /* HAP encryption context */
     struct ap2_ptp_ctx *ptp;      /* Timing */
     /* MRP now-playing over POST /command (path A, see DESIGN.md §8):
      * state carrier + body builder; only on pair-verified native sessions. */
     struct ap2_mrp_ctx *mrp;
     pthread_mutex_t mrp_lock;
+    atomic_int mrp_event_status;
+    atomic_uint mrp_pending;
     bool mrp_device_registered;
     bool mrp_extended_registered;
     int mrp_last_playback_state;
@@ -135,7 +146,6 @@ struct ap2cl_s {
     uint64_t audio_packets_dropped;
     uint64_t sync_packets_sent;
     uint64_t sync_packets_dropped;
-    _Atomic unsigned feedback_failures;
     uint64_t timeline_reanchors;
 
     /* Frozen realtime anchor line (PTP): the rtp<->wall mapping is fixed once
@@ -173,59 +183,123 @@ struct ap2cl_s {
 static int ap2_mrp_send_playback_state(struct ap2cl_s *p,
                                        ap2_mrp_playback_state_t state,
                                        bool force);
+static int ap2cl_mrp_register_locked(struct ap2cl_s *p);
+static int ap2cl_mrp_push_locked(struct ap2cl_s *p);
+
+static void ap2_mrp_process_pending(struct ap2cl_s *p, unsigned int pending)
+{
+    if (!pending || atomic_load(&p->rtsp_dead)) return;
+    if (pending & AP2_MRP_PENDING_PUSH) {
+        ap2cl_mrp_push_locked(p);
+    } else {
+        if (pending & AP2_MRP_PENDING_REGISTER)
+            ap2cl_mrp_register_locked(p);
+        if (pending & AP2_MRP_PENDING_PLAYBACK) {
+            ap2_mrp_playback_state_t state =
+                p->state == AP2_STREAMING ? AP2_MRP_PLAYBACK_PLAYING :
+                p->state == AP2_PAUSED ? AP2_MRP_PLAYBACK_PAUSED :
+                                         AP2_MRP_PLAYBACK_STOPPED;
+            ap2_mrp_send_playback_state(p, state, true);
+        }
+    }
+}
 
 /* ---- Native AP2 RTSP I/O ---- */
+
+
+
+static int ap2_rtsp_timeout_ms(struct ap2cl_s *p, const char *method,
+                               const char *uri, const char *content_type,
+                               int body_len)
+{
+    if (!p->rtsp_established) return AP2_RTSP_SETUP_TIMEOUT_MS;
+    if (strcmp(method, "POST") == 0 && strcmp(uri, "/feedback") == 0)
+        return AP2_RTSP_FEEDBACK_TIMEOUT_MS;
+    if ((strcmp(method, "POST") == 0 && strcmp(uri, "/command") == 0) ||
+        (strcmp(method, "SET_PARAMETER") == 0 && content_type &&
+         (strstr(content_type, "image/") == content_type ||
+          strcmp(content_type, "application/x-dmap-tagged") == 0)) ||
+        body_len > 4096)
+        return AP2_RTSP_METADATA_TIMEOUT_MS;
+    return AP2_RTSP_CONTROL_TIMEOUT_MS;
+}
 
 static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
                                const char *uri, const char *phase,
                                uint64_t elapsed_ms)
 {
-    int saved_errno = errno ? errno : EIO;
-    if (atomic_exchange(&p->rtsp_healthy, false)) {
+    int saved_errno = errno;
+    if ((p->rtsp_established || p->hap) &&
+        !atomic_exchange(&p->rtsp_dead, true)) {
         LOG_ERROR("[AP2] RTSP channel failed during %s %s %s after %" PRIu64
                   "ms: %s; terminating native session",
                   method, uri, phase, elapsed_ms, strerror(saved_errno));
-        if (p->sock_fd >= 0) {
-            shutdown(p->sock_fd, SHUT_RDWR);
-            close(p->sock_fd);
-            p->sock_fd = -1;
-        }
+        shutdown(p->sock_fd, SHUT_RDWR);
     }
     errno = saved_errno;
 }
 
-static int ap2_rtsp_timeout_ms(struct ap2cl_s *p, const char *method,
-                               const char *uri, const char *content_type)
+static int ap2_parse_rtsp_response(uint8_t *data, int len, int expected_cseq,
+                                   int *status, int *header_len,
+                                   int *content_len)
 {
-    if (!p->rtsp_established) return AP2_RTSP_SETUP_TIMEOUT_MS;
-    if (!strcmp(uri, "/feedback")) return AP2_RTSP_FEEDBACK_TIMEOUT_MS;
-    if (content_type && !strncasecmp(content_type, "image/", 6))
-        return AP2_RTSP_ARTWORK_TIMEOUT_MS;
-    if (!strcmp(uri, "/command") || !strcmp(method, "SET_PARAMETER"))
-        return AP2_RTSP_METADATA_TIMEOUT_MS;
-    return AP2_RTSP_CONTROL_TIMEOUT_MS;
-}
+    if (!data || len <= 0) return 0;
+    data[len] = '\0';
+    char *end = strstr((char *)data, "\r\n\r\n");
+    if (!end) return 0;
+    int hlen = (int)(end - (char *)data) + 4;
+    if (hlen > len) return -1;
 
-static bool ap2_set_nonblocking(int fd)
-{
-    int flags = fcntl(fd, F_GETFL, 0);
-    return flags >= 0 && fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
-}
+    int parsed_status = 0;
+    if (sscanf((char *)data, "%*s %d", &parsed_status) != 1) return -1;
+    char *cseq_header = strcasestr((char *)data, "CSeq:");
+    int response_cseq = -1;
+    if (!cseq_header || cseq_header >= end ||
+        sscanf(cseq_header + 5, "%d", &response_cseq) != 1 ||
+        response_cseq != expected_cseq)
+        return -1;
 
-static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, const char *uri,
-                          const uint8_t *body, int body_len, const char *ct,
-                          const char *extra_hdr,
-                          uint8_t **resp_body, int *resp_len)
-{
-    if (!atomic_load(&p->rtsp_healthy) || p->sock_fd < 0) {
-        *resp_body = NULL;
-        *resp_len = 0;
-        errno = ENOTCONN;
-        return 0;
+    int cl = 0;
+    char *length_header = strcasestr((char *)data, "Content-Length:");
+    if (length_header && length_header < end) {
+        char *number_end = NULL;
+        long parsed = strtol(length_header + 15, &number_end, 10);
+        if (!number_end || number_end == length_header + 15 ||
+            parsed < 0 || parsed > INT_MAX)
+            return -1;
+        cl = (int)parsed;
     }
+    if (cl > len - hlen) return 0;
+    *status = parsed_status;
+    *header_len = hlen;
+    *content_len = cl;
+    return 1;
+}
+
+static int ap2_hap_frames_complete(const uint8_t *data, int len)
+{
+    int offset = 0;
+    while (offset < len) {
+        if (len - offset < 2) return 0;
+        int frame_len = data[offset] | (data[offset + 1] << 8);
+        if (frame_len <= 0 || frame_len > AP2_HAP_FRAME_MAX) return -1;
+        int wire_len = 2 + frame_len + AP2_CHACHA_TAG_SIZE;
+        if (len - offset < wire_len) return 0;
+        offset += wire_len;
+    }
+    return 1;
+}
+
+static int ap2_rtsp_send_ex_unlocked(
+    struct ap2cl_s *p, const char *method, const char *uri,
+    const uint8_t *body, int body_len, const char *ct,
+    const char *extra_hdr, uint8_t **resp_body, int *resp_len)
+{
+    if (atomic_load(&p->rtsp_dead)) return 0;
     int cseq = p->cseq++;
     char hdr[1024];
-    int hdr_len = snprintf(hdr, sizeof(hdr),
+    int hdr_len = snprintf(
+        hdr, sizeof(hdr),
         "%s %s RTSP/1.0\r\nCSeq: %d\r\nUser-Agent: AirPlay/670.6.2\r\n"
         "DACP-ID: %s\r\nActive-Remote: %s\r\n%s%s%s%s"
         "Content-Length: %d\r\n\r\n",
@@ -233,56 +307,44 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         p->dacp_id ? p->dacp_id : "0",
         p->active_remote ? p->active_remote : "0",
         ct ? "Content-Type: " : "", ct ? ct : "", ct ? "\r\n" : "",
-        extra_hdr ? extra_hdr : "",
-        body_len);
+        extra_hdr ? extra_hdr : "", body_len);
     if (hdr_len <= 0 || hdr_len >= (int)sizeof(hdr)) {
-        LOG_ERROR("[AP2] RTSP request headers too large for %s %s", method, uri);
         errno = EMSGSIZE;
-        ap2_mark_rtsp_dead(p, method, uri, "construct", 0);
         return 0;
     }
 
     uint8_t *msg = NULL;
-    int msg_len = 0;
-
+    int msg_len;
     if (p->hap) {
-        /* Encrypt RTSP via HAP framing */
         int raw_len = hdr_len + body_len;
-        uint8_t *raw = malloc(raw_len);
-        if (!raw) {
-            errno = ENOMEM;
-            ap2_mark_rtsp_dead(p, method, uri, "allocate", 0);
-            return 0;
-        }
-        memcpy(raw, hdr, hdr_len);
-        if (body && body_len > 0) memcpy(raw + hdr_len, body, body_len);
+        uint8_t *raw = malloc((size_t)raw_len);
+        if (!raw) return 0;
+        memcpy(raw, hdr, (size_t)hdr_len);
+        if (body && body_len > 0)
+            memcpy(raw + hdr_len, body, (size_t)body_len);
         msg_len = ap2_hap_encrypt(p->hap, raw, raw_len, &msg);
         free(raw);
-        if (msg_len <= 0) {
+        if (msg_len <= 0 || !msg) {
             free(msg);
-            errno = EPROTO;
-            ap2_mark_rtsp_dead(p, method, uri, "encrypt", 0);
+            errno = EIO;
+            ap2_mark_rtsp_dead(p, method, uri, "encryption", 0);
             return 0;
         }
     } else {
         msg_len = hdr_len + body_len;
-        msg = malloc(msg_len);
-        if (!msg) {
-            errno = ENOMEM;
-            ap2_mark_rtsp_dead(p, method, uri, "allocate", 0);
-            return 0;
-        }
-        memcpy(msg, hdr, hdr_len);
-        if (body && body_len > 0) memcpy(msg + hdr_len, body, body_len);
+        msg = malloc((size_t)msg_len);
+        if (!msg) return 0;
+        memcpy(msg, hdr, (size_t)hdr_len);
+        if (body && body_len > 0)
+            memcpy(msg + hdr_len, body, (size_t)body_len);
     }
 
-    int timeout_ms = ap2_rtsp_timeout_ms(p, method, uri, ct);
+    int timeout_ms = ap2_rtsp_timeout_ms(p, method, uri, ct, body_len);
     uint64_t started_ms = ap2_io_monotonic_ms();
     uint64_t deadline_ms = started_ms + (uint64_t)timeout_ms;
-    LOG_DEBUG("[AP2] RTSP TX cseq=%d %s %s body=%d wire=%d timeout=%dms",
-              cseq, method, uri, body_len, msg_len, timeout_ms);
-    if (!ap2_io_write_all_deadline(
-            p->sock_fd, msg, (size_t)msg_len, deadline_ms)) {
+    LOG_SDEBUG("[AP2DIAG] RTSP TX cseq=%d %s %s body=%d wire=%d "
+               "timeout=%dms", cseq, method, uri, body_len, msg_len, timeout_ms);
+    if (!ap2_io_write_all_deadline(p->sock_fd, msg, msg_len, deadline_ms)) {
         free(msg);
         ap2_mark_rtsp_dead(p, method, uri, "write",
                            ap2_io_monotonic_ms() - started_ms);
@@ -290,125 +352,86 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
     }
     free(msg);
 
-    /* Read encrypted response.
-     * HAP framing: [2-byte LE length][encrypted chunk + 16-byte tag]
-     * We accumulate raw bytes, then decrypt complete frames. */
     uint8_t buf[16384] = {0};
     int total = 0;
-
     if (!p->hap) {
-        while (total < (int)sizeof(buf)) {
+        while (total < (int)sizeof(buf) - 1) {
             int n = (int)ap2_io_read_deadline(
-                p->sock_fd, buf + total, sizeof(buf) - (size_t)total,
-                deadline_ms);
+                p->sock_fd, buf + total,
+                sizeof(buf) - 1 - (size_t)total, deadline_ms);
             if (n <= 0) break;
             total += n;
-            ap2_rtsp_response_t parsed;
-            int parse_status = ap2_io_parse_rtsp_response(
-                buf, (size_t)total, &parsed);
-            if (parse_status < 0) {
+            int status, hlen, cl;
+            int parsed = ap2_parse_rtsp_response(
+                buf, total, cseq, &status, &hlen, &cl);
+            if (parsed < 0) {
                 errno = EPROTO;
                 break;
             }
-            if (parse_status > 0) {
-                if (parsed.message_len != (size_t)total) {
-                    LOG_ERROR("[AP2] RTSP response for %s %s contained "
-                              "unexpected trailing data",
-                              method, uri);
-                    errno = EPROTO;
-                    break;
-                }
-                if (parsed.cseq != cseq) {
-                    LOG_ERROR("[AP2] RTSP CSeq mismatch for %s %s: sent=%d got=%d",
-                              method, uri, cseq, parsed.cseq);
-                    errno = EPROTO;
-                    break;
-                }
-                *resp_len = (int)parsed.body_len;
-                *resp_body = parsed.body_len ? malloc(parsed.body_len) : NULL;
-                if (parsed.body_len && !*resp_body) {
+            if (parsed > 0) {
+                *resp_len = cl;
+                *resp_body = cl > 0 ? malloc((size_t)cl) : NULL;
+                if (cl > 0 && !*resp_body) {
                     errno = ENOMEM;
                     break;
                 }
-                if (*resp_body)
-                    memcpy(*resp_body, buf + parsed.header_len, parsed.body_len);
-                LOG_DEBUG("[AP2] RTSP RX cseq=%d %s %s status=%d body=%d "
-                          "elapsed=%" PRIu64 "ms",
-                          cseq, method, uri, parsed.status, *resp_len,
-                          ap2_io_monotonic_ms() - started_ms);
-                return parsed.status;
+                if (*resp_body) memcpy(*resp_body, buf + hlen, (size_t)cl);
+                return status;
             }
         }
-        ap2_mark_rtsp_dead(p, method, uri, "read",
-                           ap2_io_monotonic_ms() - started_ms);
-        *resp_body = NULL;
-        *resp_len = 0;
-        return 0;
-    }
+    } else {
+        while (total < (int)sizeof(buf) - 1) {
+            int n = (int)ap2_io_read_deadline(
+                p->sock_fd, buf + total,
+                sizeof(buf) - 1 - (size_t)total, deadline_ms);
+            if (n <= 0) break;
+            total += n;
+            int frames_complete = ap2_hap_frames_complete(buf, total);
+            if (frames_complete == 0) continue;
+            if (frames_complete < 0) {
+                errno = EPROTO;
+                break;
+            }
 
-    while (total < (int)sizeof(buf)) {
-        int n = (int)ap2_io_read_deadline(
-            p->sock_fd, buf + total, sizeof(buf) - (size_t)total,
-            deadline_ms);
-        if (n <= 0) break;
-        total += n;
-
-        if (total >= 2) {
-            int frame_len = buf[0] | (buf[1] << 8);
-            if (total >= 2 + frame_len + 16) {
-                uint8_t *dec = NULL;
-                uint64_t saved_counter = ap2_hap_save_read_counter(p->hap);
-                int dec_len = ap2_hap_decrypt(p->hap, buf, total, &dec);
-                if (dec_len > 0 && dec) {
-                    ap2_rtsp_response_t parsed;
-                    int parse_status = ap2_io_parse_rtsp_response(
-                        dec, (size_t)dec_len, &parsed);
-                    if (parse_status < 0) {
+            uint64_t saved_counter = ap2_hap_save_read_counter(p->hap);
+            uint8_t *dec = NULL;
+            int dec_len = ap2_hap_decrypt(p->hap, buf, total, &dec);
+            if (dec_len > 0 && dec) {
+                uint8_t *terminated = realloc(dec, (size_t)dec_len + 1);
+                if (!terminated) {
+                    free(dec);
+                    ap2_hap_restore_read_counter(p->hap, saved_counter);
+                    errno = ENOMEM;
+                    break;
+                }
+                dec = terminated;
+                int status, hlen, cl;
+                int parsed = ap2_parse_rtsp_response(
+                    dec, dec_len, cseq, &status, &hlen, &cl);
+                if (parsed > 0) {
+                    *resp_len = cl;
+                    *resp_body = cl > 0 ? malloc((size_t)cl) : NULL;
+                    if (cl > 0 && !*resp_body) {
                         free(dec);
-                        errno = EPROTO;
+                        ap2_hap_restore_read_counter(p->hap, saved_counter);
+                        errno = ENOMEM;
                         break;
                     }
-                    if (parse_status > 0) {
-                        if (parsed.message_len != (size_t)dec_len) {
-                            LOG_ERROR("[AP2] RTSP response for %s %s contained "
-                                      "unexpected trailing data",
-                                      method, uri);
-                            free(dec);
-                            errno = EPROTO;
-                            break;
-                        }
-                        if (parsed.cseq != cseq) {
-                            LOG_ERROR("[AP2] RTSP CSeq mismatch for %s %s: "
-                                      "sent=%d got=%d",
-                                      method, uri, cseq, parsed.cseq);
-                            free(dec);
-                            errno = EPROTO;
-                            break;
-                        }
-                        *resp_len = (int)parsed.body_len;
-                        *resp_body = parsed.body_len ? malloc(parsed.body_len) : NULL;
-                        if (parsed.body_len && !*resp_body) {
-                            free(dec);
-                            errno = ENOMEM;
-                            break;
-                        }
-                        if (*resp_body)
-                            memcpy(*resp_body, dec + parsed.header_len,
-                                   parsed.body_len);
-                        int status = parsed.status;
-                        free(dec);
-                        LOG_DEBUG("[AP2] RTSP RX cseq=%d %s %s status=%d "
-                                  "body=%d elapsed=%" PRIu64 "ms",
-                                  cseq, method, uri, status, *resp_len,
-                                  ap2_io_monotonic_ms() - started_ms);
-                        return status;
-                    }
+                    if (*resp_body)
+                        memcpy(*resp_body, dec + hlen, (size_t)cl);
                     free(dec);
-                    ap2_hap_restore_read_counter(p->hap, saved_counter);
-                } else {
-                    free(dec);
-                    ap2_hap_restore_read_counter(p->hap, saved_counter);
+                    return status;
                 }
+                free(dec);
+                ap2_hap_restore_read_counter(p->hap, saved_counter);
+                if (parsed < 0) {
+                    errno = EPROTO;
+                    break;
+                }
+            } else {
+                free(dec);
+                errno = EPROTO;
+                break;
             }
         }
     }
@@ -420,27 +443,25 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
     return 0;
 }
 
-/* Serialize the full request/response cycle (see the rtsp_lock field note);
- * taking the lock here covers every RTSP caller, whichever thread it runs on. */
-static int ap2_rtsp_send_ex(struct ap2cl_s *p, const char *method, const char *uri,
-                          const uint8_t *body, int body_len, const char *ct,
-                          const char *extra_hdr,
-                          uint8_t **resp_body, int *resp_len)
+/* CSeq assignment, HAP nonce advancement, request write and response read are
+ * one serialized transaction. */
+static int ap2_rtsp_send_ex(
+    struct ap2cl_s *p, const char *method, const char *uri,
+    const uint8_t *body, int body_len, const char *ct,
+    const char *extra_hdr, uint8_t **resp_body, int *resp_len)
 {
-    uint64_t started_ms = ap2_io_monotonic_ms();
     if (resp_body) *resp_body = NULL;
     if (resp_len) *resp_len = 0;
-    if (!atomic_load(&p->rtsp_healthy)) return 0;
+    uint64_t wait_started = ap2_io_monotonic_ms();
     pthread_mutex_lock(&p->rtsp_lock);
-    int status = 0;
-    if (atomic_load(&p->rtsp_healthy)) {
-        status = ap2_rtsp_send_ex_unlocked(p, method, uri, body, body_len, ct,
-                                           extra_hdr, resp_body, resp_len);
-    }
+    uint64_t waited_ms = ap2_io_monotonic_ms() - wait_started;
+    if (waited_ms >= 250)
+        LOG_SDEBUG("[AP2DIAG] RTSP %s %s waited %" PRIu64
+                   "ms for control lock", method, uri, waited_ms);
+    int status = ap2_rtsp_send_ex_unlocked(
+        p, method, uri, body, body_len, ct, extra_hdr,
+        resp_body, resp_len);
     pthread_mutex_unlock(&p->rtsp_lock);
-    uint64_t duration_ms = ap2_io_monotonic_ms() - started_ms;
-    LOG_SDEBUG("[AP2DIAG] RTSP %s %s -> %d duration_ms=%" PRIu64,
-               method, uri, status, duration_ms);
     return status;
 }
 
@@ -453,23 +474,175 @@ static int ap2_rtsp_send(struct ap2cl_s *p, const char *method, const char *uri,
                             resp_body, resp_len);
 }
 
-static bool ap2_feedback_worker_tick(void *arg)
+static void *ap2_feedback_thread_main(void *arg)
 {
     struct ap2cl_s *p = arg;
-    uint64_t now = ap2_io_monotonic_ms();
-    uint64_t gap = p->feedback_last_tick_ms
-                       ? now - p->feedback_last_tick_ms
-                       : AP2_FEEDBACK_INTERVAL_MS;
-    p->feedback_last_tick_ms = now;
-    if (gap > AP2_FEEDBACK_INTERVAL_MS + 500)
-        LOG_WARN("[AP2] feedback cadence delayed: %" PRIu64 "ms", gap);
+    uint64_t last_feedback_ms = ap2_io_monotonic_ms();
+    uint64_t next_feedback_ms =
+        last_feedback_ms + (uint64_t)p->feedback_interval_ms;
+    unsigned int feedback_failures = 0;
+    LOG_DEBUG("[AP2] feedback worker started (interval=%dms)",
+              p->feedback_interval_ms);
 
-    ap2cl_feedback(p);
-    pthread_mutex_lock(&p->mrp_lock);
-    if (p->mrp) ap2_mrp_tick(p->mrp);
-    pthread_mutex_unlock(&p->mrp_lock);
-    return atomic_load(&p->rtsp_healthy);
+    while (!atomic_load(&p->feedback_stop) &&
+           !atomic_load(&p->rtsp_dead)) {
+        uint64_t now_ms = ap2_io_monotonic_ms();
+        if (now_ms >= next_feedback_ms) {
+            uint64_t gap_ms = now_ms - last_feedback_ms;
+            LOG_SDEBUG("[AP2DIAG] feedback tick gap=%" PRIu64 "ms", gap_ms);
+            if (gap_ms > (uint64_t)p->feedback_interval_ms + 500)
+                LOG_WARN("[AP2] feedback cadence delayed: %" PRIu64 "ms",
+                         gap_ms);
+            atomic_store(&p->feedback_waiting, true);
+            bool feedback_ok = ap2cl_feedback(p);
+            atomic_store(&p->feedback_waiting, false);
+            if (feedback_ok) {
+                feedback_failures = 0;
+            } else if (!atomic_load(&p->rtsp_dead) &&
+                       ++feedback_failures >= 3) {
+                errno = EPROTO;
+                ap2_mark_rtsp_dead(p, "POST", "/feedback",
+                                   "repeated non-200 response",
+                                   ap2_io_monotonic_ms() - last_feedback_ms);
+            }
+            last_feedback_ms = ap2_io_monotonic_ms();
+            next_feedback_ms += (uint64_t)p->feedback_interval_ms;
+            if (next_feedback_ms <= last_feedback_ms)
+                next_feedback_ms =
+                    last_feedback_ms + (uint64_t)p->feedback_interval_ms;
+        }
+
+        /* This worker is the sole owner of reverse-event/DataStream ticking.
+         * Run it after the keepalive so a busy event stream cannot delay the
+         * receiver's feedback deadline. */
+        pthread_mutex_lock(&p->mrp_lock);
+        int event_status = -1;
+        if (p->mrp) {
+            ap2_mrp_tick(p->mrp);
+            event_status = ap2_mrp_event_status(p->mrp);
+        }
+        atomic_store(&p->mrp_event_status, event_status);
+        pthread_mutex_unlock(&p->mrp_lock);
+        usleep(100000);
+    }
+    LOG_DEBUG("[AP2] feedback worker stopped (dead=%d)",
+              atomic_load(&p->rtsp_dead) ? 1 : 0);
+    return NULL;
 }
+
+static void *ap2_mrp_thread_main(void *arg)
+{
+    struct ap2cl_s *p = arg;
+    while (!atomic_load(&p->feedback_stop) &&
+           !atomic_load(&p->rtsp_dead)) {
+        unsigned int pending = atomic_exchange(&p->mrp_pending, 0);
+        if (pending)
+            ap2_mrp_process_pending(p, pending);
+        else
+            usleep(100000);
+    }
+    return NULL;
+}
+
+static bool ap2_feedback_start(struct ap2cl_s *p)
+{
+    atomic_store(&p->feedback_stop, false);
+    int err = pthread_create(
+        &p->feedback_thread, NULL, ap2_feedback_thread_main, p);
+    if (err != 0) {
+        LOG_ERROR("[AP2] Cannot start feedback worker: %s", strerror(err));
+        return false;
+    }
+    p->feedback_thread_started = true;
+    err = pthread_create(&p->mrp_thread, NULL, ap2_mrp_thread_main, p);
+    if (err != 0) {
+        LOG_ERROR("[AP2] Cannot start MRP publication worker: %s",
+                  strerror(err));
+        atomic_store(&p->feedback_stop, true);
+        pthread_join(p->feedback_thread, NULL);
+        p->feedback_thread_started = false;
+        return false;
+    }
+    p->mrp_thread_started = true;
+    return true;
+}
+
+static void ap2_feedback_stop(struct ap2cl_s *p)
+{
+    if (!p || (!p->feedback_thread_started && !p->mrp_thread_started)) return;
+    atomic_store(&p->feedback_stop, true);
+    if (p->mrp_thread_started) {
+        pthread_join(p->mrp_thread, NULL);
+        p->mrp_thread_started = false;
+    }
+    if (p->feedback_thread_started) {
+        pthread_join(p->feedback_thread, NULL);
+        p->feedback_thread_started = false;
+    }
+}
+
+#ifdef AP2_TESTING
+bool ap2cl_test_start_feedback_worker(struct ap2cl_s *p, int socket_fd,
+                                      int interval_ms)
+{
+    if (!p || socket_fd < 0 || interval_ms <= 0) return false;
+    p->flow = FLOW_NATIVE_AP2;
+    p->sock_fd = socket_fd;
+    p->rtsp_established = true;
+    p->state = AP2_CONNECTED;
+    p->feedback_interval_ms = interval_ms;
+    atomic_store(&p->rtsp_dead, false);
+    return ap2_feedback_start(p);
+}
+
+bool ap2cl_test_attach_mrp(struct ap2cl_s *p, int event_socket,
+                           const uint8_t shared_secret[32])
+{
+    if (!p || event_socket < 0 || !shared_secret) return false;
+    pthread_mutex_lock(&p->mrp_lock);
+    p->mrp = ap2_mrp_create(
+        "127.0.0.1", 7000, p->auth_credentials, p->dacp_id,
+        "test sender", "11111111-2222-4333-8444-555555555555",
+        "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE", shared_secret);
+    bool attached = p->mrp && ap2_mrp_attach_events(p->mrp, event_socket);
+    if (!attached && p->mrp) {
+        ap2_mrp_destroy(p->mrp);
+        p->mrp = NULL;
+    }
+    atomic_store(&p->mrp_event_status, attached ? 1 : -1);
+    pthread_mutex_unlock(&p->mrp_lock);
+    return attached;
+}
+
+void ap2cl_test_stop_feedback_worker(struct ap2cl_s *p)
+{
+    if (!p) return;
+    ap2_feedback_stop(p);
+    p->sock_fd = -1;
+    p->rtsp_established = false;
+    atomic_init(&p->state, AP2_DOWN);
+}
+
+int ap2cl_test_post_command(struct ap2cl_s *p)
+{
+    if (!p) return 0;
+    uint8_t *response = NULL;
+    int response_len = 0;
+    int status = ap2_rtsp_send(
+        p, "POST", "/command", NULL, 0, NULL, &response, &response_len);
+    free(response);
+    return status;
+}
+
+int ap2cl_test_parse_response(uint8_t *data, int len, int expected_cseq)
+{
+    int status = 0;
+    int header_len = 0;
+    int content_len = 0;
+    return ap2_parse_rtsp_response(
+        data, len, expected_cseq, &status, &header_len, &content_len);
+}
+#endif
 
 /* ---- Native AP2 connect helpers ---- */
 
@@ -716,27 +889,31 @@ static void ap2_native_setup_mrp(struct ap2cl_s *p)
 
     /* Bind the sender to THIS session's pair-verify shared secret and open the
      * channel (TCP connect + DEVICE_INFO-first handshake). */
+    pthread_mutex_lock(&p->mrp_lock);
     if (!p->mrp)
         p->mrp = ap2_mrp_create(p->device.address, p->device.port,
                                 p->auth_credentials, p->dacp_id, p->device.name,
                                 p->session_uuid, p->group_uuid,
                                 ap2_hap_get_shared_secret(p->hap));
-    if (!p->mrp) return;
+    if (!p->mrp) goto done;
     if (!ap2_mrp_attach_events(p->mrp, p->events_sock)) {
         LOG_WARN("[MRP] event-channel attach failed; degrading to no-MRP");
         ap2_mrp_destroy(p->mrp);
         p->mrp = NULL;
-        return;
+        goto done;
     }
-    p->events_sock = -1; /* ownership transferred to the MRP context */
+    atomic_store(&p->mrp_event_status, 1);
 
     if (!ap2_mrp_attach(p->mrp, data_port, seed)) {
         LOG_WARN("[MRP] data-channel attach failed; degrading to no-MRP");
         ap2_mrp_destroy(p->mrp);
         p->mrp = NULL;
-        return;
+        atomic_store(&p->mrp_event_status, -1);
+        goto done;
     }
     LOG_INFO("[MRP] remote-control data channel established (now-playing active)");
+done:
+    pthread_mutex_unlock(&p->mrp_lock);
 }
 
 /* ---- Native AP2 connect sequence ---- */
@@ -772,7 +949,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
         return false;
     }
     freeaddrinfo(res);
-    atomic_store(&p->rtsp_healthy, true);
+    atomic_store(&p->rtsp_dead, false);
 #ifdef SO_NOSIGPIPE
     int no_sigpipe = 1;
     setsockopt(p->sock_fd, SOL_SOCKET, SO_NOSIGPIPE,
@@ -1006,7 +1183,13 @@ static bool ap2_native_connect(struct ap2cl_s *p)
                 int one = 1;
                 setsockopt(events_sock, IPPROTO_TCP, TCP_NODELAY,
                            &one, sizeof(one));
-                p->events_sock = events_sock;
+                if (ap2_io_set_nonblocking(events_sock)) {
+                    p->events_sock = events_sock;
+                } else {
+                    LOG_WARN("[AP2] Cannot make events socket nonblocking: %s",
+                             strerror(errno));
+                    close(events_sock);
+                }
             } else {
                 LOG_WARN("[AP2] Events connect failed");
                 close(events_sock);
@@ -1029,7 +1212,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     struct sockaddr_in bind_addr = {.sin_family = AF_INET, .sin_addr = p->bind_addr};
     if (p->data_sock < 0 ||
         bind(p->data_sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) != 0 ||
-        !ap2_set_nonblocking(p->data_sock)) {
+        !ap2_io_set_nonblocking(p->data_sock)) {
         LOG_ERROR("[AP2] Cannot create non-blocking RTP data socket: %s",
                   strerror(errno));
         if (p->data_sock >= 0) { close(p->data_sock); p->data_sock = -1; }
@@ -1043,7 +1226,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     p->ctrl_sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (p->ctrl_sock < 0 ||
         bind(p->ctrl_sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) != 0 ||
-        !ap2_set_nonblocking(p->ctrl_sock)) {
+        !ap2_io_set_nonblocking(p->ctrl_sock)) {
         LOG_ERROR("[AP2] Cannot create non-blocking RTP control socket: %s",
                   strerror(errno));
         if (p->ctrl_sock >= 0) { close(p->ctrl_sock); p->ctrl_sock = -1; }
@@ -1234,9 +1417,8 @@ static bool ap2_native_connect(struct ap2cl_s *p)
                          inet_ntoa(p->bind_addr));
         }
         if (p->buffered_sock >= 0) {
-            /* Bound both directions so a receiver that stops draining the
-             * stream can never hang the process: the blocking send loop in
-             * ap2_buffered_send_chunk relies on SO_SNDTIMEO expiring. */
+            /* Keep kernel timeouts as a second line of defense; audio writes
+             * also use a cumulative userspace deadline. */
             struct timeval stv = {.tv_sec = 8};
             setsockopt(p->buffered_sock, SOL_SOCKET, SO_SNDTIMEO, &stv, sizeof(stv));
             setsockopt(p->buffered_sock, SOL_SOCKET, SO_RCVTIMEO, &stv, sizeof(stv));
@@ -1277,13 +1459,11 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     }
 
     p->first_packet = true;
+    if (atomic_load(&p->rtsp_dead)) return false;
     p->rtsp_established = true;
     p->state = AP2_CONNECTED;
-    p->feedback_last_tick_ms = ap2_io_monotonic_ms();
-    if (!ap2_periodic_worker_start(&p->feedback_worker)) {
-        LOG_ERROR("[AP2] Cannot start feedback worker: %s", strerror(errno));
-        errno = EIO;
-        ap2_mark_rtsp_dead(p, "POST", "/feedback", "worker-start", 0);
+    if (!ap2_feedback_start(p)) {
+        atomic_store(&p->rtsp_dead, true);
         return false;
     }
     LOG_INFO("[AP2] Native AP2 session ready");
@@ -1403,14 +1583,13 @@ static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
         }
         p->rt_anchor_valid = true;
     }
-    int64_t elapsed_ns = (int64_t)wall - (int64_t)p->rt_anchor_wall0
-                       - (int64_t)p->latency_ms * 1000000LL;
-    uint32_t play_pos = p->rt_anchor_pos0
-                      + (uint32_t)((elapsed_ns * p->format.sample_rate) / 1000000000LL);
-    uint32_t frame_1 = play_pos + 11035;
-    uint32_t frame_2 = frame_1 + 77175;
+    ap2_timeline_ptp_anchor_t anchor;
+    if (!ap2_timeline_ptp_anchor(
+            wall, p->rt_anchor_wall0, p->rt_anchor_pos0,
+            p->format.sample_rate, p->latency_ms, &anchor))
+        return;
 
-    uint32_t be = htonl(frame_1);
+    uint32_t be = htonl(anchor.frame_1);
     memcpy(pkt + 4, &be, 4);
 
     uint32_t wall_hi = htonl((uint32_t)(wall >> 32));
@@ -1418,7 +1597,7 @@ static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
     memcpy(pkt + 8, &wall_hi, 4);
     memcpy(pkt + 12, &wall_lo, 4);
 
-    be = htonl(frame_2);
+    be = htonl(anchor.frame_2);
     memcpy(pkt + 16, &be, 4);
 
     uint64_t cid = ap2_ptp_master_clock_id(p->ptp);
@@ -1444,38 +1623,38 @@ static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
         }
     }
     LOG_DEBUG("[AP2] TX PTP sync %s play_pos=%u wall=%" PRIu64 "ns",
-              first ? "(initial)" : "", play_pos, wall);
-    return result;
+              first ? "(initial)" : "", anchor.frame_1 - 11035, wall);
 }
 
 /* ---- Native AP2 buffered audio (type 103) ---- */
 
-static bool ap2_encrypt_audio(const uint8_t key[32], const uint8_t nonce[12],
-                              const uint8_t aad[8], const uint8_t *plain,
-                              int plain_len, uint8_t *cipher,
-                              int *cipher_len, uint8_t tag[AP2_CHACHA_TAG_SIZE])
+static int ap2_encrypt_audio_payload(
+    const uint8_t key[32], const uint8_t nonce[12],
+    const uint8_t *aad, int aad_len,
+    const uint8_t *plaintext, int plaintext_len,
+    uint8_t *ciphertext, uint8_t tag[AP2_CHACHA_TAG_SIZE])
 {
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
-    if (!ctx) return false;
+    if (!ctx) return -1;
+
     int len = 0;
     int total = 0;
     bool ok =
-        EVP_EncryptInit_ex(ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) > 0 &&
-        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) > 0 &&
-        EVP_EncryptInit_ex(ctx, NULL, NULL, key, nonce) > 0 &&
-        EVP_EncryptUpdate(ctx, NULL, &len, aad, 8) > 0 &&
-        EVP_EncryptUpdate(ctx, cipher, &len, plain, plain_len) > 0;
+        EVP_EncryptInit_ex(ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) == 1 &&
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) == 1 &&
+        EVP_EncryptInit_ex(ctx, NULL, NULL, key, nonce) == 1 &&
+        EVP_EncryptUpdate(ctx, NULL, &len, aad, aad_len) == 1 &&
+        EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len) == 1;
     if (ok) {
         total = len;
-        ok = EVP_EncryptFinal_ex(ctx, cipher + total, &len) > 0;
+        ok = EVP_EncryptFinal_ex(ctx, ciphertext + total, &len) == 1;
         total += len;
     }
     if (ok)
         ok = EVP_CIPHER_CTX_ctrl(
-                 ctx, EVP_CTRL_AEAD_GET_TAG, AP2_CHACHA_TAG_SIZE, tag) > 0;
+                 ctx, EVP_CTRL_AEAD_GET_TAG, AP2_CHACHA_TAG_SIZE, tag) == 1;
     EVP_CIPHER_CTX_free(ctx);
-    if (ok) *cipher_len = total;
-    return ok;
+    return ok ? total : -1;
 }
 
 /* Send the SETRATEANCHORTIME anchor. It pins an RTP sample number to a point on
@@ -1547,20 +1726,17 @@ static bool ap2_send_flushbuffered(struct ap2cl_s *p)
 /* Push one encoded chunk over the buffered TCP data connection. The wire frame
  * is a 2-byte big-endian length prefix followed by the encrypted RTP packet
  * [12B hdr][ciphertext][16B tag][8B nonce]. TCP provides reliability and, via
- * bounded backpressure, flow control (no resend logic). */
+ * backpressure on the blocking write, flow control (no resend logic). */
 static ap2_send_result_t ap2_buffered_send_chunk(
     struct ap2cl_s *p, uint8_t *sample, int frames)
 {
-    if (p->buffered_sock < 0 || !p->alac) {
-        LOG_ERROR("[AP2] Buffered audio channel is unavailable");
-        return AP2_SEND_FATAL;
-    }
+    if (p->buffered_sock < 0 || !p->alac) return AP2_SEND_FATAL;
 
     uint8_t *encoded = NULL;
     int enc_size = 0;
     pcm_to_alac(p->alac, sample, frames, &encoded, &enc_size);
     if (!encoded || enc_size <= 0) {
-        LOG_ERROR("[AP2] ALAC encoder failed for buffered audio");
+        LOG_ERROR("[AP2] ALAC encoder failed");
         free(encoded);
         return AP2_SEND_FATAL;
     }
@@ -1596,26 +1772,23 @@ static ap2_send_result_t ap2_buffered_send_chunk(
     int cap = 2 + 12 + enc_size + AP2_CHACHA_TAG_SIZE + 8;
     uint8_t *frame = malloc(cap);
     if (!frame) {
-        LOG_ERROR("[AP2] Cannot allocate buffered RTP packet");
+        LOG_ERROR("[AP2] Cannot allocate buffered audio frame");
         free(encoded);
         return AP2_SEND_FATAL;
     }
     uint8_t *pkt = frame + 2;   /* payload starts after the 2-byte length prefix */
     memcpy(pkt, rtp_hdr, 12);
 
-    int ct_len = 0;
     uint8_t tag[AP2_CHACHA_TAG_SIZE];
-    bool encrypted_ok = ap2_encrypt_audio(
-        audio_key, nonce, rtp_hdr + 4, encoded, enc_size,
-        pkt + 12, &ct_len, tag);
+    int ct_len = ap2_encrypt_audio_payload(
+        audio_key, nonce, rtp_hdr + 4, 8, encoded, enc_size, pkt + 12, tag);
     free(encoded);
-    if (!encrypted_ok) {
+    if (ct_len < 0) {
         LOG_ERROR("[AP2] Buffered audio encryption failed");
         free(frame);
         return AP2_SEND_FATAL;
     }
     memcpy(pkt + 12 + ct_len, tag, sizeof(tag));
-    p->audio_nonce_counter++;
 
     int payload_len = 12 + ct_len + AP2_CHACHA_TAG_SIZE;
     memcpy(pkt + payload_len, nonce + 4, 8);   /* trailing nonce (nonce[4..11]) */
@@ -1629,8 +1802,8 @@ static ap2_send_result_t ap2_buffered_send_chunk(
     frame[1] = (uint8_t)(total & 0xFF);
 
     bool ok = ap2_io_write_all_deadline(
-        p->buffered_sock, frame, (size_t)total,
-        ap2_io_monotonic_ms() + AP2_BUFFERED_WRITE_TIMEOUT_MS);
+        p->buffered_sock, frame, total,
+        ap2_io_monotonic_ms() + AP2_RTSP_CONTROL_TIMEOUT_MS);
     free(frame);
 
     if (ok) {
@@ -1643,19 +1816,15 @@ static ap2_send_result_t ap2_buffered_send_chunk(
         shutdown(p->buffered_sock, SHUT_RDWR);
         close(p->buffered_sock);
         p->buffered_sock = -1;
-        return AP2_SEND_FATAL;
     }
-    return AP2_SEND_SENT;
+    return ok ? AP2_SEND_SENT : AP2_SEND_FATAL;
 }
 
 static ap2_send_result_t ap2_native_send_chunk(
     struct ap2cl_s *p, uint8_t *sample, int frames)
 {
     if (p->use_buffered) return ap2_buffered_send_chunk(p, sample, frames);
-    if (p->data_sock < 0 || !p->alac || !p->hap) {
-        LOG_ERROR("[AP2] Realtime audio session is incomplete");
-        return AP2_SEND_FATAL;
-    }
+    if (p->data_sock < 0 || !p->alac) return AP2_SEND_FATAL;
 
     /* Send initial sync/anchor packet before the very first audio packet, then
      * periodically every ~100 chunks (~0.8s at 352fpp/44.1kHz). PTP sessions use
@@ -1675,7 +1844,7 @@ static ap2_send_result_t ap2_native_send_chunk(
     int enc_size = 0;
     pcm_to_alac(p->alac, sample, frames, &encoded, &enc_size);
     if (!encoded || enc_size <= 0) {
-        LOG_ERROR("[AP2] ALAC encoder failed for realtime audio");
+        LOG_ERROR("[AP2] ALAC encoder failed");
         free(encoded);
         return AP2_SEND_FATAL;
     }
@@ -1721,13 +1890,11 @@ static ap2_send_result_t ap2_native_send_chunk(
     }
     memcpy(pkt, rtp_hdr, 12);
 
-    int ct_len = 0;
     uint8_t tag[AP2_CHACHA_TAG_SIZE];
-    bool encrypted_ok = ap2_encrypt_audio(
-        audio_key, nonce, rtp_hdr + 4, encoded, enc_size,
-        pkt + 12, &ct_len, tag);
+    int ct_len = ap2_encrypt_audio_payload(
+        audio_key, nonce, rtp_hdr + 4, 8, encoded, enc_size, pkt + 12, tag);
     free(encoded);
-    if (!encrypted_ok) {
+    if (ct_len < 0) {
         LOG_ERROR("[AP2] Realtime audio encryption failed");
         free(pkt);
         return AP2_SEND_FATAL;
@@ -1740,23 +1907,22 @@ static ap2_send_result_t ap2_native_send_chunk(
      * packet fails its auth tag and is silently dropped. */
     memcpy(pkt + 12 + ct_len + AP2_CHACHA_TAG_SIZE, nonce + 4, 8);
     int actual_pkt_size = 12 + ct_len + AP2_CHACHA_TAG_SIZE + 8;
-    ap2_send_result_t result = ap2_io_send_datagram_deadline(
+    ap2_io_datagram_result_t send_result = ap2_io_send_datagram_deadline(
         p->data_sock, pkt, (size_t)actual_pkt_size,
-        (const struct sockaddr *)&p->data_addr, sizeof(p->data_addr),
+        (struct sockaddr *)&p->data_addr, sizeof(p->data_addr),
         ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS);
     free(pkt);
 
-    if (result == AP2_SEND_SENT) {
+    if (send_result == AP2_IO_DATAGRAM_SENT) {
         p->audio_packets_sent++;
-    } else if (result == AP2_SEND_DROPPED) {
+    } else if (send_result == AP2_IO_DATAGRAM_DROPPED) {
         p->audio_packets_dropped++;
         if (p->audio_packets_dropped <= 3 ||
             (p->audio_packets_dropped % 100) == 0)
-            LOG_WARN("[AP2] RTP send transiently dropped seq=%u rtptime=%u",
-                     p->seq_number, p->rtp_timestamp);
+            LOG_WARN("[AP2] RTP send transiently dropped seq=%u rtptime=%u: %s",
+                     p->seq_number, p->rtp_timestamp, strerror(errno));
     } else {
-        LOG_ERROR("[AP2] Realtime RTP send failed seq=%u rtptime=%u "
-                  "bytes=%d: %s",
+        LOG_ERROR("[AP2] RTP send failed seq=%u rtptime=%u bytes=%d: %s",
                   p->seq_number, p->rtp_timestamp, actual_pkt_size,
                   strerror(errno));
         return AP2_SEND_FATAL;
@@ -1769,7 +1935,8 @@ static ap2_send_result_t ap2_native_send_chunk(
     p->rtp_timestamp += frames;
     p->head_ts += frames;
 
-    return result;
+    return send_result == AP2_IO_DATAGRAM_SENT
+               ? AP2_SEND_SENT : AP2_SEND_DROPPED;
 }
 
 /* ---- RAOP-compat connect ---- */
@@ -1838,25 +2005,15 @@ struct ap2cl_s *ap2cl_create(
     p->ctrl_sock = -1;
     p->events_sock = -1;
     p->buffered_sock = -1;
-    if (pthread_mutex_init(&p->rtsp_lock, NULL) != 0) {
-        free(p);
-        return NULL;
-    }
-    if (pthread_mutex_init(&p->mrp_lock, NULL) != 0) {
-        pthread_mutex_destroy(&p->rtsp_lock);
-        free(p);
-        return NULL;
-    }
-    if (!ap2_periodic_worker_init(&p->feedback_worker,
-                                  AP2_FEEDBACK_INTERVAL_MS,
-                                  ap2_feedback_worker_tick, p)) {
-        pthread_mutex_destroy(&p->mrp_lock);
-        pthread_mutex_destroy(&p->rtsp_lock);
-        free(p);
-        return NULL;
-    }
-    atomic_init(&p->rtsp_healthy, false);
-    atomic_init(&p->media_healthy, true);
+    pthread_mutex_init(&p->rtsp_lock, NULL);
+    pthread_mutex_init(&p->mrp_lock, NULL);
+    atomic_init(&p->rtsp_dead, false);
+    atomic_init(&p->rtsp_established, false);
+    atomic_init(&p->feedback_stop, true);
+    atomic_init(&p->feedback_waiting, false);
+    atomic_init(&p->mrp_event_status, -1);
+    atomic_init(&p->mrp_pending, 0);
+    p->feedback_interval_ms = AP2_FEEDBACK_INTERVAL_MS;
     if (dacp_id) p->dacp_id = strdup(dacp_id);
     if (active_remote) p->active_remote = strdup(active_remote);
     if (password) p->password = strdup(password);
@@ -1877,7 +2034,7 @@ struct ap2cl_s *ap2cl_create(
 bool ap2cl_destroy(struct ap2cl_s *p)
 {
     if (!p) return false;
-    ap2_periodic_worker_stop(&p->feedback_worker);
+    ap2_feedback_stop(p);
     /* Preserve the on-wire shutdown sequence (final MediaRemote stopped state,
      * MRP disconnect, RTSP TEARDOWN) on the normal EOF path too. */
     if (p->state != AP2_DOWN || p->sock_fd >= 0)
@@ -1886,8 +2043,11 @@ bool ap2cl_destroy(struct ap2cl_s *p)
     if (p->hap) ap2_hap_destroy(p->hap);
     if (p->ptp) ap2_ptp_destroy(p->ptp);
     pthread_mutex_lock(&p->mrp_lock);
-    if (p->mrp) ap2_mrp_destroy(p->mrp);
-    p->mrp = NULL;
+    if (p->mrp) {
+        ap2_mrp_destroy(p->mrp);
+        p->mrp = NULL;
+        atomic_store(&p->mrp_event_status, -1);
+    }
     pthread_mutex_unlock(&p->mrp_lock);
     if (p->alac) alac_delete_encoder(p->alac);
     /* Close the RTSP socket under the lock so an in-flight request/response
@@ -1897,7 +2057,6 @@ bool ap2cl_destroy(struct ap2cl_s *p)
     if (p->sock_fd >= 0) { close(p->sock_fd); p->sock_fd = -1; }
     pthread_mutex_unlock(&p->rtsp_lock);
     pthread_mutex_destroy(&p->rtsp_lock);
-    ap2_periodic_worker_destroy(&p->feedback_worker);
     pthread_mutex_destroy(&p->mrp_lock);
     if (p->data_sock >= 0) close(p->data_sock);
     if (p->ctrl_sock >= 0) close(p->ctrl_sock);
@@ -1979,17 +2138,20 @@ bool ap2cl_disconnect(struct ap2cl_s *p)
 {
     if (!p) return false;
     if (p->flow == FLOW_NATIVE_AP2) {
-        /* Stop and join the sole feedback/event owner before touching either
-         * encrypted channel. */
-        ap2_periodic_worker_stop(&p->feedback_worker);
+        ap2_feedback_stop(p);
+        atomic_store(&p->mrp_pending, 0);
         /* Publish the final stopped state before disconnecting MediaRemote,
          * while the encrypted RTSP session is still live. */
         pthread_mutex_lock(&p->mrp_lock);
-        if (p->mrp) {
-            ap2_mrp_set_stopped(p->mrp);
-            ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_STOPPED, true);
-            ap2_mrp_stop(p->mrp);
-        }
+        bool mrp_ready = p->mrp != NULL;
+        if (mrp_ready) ap2_mrp_set_stopped(p->mrp);
+        pthread_mutex_unlock(&p->mrp_lock);
+        if (mrp_ready)
+            ap2_mrp_send_playback_state(
+                p, AP2_MRP_PLAYBACK_STOPPED, true);
+        pthread_mutex_lock(&p->mrp_lock);
+        if (p->mrp) ap2_mrp_stop(p->mrp);
+        atomic_store(&p->mrp_event_status, -1);
         pthread_mutex_unlock(&p->mrp_lock);
         if (p->events_sock >= 0) {
             close(p->events_sock);
@@ -2037,7 +2199,6 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
         p->seq_number = (uint16_t)(getpid() * 40503u);
         p->start_ntp = ntp_start;
         p->state = AP2_STREAMING;
-        atomic_store(&p->media_healthy, true);
         pthread_mutex_lock(&p->mrp_lock);
         if (p->mrp) ap2_mrp_set_playing(p->mrp, true);
         pthread_mutex_unlock(&p->mrp_lock);
@@ -2086,27 +2247,18 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
     return true;
 }
 
-ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample,
-                                   int frames)
+ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p,
+                                   uint8_t *sample, int frames)
 {
-    if (!p || p->state != AP2_STREAMING) {
-        LOG_ERROR("[AP2] Audio send attempted outside a streaming session");
-        return AP2_SEND_FATAL;
-    }
+    if (!p || p->state != AP2_STREAMING) return AP2_SEND_FATAL;
     if (p->flow == FLOW_NATIVE_AP2) {
-        ap2_send_result_t result = ap2_native_send_chunk(p, sample, frames);
-        if (result == AP2_SEND_FATAL)
-            atomic_store(&p->media_healthy, false);
-        return result;
+        if (atomic_load(&p->rtsp_dead)) return AP2_SEND_FATAL;
+        return ap2_native_send_chunk(p, sample, frames);
     }
-    if (!p->raopcl) {
-        LOG_ERROR("[AP2] RAOP-compatible audio session is unavailable");
-        return AP2_SEND_FATAL;
-    }
+    if (!p->raopcl) return AP2_SEND_FATAL;
     uint64_t playtime;
     return raopcl_send_chunk(p->raopcl, sample, frames, &playtime)
-               ? AP2_SEND_SENT
-               : AP2_SEND_FATAL;
+               ? AP2_SEND_SENT : AP2_SEND_FATAL;
 }
 
 static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
@@ -2172,7 +2324,7 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p)
     atomic_store(&p->rtp_offset, recovery.offset);
     if (p->use_ptp && p->rt_anchor_valid) {
         uint64_t shift_ns = ap2_timeline_frames_to_ns(
-            shifted_frames, (uint32_t)p->format.sample_rate);
+            shifted_frames, p->format.sample_rate);
         p->rt_anchor_wall0 += shift_ns;
     }
     p->timeline_reanchors++;
@@ -2211,30 +2363,39 @@ void ap2cl_log_diagnostics(struct ap2cl_s *p)
                ptp_now, clock_id, p->timeline_reanchors);
 }
 
+static void ap2_mrp_publish_playback_state(
+    struct ap2cl_s *p, ap2_state_t client_state,
+    ap2_mrp_playback_state_t state)
+{
+    p->state = client_state;
+    pthread_mutex_lock(&p->mrp_lock);
+    bool ready = p->mrp != NULL;
+    if (ready) {
+        if (state == AP2_MRP_PLAYBACK_STOPPED)
+            ap2_mrp_set_stopped(p->mrp);
+        else
+            ap2_mrp_set_playing(
+                 p->mrp, state == AP2_MRP_PLAYBACK_PLAYING);
+    }
+    pthread_mutex_unlock(&p->mrp_lock);
+    if (ready)
+        atomic_fetch_or(&p->mrp_pending, AP2_MRP_PENDING_PLAYBACK);
+}
+
 void ap2cl_pause(struct ap2cl_s *p)
 {
     if (!p) return;
     if (p->use_buffered && p->buffered_sock >= 0) {
         /* Freeze the buffered timeline in place with a rate-0 anchor. */
         ap2_send_setrateanchortime(p, p->rtp_timestamp, ap2_ptp_master_now_ns(p->ptp), 0);
-        p->state = AP2_PAUSED;
-        pthread_mutex_lock(&p->mrp_lock);
-        if (p->mrp) {
-            ap2_mrp_set_playing(p->mrp, false);
-            ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PAUSED, true);
-        }
-        pthread_mutex_unlock(&p->mrp_lock);
+        ap2_mrp_publish_playback_state(
+            p, AP2_PAUSED, AP2_MRP_PLAYBACK_PAUSED);
         return;
     }
     if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
     p->rt_anchor_valid = false;    /* resume re-anchors on a fresh line */
-    p->state = AP2_PAUSED;
-    pthread_mutex_lock(&p->mrp_lock);
-    if (p->mrp) {
-        ap2_mrp_set_playing(p->mrp, false);
-        ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PAUSED, true);
-    }
-    pthread_mutex_unlock(&p->mrp_lock);
+    ap2_mrp_publish_playback_state(
+        p, AP2_PAUSED, AP2_MRP_PLAYBACK_PAUSED);
 }
 
 void ap2cl_play(struct ap2cl_s *p)
@@ -2244,13 +2405,8 @@ void ap2cl_play(struct ap2cl_s *p)
         /* Re-anchor at rate 1 a short lead ahead to resume the buffered stream. */
         uint64_t anchor_ns = ap2_ptp_master_now_ns(p->ptp) + (uint64_t)p->latency_ms * 1000000ULL;
         ap2_send_setrateanchortime(p, p->rtp_timestamp, anchor_ns, 1);
-        p->state = AP2_STREAMING;
-        pthread_mutex_lock(&p->mrp_lock);
-        if (p->mrp) {
-            ap2_mrp_set_playing(p->mrp, true);
-            ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PLAYING, true);
-        }
-        pthread_mutex_unlock(&p->mrp_lock);
+        ap2_mrp_publish_playback_state(
+            p, AP2_STREAMING, AP2_MRP_PLAYBACK_PLAYING);
         return;
     }
     if (p->raopcl) {
@@ -2258,13 +2414,8 @@ void ap2cl_play(struct ap2cl_s *p)
         uint64_t now = raopcl_get_ntp(NULL);
         raopcl_start_at(p->raopcl, now + MS2NTP(200) - TS2NTP(lat, raopcl_sample_rate(p->raopcl)));
     }
-    p->state = AP2_STREAMING;
-    pthread_mutex_lock(&p->mrp_lock);
-    if (p->mrp) {
-        ap2_mrp_set_playing(p->mrp, true);
-        ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_PLAYING, true);
-    }
-    pthread_mutex_unlock(&p->mrp_lock);
+    ap2_mrp_publish_playback_state(
+        p, AP2_STREAMING, AP2_MRP_PLAYBACK_PLAYING);
 }
 
 void ap2cl_stop(struct ap2cl_s *p)
@@ -2273,14 +2424,9 @@ void ap2cl_stop(struct ap2cl_s *p)
     if (p->use_buffered && p->buffered_sock >= 0)
         ap2_send_flushbuffered(p);
     if (p->raopcl) raopcl_stop(p->raopcl);
-    pthread_mutex_lock(&p->mrp_lock);
-    if (p->mrp) {
-        ap2_mrp_set_stopped(p->mrp);
-        ap2_mrp_send_playback_state(p, AP2_MRP_PLAYBACK_STOPPED, true);
-    }
-    pthread_mutex_unlock(&p->mrp_lock);
+    ap2_mrp_publish_playback_state(
+        p, AP2_DOWN, AP2_MRP_PLAYBACK_STOPPED);
     p->rt_anchor_valid = false;
-    p->state = AP2_DOWN;
 }
 
 bool ap2cl_feedback(struct ap2cl_s *p)
@@ -2293,31 +2439,14 @@ bool ap2cl_feedback(struct ap2cl_s *p)
     int status = ap2_rtsp_send(p, "POST", "/feedback", NULL, 0, NULL, &resp, &resp_len);
     free(resp);
     LOG_DEBUG("[AP2] /feedback keepalive -> %d", status);
-    if (status == 200) {
-        unsigned failures = atomic_exchange(&p->feedback_failures, 0);
-        if (failures)
-            LOG_INFO("[AP2] /feedback recovered after %u failure(s)",
-                     failures);
-    } else {
-        unsigned failures = atomic_fetch_add(&p->feedback_failures, 1) + 1;
-        if (failures <= 3 || (failures % 10) == 0)
-            LOG_WARN("[AP2] /feedback failed: status=%d consecutive=%u",
-                     status, failures);
-    }
     return status == 200;
 }
 
 bool ap2cl_control_healthy(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2) return true;
-    if (!atomic_load(&p->rtsp_healthy) ||
-        !atomic_load(&p->media_healthy) ||
-        atomic_load(&p->feedback_failures) >= 3)
-        return false;
-    pthread_mutex_lock(&p->mrp_lock);
-    bool healthy = !p->mrp || ap2_mrp_event_status(p->mrp) != 0;
-    pthread_mutex_unlock(&p->mrp_lock);
-    return healthy;
+    if (atomic_load(&p->rtsp_dead)) return false;
+    return atomic_load(&p->mrp_event_status) != 0;
 }
 
 bool ap2cl_set_volume(struct ap2cl_s *p, int volume)
@@ -2402,7 +2531,8 @@ static bool ap2_native_send_metadata(struct ap2cl_s *p, const char *title,
  * messages. Set CLIAIRPLAY_MRP=0 to disable the path for diagnosis. */
 static void ap2_mrp_ready_locked(struct ap2cl_s *p)
 {
-    if (p->mrp || p->flow != FLOW_NATIVE_AP2 || !p->auth_credentials ||
+    if (p->mrp || !p->rtsp_established ||
+        p->flow != FLOW_NATIVE_AP2 || !p->auth_credentials ||
         p->sock_fd < 0 || p->events_sock < 0 || !p->session_uuid[0])
         return;
     const char *setting = getenv("CLIAIRPLAY_MRP");
@@ -2418,10 +2548,20 @@ static void ap2_mrp_ready_locked(struct ap2cl_s *p)
         LOG_WARN("[MRP] event-channel attach failed; MediaRemote disabled");
         ap2_mrp_destroy(p->mrp);
         p->mrp = NULL;
+        atomic_store(&p->mrp_event_status, -1);
         return;
     }
-    p->events_sock = -1; /* ownership transferred to the MRP context */
+    atomic_store(&p->mrp_event_status, 1);
     ap2_mrp_set_playing(p->mrp, p->state == AP2_STREAMING);
+}
+
+static bool ap2_mrp_ensure_ready(struct ap2cl_s *p)
+{
+    pthread_mutex_lock(&p->mrp_lock);
+    ap2_mrp_ready_locked(p);
+    bool ready = p->mrp != NULL;
+    pthread_mutex_unlock(&p->mrp_lock);
+    return ready;
 }
 
 /* Log an RTSP response body for diagnosis: a printable-text view (control bytes
@@ -2451,10 +2591,20 @@ typedef bool (*ap2_mrp_command_builder_t)(struct ap2_mrp_ctx *,
 
 static int ap2_mrp_post_command(struct ap2cl_s *p,
                                 ap2_mrp_command_builder_t builder,
-                                const char *tag)
+                                const char *tag,
+                                uint64_t *artwork_generation)
 {
     uint8_t *body = NULL; int body_len = 0;
-    if (!builder(p->mrp, &body, &body_len)) return -1;
+    pthread_mutex_lock(&p->mrp_lock);
+    bool built = p->mrp && builder(p->mrp, &body, &body_len);
+    if (built && artwork_generation)
+        *artwork_generation = ap2_mrp_artwork_generation(p->mrp);
+    pthread_mutex_unlock(&p->mrp_lock);
+    if (!built) return -1;
+    while (atomic_load(&p->feedback_waiting) &&
+           !atomic_load(&p->rtsp_dead) &&
+           !atomic_load(&p->feedback_stop))
+        usleep(1000);
     uint8_t *resp = NULL;
     int resp_len = 0;
     int status = ap2_rtsp_send(p, "POST", "/command", body, body_len,
@@ -2476,13 +2626,13 @@ static int ap2_mrp_send_playback_state(struct ap2cl_s *p,
                                        ap2_mrp_playback_state_t state,
                                        bool force)
 {
-    if (!p || !p->mrp || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0)
+    if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0)
         return -1;
     if (!force && p->mrp_last_playback_state == state) return 200;
 
     int status = ap2_mrp_post_command(
         p, ap2_mrp_build_playbackstate_command,
-        "[MRP] /command updateMRPlaybackState");
+        "[MRP] /command updateMRPlaybackState", NULL);
     if (ap2_mrp_status_ok(status))
         p->mrp_last_playback_state = state;
     return status;
@@ -2501,11 +2651,11 @@ static int ap2_mrp_send_extended_registration(struct ap2cl_s *p)
 
     int st_cmd = ap2_mrp_post_command(
         p, ap2_mrp_build_supportedcommands_command,
-        "[MRP] /command updateMRSupportedCommands");
+        "[MRP] /command updateMRSupportedCommands", NULL);
     int st_state = ap2_mrp_send_playback_state(p, state, true);
     int st_client = ap2_mrp_post_command(
         p, ap2_mrp_build_nowplayingclient_command,
-        "[MRP] /command updateMRNowPlayingClient");
+        "[MRP] /command updateMRNowPlayingClient", NULL);
 
     p->mrp_extended_registered =
         ap2_mrp_status_ok(st_cmd) && ap2_mrp_status_ok(st_state) &&
@@ -2518,22 +2668,23 @@ static int ap2_mrp_send_extended_registration(struct ap2cl_s *p)
     return st_client;
 }
 
-static int ap2cl_mrp_register_locked(struct ap2cl_s *p);
-
 static int ap2cl_mrp_push_locked(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return -1;
-    ap2_mrp_ready_locked(p);
-    if (!p->mrp) return -1;
+    if (!ap2_mrp_ensure_ready(p)) return -1;
 
     if (!p->mrp_device_registered && ap2cl_mrp_register_locked(p) != 1)
         return 0;
 
+    uint64_t artwork_generation = 0;
     int status = ap2_mrp_post_command(
         p, ap2_mrp_build_nowplaying_command,
-        "[MRP] /command updateMRNowPlayingInfo");
+        "[MRP] /command updateMRNowPlayingInfo", &artwork_generation);
     if (!ap2_mrp_status_ok(status)) return status;
-    ap2_mrp_mark_artwork_sent(p->mrp);
+    pthread_mutex_lock(&p->mrp_lock);
+    if (p->mrp)
+        ap2_mrp_mark_artwork_sent(p->mrp, artwork_generation);
+    pthread_mutex_unlock(&p->mrp_lock);
 
     int ext_status;
     if (!p->mrp_extended_registered) {
@@ -2550,11 +2701,9 @@ static int ap2cl_mrp_push_locked(struct ap2cl_s *p)
 
 int ap2cl_mrp_push(struct ap2cl_s *p)
 {
-    if (!p) return -1;
-    pthread_mutex_lock(&p->mrp_lock);
-    int status = ap2cl_mrp_push_locked(p);
-    pthread_mutex_unlock(&p->mrp_lock);
-    return status;
+    if (!p || !ap2_mrp_ensure_ready(p)) return -1;
+    atomic_fetch_or(&p->mrp_pending, AP2_MRP_PENDING_PUSH);
+    return 202;
 }
 
 /* MRP data-channel (path B) status for the [STATUS] mrp line:
@@ -2580,24 +2729,21 @@ int ap2cl_mrp_channel_status(struct ap2cl_s *p)
 static int ap2cl_mrp_register_locked(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return -1;
-    ap2_mrp_ready_locked(p);
-    if (!p->mrp) return -1;
+    if (!ap2_mrp_ensure_ready(p)) return -1;
     if (p->mrp_device_registered) return 1;
 
     int status = ap2_mrp_post_command(
         p, ap2_mrp_build_deviceinfo_command,
-        "[MRP] /command DEVICE_INFO");
+        "[MRP] /command DEVICE_INFO", NULL);
     p->mrp_device_registered = ap2_mrp_status_ok(status);
     return p->mrp_device_registered ? 1 : 0;
 }
 
 int ap2cl_mrp_register(struct ap2cl_s *p)
 {
-    if (!p) return -1;
-    pthread_mutex_lock(&p->mrp_lock);
-    int status = ap2cl_mrp_register_locked(p);
-    pthread_mutex_unlock(&p->mrp_lock);
-    return status;
+    if (!p || !ap2_mrp_ensure_ready(p)) return -1;
+    atomic_fetch_or(&p->mrp_pending, AP2_MRP_PENDING_REGISTER);
+    return 202;
 }
 
 bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist,

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -50,7 +50,6 @@
 #include "ap2_bplist.h"
 #include "ap2_ptp.h"
 #include "ap2_timeline.h"
-#include "ap2_io.h"
 #include "ap2_feedback.h"
 
 extern log_level *loglevel;
@@ -63,6 +62,7 @@ extern log_level *loglevel;
 #define AP2_RTSP_METADATA_TIMEOUT_MS  5000
 #define AP2_FEEDBACK_INTERVAL_MS      2000
 #define AP2_UDP_SEND_TIMEOUT_MS       20
+#define AP2_BUFFERED_WRITE_TIMEOUT_MS 8000
 #define AP2_HAP_FRAME_MAX             1024
 #define AP2_MRP_PENDING_REGISTER      (1u << 0)
 #define AP2_MRP_PENDING_PUSH          (1u << 1)
@@ -84,6 +84,8 @@ struct ap2cl_s {
     int dev_render_ms;             /* receiver-reported arrival->render latency (ms) */
     int volume;
     ap2_flow_t flow;
+    pthread_mutex_t media_lock;
+    atomic_bool media_transition;
 
     /* Identifiers */
     char *dacp_id;
@@ -112,13 +114,16 @@ struct ap2cl_s {
     pthread_mutex_t rtsp_lock;
     atomic_bool rtsp_dead;
     atomic_bool rtsp_established;
-    pthread_t feedback_thread;
-    atomic_bool feedback_stop;
+    atomic_bool media_healthy;
+    ap2_periodic_worker_t feedback_worker;
+    ap2_periodic_worker_t mrp_worker;
+    bool workers_initialized;
+    atomic_bool workers_stopping;
     atomic_bool feedback_waiting;
-    bool feedback_thread_started;
-    pthread_t mrp_thread;
-    bool mrp_thread_started;
     int feedback_interval_ms;
+    uint64_t feedback_last_ms;
+    uint64_t feedback_next_ms;
+    unsigned int feedback_failures;
     struct ap2_hap_ctx *hap;      /* HAP encryption context */
     struct ap2_ptp_ctx *ptp;      /* Timing */
     /* MRP now-playing over POST /command (path A, see DESIGN.md §8):
@@ -138,7 +143,7 @@ struct ap2cl_s {
     struct alac_codec_s *alac;    /* ALAC encoder for native flow */
     uint8_t audio_key[32];        /* ChaCha20 key for audio encryption */
     uint16_t seq_number;
-    uint32_t rtp_timestamp;
+    _Atomic uint32_t rtp_timestamp;
     uint32_t ssrc;
     uint64_t head_ts;
     bool first_packet;
@@ -239,40 +244,24 @@ static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
     errno = saved_errno;
 }
 
-static int ap2_parse_rtsp_response(uint8_t *data, int len, int expected_cseq,
+static int ap2_parse_rtsp_response(const uint8_t *data, int len,
+                                   int expected_cseq,
                                    int *status, int *header_len,
                                    int *content_len)
 {
     if (!data || len <= 0) return 0;
-    data[len] = '\0';
-    char *end = strstr((char *)data, "\r\n\r\n");
-    if (!end) return 0;
-    int hlen = (int)(end - (char *)data) + 4;
-    if (hlen > len) return -1;
-
-    int parsed_status = 0;
-    if (sscanf((char *)data, "%*s %d", &parsed_status) != 1) return -1;
-    char *cseq_header = strcasestr((char *)data, "CSeq:");
-    int response_cseq = -1;
-    if (!cseq_header || cseq_header >= end ||
-        sscanf(cseq_header + 5, "%d", &response_cseq) != 1 ||
-        response_cseq != expected_cseq)
+    ap2_rtsp_response_t response;
+    int parsed = ap2_io_parse_rtsp_response(
+        data, (size_t)len, &response);
+    if (parsed <= 0) return parsed;
+    if (response.message_len != (size_t)len ||
+        response.cseq != expected_cseq ||
+        response.header_len > INT_MAX ||
+        response.body_len > INT_MAX)
         return -1;
-
-    int cl = 0;
-    char *length_header = strcasestr((char *)data, "Content-Length:");
-    if (length_header && length_header < end) {
-        char *number_end = NULL;
-        long parsed = strtol(length_header + 15, &number_end, 10);
-        if (!number_end || number_end == length_header + 15 ||
-            parsed < 0 || parsed > INT_MAX)
-            return -1;
-        cl = (int)parsed;
-    }
-    if (cl > len - hlen) return 0;
-    *status = parsed_status;
-    *header_len = hlen;
-    *content_len = cl;
+    *status = response.status;
+    *header_len = (int)response.header_len;
+    *content_len = (int)response.body_len;
     return 1;
 }
 
@@ -474,111 +463,93 @@ static int ap2_rtsp_send(struct ap2cl_s *p, const char *method, const char *uri,
                             resp_body, resp_len);
 }
 
-static void *ap2_feedback_thread_main(void *arg)
+static bool ap2_feedback_worker_tick(void *arg)
 {
     struct ap2cl_s *p = arg;
-    uint64_t last_feedback_ms = ap2_io_monotonic_ms();
-    uint64_t next_feedback_ms =
-        last_feedback_ms + (uint64_t)p->feedback_interval_ms;
-    unsigned int feedback_failures = 0;
-    LOG_DEBUG("[AP2] feedback worker started (interval=%dms)",
-              p->feedback_interval_ms);
+    if (atomic_load(&p->workers_stopping) ||
+        atomic_load(&p->rtsp_dead))
+        return false;
 
-    while (!atomic_load(&p->feedback_stop) &&
-           !atomic_load(&p->rtsp_dead)) {
-        uint64_t now_ms = ap2_io_monotonic_ms();
-        if (now_ms >= next_feedback_ms) {
-            uint64_t gap_ms = now_ms - last_feedback_ms;
-            LOG_SDEBUG("[AP2DIAG] feedback tick gap=%" PRIu64 "ms", gap_ms);
-            if (gap_ms > (uint64_t)p->feedback_interval_ms + 500)
-                LOG_WARN("[AP2] feedback cadence delayed: %" PRIu64 "ms",
-                         gap_ms);
-            atomic_store(&p->feedback_waiting, true);
-            bool feedback_ok = ap2cl_feedback(p);
-            atomic_store(&p->feedback_waiting, false);
-            if (feedback_ok) {
-                feedback_failures = 0;
-            } else if (!atomic_load(&p->rtsp_dead) &&
-                       ++feedback_failures >= 3) {
-                errno = EPROTO;
-                ap2_mark_rtsp_dead(p, "POST", "/feedback",
-                                   "repeated non-200 response",
-                                   ap2_io_monotonic_ms() - last_feedback_ms);
-            }
-            last_feedback_ms = ap2_io_monotonic_ms();
-            next_feedback_ms += (uint64_t)p->feedback_interval_ms;
-            if (next_feedback_ms <= last_feedback_ms)
-                next_feedback_ms =
-                    last_feedback_ms + (uint64_t)p->feedback_interval_ms;
+    uint64_t now_ms = ap2_io_monotonic_ms();
+    if (now_ms >= p->feedback_next_ms) {
+        uint64_t gap_ms = now_ms - p->feedback_last_ms;
+        LOG_SDEBUG("[AP2DIAG] feedback tick gap=%" PRIu64 "ms", gap_ms);
+        if (gap_ms > (uint64_t)p->feedback_interval_ms + 500)
+            LOG_WARN("[AP2] feedback cadence delayed: %" PRIu64 "ms",
+                     gap_ms);
+        atomic_store(&p->feedback_waiting, true);
+        bool feedback_ok = ap2cl_feedback(p);
+        atomic_store(&p->feedback_waiting, false);
+        if (feedback_ok) {
+            p->feedback_failures = 0;
+        } else if (!atomic_load(&p->rtsp_dead) &&
+                   ++p->feedback_failures >= 3) {
+            errno = EPROTO;
+            ap2_mark_rtsp_dead(p, "POST", "/feedback",
+                               "repeated non-200 response",
+                               ap2_io_monotonic_ms() - p->feedback_last_ms);
         }
-
-        /* This worker is the sole owner of reverse-event/DataStream ticking.
-         * Run it after the keepalive so a busy event stream cannot delay the
-         * receiver's feedback deadline. */
-        pthread_mutex_lock(&p->mrp_lock);
-        int event_status = -1;
-        if (p->mrp) {
-            ap2_mrp_tick(p->mrp);
-            event_status = ap2_mrp_event_status(p->mrp);
-        }
-        atomic_store(&p->mrp_event_status, event_status);
-        pthread_mutex_unlock(&p->mrp_lock);
-        usleep(100000);
+        p->feedback_last_ms = ap2_io_monotonic_ms();
+        p->feedback_next_ms += (uint64_t)p->feedback_interval_ms;
+        if (p->feedback_next_ms <= p->feedback_last_ms)
+            p->feedback_next_ms =
+                p->feedback_last_ms + (uint64_t)p->feedback_interval_ms;
     }
-    LOG_DEBUG("[AP2] feedback worker stopped (dead=%d)",
-              atomic_load(&p->rtsp_dead) ? 1 : 0);
-    return NULL;
+
+    /* This worker is the sole owner of reverse-event/DataStream ticking.
+     * Run it after the keepalive so a busy event stream cannot delay the
+     * receiver's feedback deadline. */
+    pthread_mutex_lock(&p->mrp_lock);
+    int event_status = -1;
+    if (p->mrp) {
+        ap2_mrp_tick(p->mrp);
+        event_status = ap2_mrp_event_status(p->mrp);
+    }
+    atomic_store(&p->mrp_event_status, event_status);
+    pthread_mutex_unlock(&p->mrp_lock);
+    return !atomic_load(&p->rtsp_dead);
 }
 
-static void *ap2_mrp_thread_main(void *arg)
+static bool ap2_mrp_worker_tick(void *arg)
 {
     struct ap2cl_s *p = arg;
-    while (!atomic_load(&p->feedback_stop) &&
-           !atomic_load(&p->rtsp_dead)) {
-        unsigned int pending = atomic_exchange(&p->mrp_pending, 0);
-        if (pending)
-            ap2_mrp_process_pending(p, pending);
-        else
-            usleep(100000);
-    }
-    return NULL;
+    if (atomic_load(&p->workers_stopping) ||
+        atomic_load(&p->rtsp_dead))
+        return false;
+    ap2_mrp_process_pending(p, atomic_exchange(&p->mrp_pending, 0));
+    return !atomic_load(&p->rtsp_dead);
 }
 
 static bool ap2_feedback_start(struct ap2cl_s *p)
 {
-    atomic_store(&p->feedback_stop, false);
-    int err = pthread_create(
-        &p->feedback_thread, NULL, ap2_feedback_thread_main, p);
-    if (err != 0) {
-        LOG_ERROR("[AP2] Cannot start feedback worker: %s", strerror(err));
+    if (!p->workers_initialized) return false;
+    atomic_store(&p->workers_stopping, false);
+    p->feedback_failures = 0;
+    p->feedback_last_ms = ap2_io_monotonic_ms();
+    p->feedback_next_ms =
+        p->feedback_last_ms + (uint64_t)p->feedback_interval_ms;
+    if (!ap2_periodic_worker_start(&p->feedback_worker)) {
+        LOG_ERROR("[AP2] Cannot start feedback worker: %s", strerror(errno));
         return false;
     }
-    p->feedback_thread_started = true;
-    err = pthread_create(&p->mrp_thread, NULL, ap2_mrp_thread_main, p);
-    if (err != 0) {
+    if (!ap2_periodic_worker_start(&p->mrp_worker)) {
         LOG_ERROR("[AP2] Cannot start MRP publication worker: %s",
-                  strerror(err));
-        atomic_store(&p->feedback_stop, true);
-        pthread_join(p->feedback_thread, NULL);
-        p->feedback_thread_started = false;
+                  strerror(errno));
+        atomic_store(&p->workers_stopping, true);
+        ap2_periodic_worker_stop(&p->feedback_worker);
         return false;
     }
-    p->mrp_thread_started = true;
+    LOG_DEBUG("[AP2] maintenance workers started (feedback=%dms)",
+              p->feedback_interval_ms);
     return true;
 }
 
 static void ap2_feedback_stop(struct ap2cl_s *p)
 {
-    if (!p || (!p->feedback_thread_started && !p->mrp_thread_started)) return;
-    atomic_store(&p->feedback_stop, true);
-    if (p->mrp_thread_started) {
-        pthread_join(p->mrp_thread, NULL);
-        p->mrp_thread_started = false;
-    }
-    if (p->feedback_thread_started) {
-        pthread_join(p->feedback_thread, NULL);
-        p->feedback_thread_started = false;
-    }
+    if (!p || !p->workers_initialized) return;
+    atomic_store(&p->workers_stopping, true);
+    ap2_periodic_worker_stop(&p->mrp_worker);
+    ap2_periodic_worker_stop(&p->feedback_worker);
 }
 
 #ifdef AP2_TESTING
@@ -620,7 +591,7 @@ void ap2cl_test_stop_feedback_worker(struct ap2cl_s *p)
     ap2_feedback_stop(p);
     p->sock_fd = -1;
     p->rtsp_established = false;
-    atomic_init(&p->state, AP2_DOWN);
+    atomic_store(&p->state, AP2_DOWN);
 }
 
 int ap2cl_test_post_command(struct ap2cl_s *p)
@@ -634,14 +605,6 @@ int ap2cl_test_post_command(struct ap2cl_s *p)
     return status;
 }
 
-int ap2cl_test_parse_response(uint8_t *data, int len, int expected_cseq)
-{
-    int status = 0;
-    int header_len = 0;
-    int content_len = 0;
-    return ap2_parse_rtsp_response(
-        data, len, expected_cseq, &status, &header_len, &content_len);
-}
 #endif
 
 /* ---- Native AP2 connect helpers ---- */
@@ -896,21 +859,22 @@ static void ap2_native_setup_mrp(struct ap2cl_s *p)
                                 p->session_uuid, p->group_uuid,
                                 ap2_hap_get_shared_secret(p->hap));
     if (!p->mrp) goto done;
-    if (!ap2_mrp_attach_events(p->mrp, p->events_sock)) {
-        LOG_WARN("[MRP] event-channel attach failed; degrading to no-MRP");
-        ap2_mrp_destroy(p->mrp);
-        p->mrp = NULL;
-        goto done;
-    }
-    atomic_store(&p->mrp_event_status, 1);
-
     if (!ap2_mrp_attach(p->mrp, data_port, seed)) {
-        LOG_WARN("[MRP] data-channel attach failed; degrading to no-MRP");
+        LOG_WARN("[MRP] data-channel attach failed; continuing with /command");
         ap2_mrp_destroy(p->mrp);
         p->mrp = NULL;
         atomic_store(&p->mrp_event_status, -1);
         goto done;
     }
+    if (!ap2_mrp_attach_events(p->mrp, p->events_sock)) {
+        LOG_WARN("[MRP] event-channel attach failed; MediaRemote disabled");
+        ap2_mrp_destroy(p->mrp);
+        p->mrp = NULL;
+        atomic_store(&p->mrp_event_status, -1);
+        goto done;
+    }
+    p->events_sock = -1;
+    atomic_store(&p->mrp_event_status, 1);
     LOG_INFO("[MRP] remote-control data channel established (now-playing active)");
 done:
     pthread_mutex_unlock(&p->mrp_lock);
@@ -950,6 +914,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     }
     freeaddrinfo(res);
     atomic_store(&p->rtsp_dead, false);
+    atomic_store(&p->media_healthy, true);
 #ifdef SO_NOSIGPIPE
     int no_sigpipe = 1;
     setsockopt(p->sock_fd, SOL_SOCKET, SO_NOSIGPIPE,
@@ -1486,6 +1451,7 @@ static ap2_send_result_t ap2_send_sync_packet(struct ap2cl_s *p, bool first)
     if (p->ctrl_sock < 0) {
         LOG_ERROR("[AP2] NTP sync socket is unavailable");
         atomic_store(&p->media_healthy, false);
+        errno = ENOTCONN;
         return AP2_SEND_FATAL;
     }
 
@@ -1511,10 +1477,14 @@ static ap2_send_result_t ap2_send_sync_packet(struct ap2cl_s *p, bool first)
     uint32_t cur_ts_be = htonl(p->rtp_timestamp);
     memcpy(pkt + 16, &cur_ts_be, 4);
 
-    ap2_send_result_t result = ap2_io_send_datagram_deadline(
+    ap2_io_datagram_result_t io_result = ap2_io_send_datagram_deadline(
         p->ctrl_sock, pkt, sizeof(pkt),
         (const struct sockaddr *)&p->ctrl_addr, sizeof(p->ctrl_addr),
         ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS);
+    ap2_send_result_t result =
+        io_result == AP2_IO_DATAGRAM_SENT ? AP2_SEND_SENT :
+        io_result == AP2_IO_DATAGRAM_DROPPED ? AP2_SEND_DROPPED :
+                                               AP2_SEND_FATAL;
     if (result == AP2_SEND_SENT) {
         p->sync_packets_sent++;
     } else {
@@ -1545,6 +1515,7 @@ static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
     if (p->ctrl_sock < 0) {
         LOG_ERROR("[AP2] PTP sync socket is unavailable");
         atomic_store(&p->media_healthy, false);
+        errno = ENOTCONN;
         return AP2_SEND_FATAL;
     }
 
@@ -1586,8 +1557,11 @@ static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
     ap2_timeline_ptp_anchor_t anchor;
     if (!ap2_timeline_ptp_anchor(
             wall, p->rt_anchor_wall0, p->rt_anchor_pos0,
-            p->format.sample_rate, p->latency_ms, &anchor))
-        return;
+            p->format.sample_rate, p->latency_ms, &anchor)) {
+        atomic_store(&p->media_healthy, false);
+        errno = EINVAL;
+        return AP2_SEND_FATAL;
+    }
 
     uint32_t be = htonl(anchor.frame_1);
     memcpy(pkt + 4, &be, 4);
@@ -1606,10 +1580,14 @@ static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
     memcpy(pkt + 20, &cid_hi, 4);
     memcpy(pkt + 24, &cid_lo, 4);
 
-    ap2_send_result_t result = ap2_io_send_datagram_deadline(
+    ap2_io_datagram_result_t io_result = ap2_io_send_datagram_deadline(
         p->ctrl_sock, pkt, sizeof(pkt),
         (const struct sockaddr *)&p->ctrl_addr, sizeof(p->ctrl_addr),
         ap2_io_monotonic_ms() + AP2_UDP_SEND_TIMEOUT_MS);
+    ap2_send_result_t result =
+        io_result == AP2_IO_DATAGRAM_SENT ? AP2_SEND_SENT :
+        io_result == AP2_IO_DATAGRAM_DROPPED ? AP2_SEND_DROPPED :
+                                               AP2_SEND_FATAL;
     if (result == AP2_SEND_SENT) {
         p->sync_packets_sent++;
     } else {
@@ -1624,6 +1602,7 @@ static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
     }
     LOG_DEBUG("[AP2] TX PTP sync %s play_pos=%u wall=%" PRIu64 "ns",
               first ? "(initial)" : "", anchor.frame_1 - 11035, wall);
+    return result;
 }
 
 /* ---- Native AP2 buffered audio (type 103) ---- */
@@ -1655,6 +1634,50 @@ static int ap2_encrypt_audio_payload(
                  ctx, EVP_CTRL_AEAD_GET_TAG, AP2_CHACHA_TAG_SIZE, tag) == 1;
     EVP_CIPHER_CTX_free(ctx);
     return ok ? total : -1;
+}
+
+static ap2_send_result_t ap2_buffered_write_frame(
+    struct ap2cl_s *p, const uint8_t *frame, size_t frame_len)
+{
+    size_t offset = 0;
+    uint64_t deadline =
+        ap2_io_monotonic_ms() + AP2_BUFFERED_WRITE_TIMEOUT_MS;
+    while (offset < frame_len) {
+        if (!offset && atomic_load(&p->media_transition)) {
+            errno = EAGAIN;
+            return AP2_SEND_FATAL;
+        }
+
+        int flags = MSG_DONTWAIT;
+#ifdef MSG_NOSIGNAL
+        flags |= MSG_NOSIGNAL;
+#endif
+        ssize_t written = send(
+            p->buffered_sock, frame + offset, frame_len - offset, flags);
+        if (written > 0) {
+            offset += (size_t)written;
+            continue;
+        }
+        if (written < 0 && errno == EINTR) continue;
+        if (written < 0 &&
+            (errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS)) {
+            uint64_t now = ap2_io_monotonic_ms();
+            if (now >= deadline) {
+                errno = ETIMEDOUT;
+                return AP2_SEND_FATAL;
+            }
+            uint64_t poll_deadline = now + 50;
+            if (poll_deadline > deadline) poll_deadline = deadline;
+            int ready = ap2_io_poll_fd(
+                p->buffered_sock, POLLOUT, poll_deadline);
+            if (ready > 0) continue;
+            if (ready == 0 && poll_deadline < deadline) continue;
+            return AP2_SEND_FATAL;
+        }
+        if (written == 0) errno = EPIPE;
+        return AP2_SEND_FATAL;
+    }
+    return AP2_SEND_SENT;
 }
 
 /* Send the SETRATEANCHORTIME anchor. It pins an RTP sample number to a point on
@@ -1730,7 +1753,10 @@ static bool ap2_send_flushbuffered(struct ap2cl_s *p)
 static ap2_send_result_t ap2_buffered_send_chunk(
     struct ap2cl_s *p, uint8_t *sample, int frames)
 {
-    if (p->buffered_sock < 0 || !p->alac) return AP2_SEND_FATAL;
+    if (p->buffered_sock < 0 || !p->alac) {
+        errno = ENOTCONN;
+        return AP2_SEND_FATAL;
+    }
 
     uint8_t *encoded = NULL;
     int enc_size = 0;
@@ -1738,6 +1764,7 @@ static ap2_send_result_t ap2_buffered_send_chunk(
     if (!encoded || enc_size <= 0) {
         LOG_ERROR("[AP2] ALAC encoder failed");
         free(encoded);
+        errno = EIO;
         return AP2_SEND_FATAL;
     }
 
@@ -1745,6 +1772,7 @@ static ap2_send_result_t ap2_buffered_send_chunk(
     if (!audio_key) {
         LOG_ERROR("[AP2] No shared secret for audio encryption");
         free(encoded);
+        errno = EACCES;
         return AP2_SEND_FATAL;
     }
 
@@ -1774,6 +1802,7 @@ static ap2_send_result_t ap2_buffered_send_chunk(
     if (!frame) {
         LOG_ERROR("[AP2] Cannot allocate buffered audio frame");
         free(encoded);
+        errno = ENOMEM;
         return AP2_SEND_FATAL;
     }
     uint8_t *pkt = frame + 2;   /* payload starts after the 2-byte length prefix */
@@ -1786,6 +1815,7 @@ static ap2_send_result_t ap2_buffered_send_chunk(
     if (ct_len < 0) {
         LOG_ERROR("[AP2] Buffered audio encryption failed");
         free(frame);
+        errno = EIO;
         return AP2_SEND_FATAL;
     }
     memcpy(pkt + 12 + ct_len, tag, sizeof(tag));
@@ -1801,30 +1831,33 @@ static ap2_send_result_t ap2_buffered_send_chunk(
     frame[0] = (uint8_t)((total >> 8) & 0xFF);
     frame[1] = (uint8_t)(total & 0xFF);
 
-    bool ok = ap2_io_write_all_deadline(
-        p->buffered_sock, frame, total,
-        ap2_io_monotonic_ms() + AP2_RTSP_CONTROL_TIMEOUT_MS);
+    ap2_send_result_t write_result = ap2_buffered_write_frame(
+        p, frame, (size_t)total);
     free(frame);
 
-    if (ok) {
+    if (write_result == AP2_SEND_SENT) {
+        p->audio_nonce_counter++;
         p->first_packet = false;
         p->seq_number++;
         p->rtp_timestamp += frames;
         p->head_ts += frames;
-    } else {
+    } else if (errno != EAGAIN) {
         LOG_ERROR("[AP2] Buffered TCP write failed: %s", strerror(errno));
         shutdown(p->buffered_sock, SHUT_RDWR);
         close(p->buffered_sock);
         p->buffered_sock = -1;
     }
-    return ok ? AP2_SEND_SENT : AP2_SEND_FATAL;
+    return write_result;
 }
 
 static ap2_send_result_t ap2_native_send_chunk(
     struct ap2cl_s *p, uint8_t *sample, int frames)
 {
     if (p->use_buffered) return ap2_buffered_send_chunk(p, sample, frames);
-    if (p->data_sock < 0 || !p->alac) return AP2_SEND_FATAL;
+    if (p->data_sock < 0 || !p->alac) {
+        errno = ENOTCONN;
+        return AP2_SEND_FATAL;
+    }
 
     /* Send initial sync/anchor packet before the very first audio packet, then
      * periodically every ~100 chunks (~0.8s at 352fpp/44.1kHz). PTP sessions use
@@ -1846,6 +1879,7 @@ static ap2_send_result_t ap2_native_send_chunk(
     if (!encoded || enc_size <= 0) {
         LOG_ERROR("[AP2] ALAC encoder failed");
         free(encoded);
+        errno = EIO;
         return AP2_SEND_FATAL;
     }
 
@@ -1871,6 +1905,7 @@ static ap2_send_result_t ap2_native_send_chunk(
     if (!audio_key) {
         LOG_ERROR("[AP2] No shared secret for audio encryption");
         free(encoded);
+        errno = EACCES;
         return AP2_SEND_FATAL;
     }
 
@@ -1886,6 +1921,7 @@ static ap2_send_result_t ap2_native_send_chunk(
     if (!pkt) {
         LOG_ERROR("[AP2] Cannot allocate realtime RTP packet");
         free(encoded);
+        errno = ENOMEM;
         return AP2_SEND_FATAL;
     }
     memcpy(pkt, rtp_hdr, 12);
@@ -1897,6 +1933,7 @@ static ap2_send_result_t ap2_native_send_chunk(
     if (ct_len < 0) {
         LOG_ERROR("[AP2] Realtime audio encryption failed");
         free(pkt);
+        errno = EIO;
         return AP2_SEND_FATAL;
     }
     memcpy(pkt + 12 + ct_len, tag, sizeof(tag));
@@ -1997,7 +2034,7 @@ struct ap2cl_s *ap2cl_create(
 
     p->device = *device;
     p->format = *format;
-    p->state = AP2_DOWN;
+    atomic_init(&p->state, AP2_DOWN);
     p->latency_ms = latency_ms;
     p->volume = volume;
     p->sock_fd = -1;
@@ -2007,13 +2044,34 @@ struct ap2cl_s *ap2cl_create(
     p->buffered_sock = -1;
     pthread_mutex_init(&p->rtsp_lock, NULL);
     pthread_mutex_init(&p->mrp_lock, NULL);
+    pthread_mutex_init(&p->media_lock, NULL);
     atomic_init(&p->rtsp_dead, false);
     atomic_init(&p->rtsp_established, false);
-    atomic_init(&p->feedback_stop, true);
+    atomic_init(&p->media_healthy, true);
+    atomic_init(&p->media_transition, false);
+    atomic_init(&p->workers_stopping, true);
     atomic_init(&p->feedback_waiting, false);
     atomic_init(&p->mrp_event_status, -1);
     atomic_init(&p->mrp_pending, 0);
     p->feedback_interval_ms = AP2_FEEDBACK_INTERVAL_MS;
+    if (!ap2_periodic_worker_init(
+            &p->feedback_worker, 100, ap2_feedback_worker_tick, p)) {
+        pthread_mutex_destroy(&p->rtsp_lock);
+        pthread_mutex_destroy(&p->mrp_lock);
+        pthread_mutex_destroy(&p->media_lock);
+        free(p);
+        return NULL;
+    }
+    if (!ap2_periodic_worker_init(
+            &p->mrp_worker, 100, ap2_mrp_worker_tick, p)) {
+        ap2_periodic_worker_destroy(&p->feedback_worker);
+        pthread_mutex_destroy(&p->rtsp_lock);
+        pthread_mutex_destroy(&p->mrp_lock);
+        pthread_mutex_destroy(&p->media_lock);
+        free(p);
+        return NULL;
+    }
+    p->workers_initialized = true;
     if (dacp_id) p->dacp_id = strdup(dacp_id);
     if (active_remote) p->active_remote = strdup(active_remote);
     if (password) p->password = strdup(password);
@@ -2056,8 +2114,14 @@ bool ap2cl_destroy(struct ap2cl_s *p)
     pthread_mutex_lock(&p->rtsp_lock);
     if (p->sock_fd >= 0) { close(p->sock_fd); p->sock_fd = -1; }
     pthread_mutex_unlock(&p->rtsp_lock);
+    if (p->workers_initialized) {
+        ap2_periodic_worker_destroy(&p->mrp_worker);
+        ap2_periodic_worker_destroy(&p->feedback_worker);
+        p->workers_initialized = false;
+    }
     pthread_mutex_destroy(&p->rtsp_lock);
     pthread_mutex_destroy(&p->mrp_lock);
+    pthread_mutex_destroy(&p->media_lock);
     if (p->data_sock >= 0) close(p->data_sock);
     if (p->ctrl_sock >= 0) close(p->ctrl_sock);
     if (p->events_sock >= 0) close(p->events_sock);
@@ -2137,6 +2201,8 @@ bool ap2cl_connect(struct ap2cl_s *p)
 bool ap2cl_disconnect(struct ap2cl_s *p)
 {
     if (!p) return false;
+    atomic_store(&p->media_transition, true);
+    pthread_mutex_lock(&p->media_lock);
     if (p->flow == FLOW_NATIVE_AP2) {
         ap2_feedback_stop(p);
         atomic_store(&p->mrp_pending, 0);
@@ -2175,6 +2241,7 @@ bool ap2cl_disconnect(struct ap2cl_s *p)
         raopcl_disconnect(p->raopcl);
     }
     p->state = AP2_DOWN;
+    pthread_mutex_unlock(&p->media_lock);
     return true;
 }
 
@@ -2250,15 +2317,44 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
 ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p,
                                    uint8_t *sample, int frames)
 {
-    if (!p || p->state != AP2_STREAMING) return AP2_SEND_FATAL;
-    if (p->flow == FLOW_NATIVE_AP2) {
-        if (atomic_load(&p->rtsp_dead)) return AP2_SEND_FATAL;
-        return ap2_native_send_chunk(p, sample, frames);
+    if (!p) {
+        errno = EINVAL;
+        return AP2_SEND_FATAL;
     }
-    if (!p->raopcl) return AP2_SEND_FATAL;
-    uint64_t playtime;
-    return raopcl_send_chunk(p->raopcl, sample, frames, &playtime)
-               ? AP2_SEND_SENT : AP2_SEND_FATAL;
+    if (atomic_load(&p->media_transition)) {
+        errno = EAGAIN;
+        return AP2_SEND_FATAL;
+    }
+
+    pthread_mutex_lock(&p->media_lock);
+    if (atomic_load(&p->media_transition) ||
+        p->state != AP2_STREAMING) {
+        pthread_mutex_unlock(&p->media_lock);
+        errno = EAGAIN;
+        return AP2_SEND_FATAL;
+    }
+
+    ap2_send_result_t result;
+    if (p->flow == FLOW_NATIVE_AP2) {
+        if (atomic_load(&p->rtsp_dead)) {
+            pthread_mutex_unlock(&p->media_lock);
+            errno = ENOTCONN;
+            return AP2_SEND_FATAL;
+        }
+        result = ap2_native_send_chunk(p, sample, frames);
+    } else if (!p->raopcl) {
+        pthread_mutex_unlock(&p->media_lock);
+        errno = ENOTCONN;
+        return AP2_SEND_FATAL;
+    } else {
+        uint64_t playtime;
+        result = raopcl_send_chunk(
+                     p->raopcl, sample, frames, &playtime)
+                     ? AP2_SEND_SENT : AP2_SEND_FATAL;
+        if (result == AP2_SEND_FATAL) errno = EIO;
+    }
+    pthread_mutex_unlock(&p->media_lock);
+    return result;
 }
 
 static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
@@ -2297,9 +2393,18 @@ bool ap2cl_accept_frames(struct ap2cl_s *p)
 bool ap2cl_recover_input_gap(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->use_buffered ||
-        p->state != AP2_STREAMING)
+        p->state != AP2_STREAMING ||
+        atomic_load(&p->media_transition))
         return false;
 
+    pthread_mutex_lock(&p->media_lock);
+    if (p->state != AP2_STREAMING ||
+        atomic_load(&p->media_transition)) {
+        pthread_mutex_unlock(&p->media_lock);
+        return false;
+    }
+
+    bool recovered = false;
     uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
     uint64_t floor = MS2TS(250, p->format.sample_rate);
     uint64_t window = ap2_pacing_window_frames(p);
@@ -2313,12 +2418,12 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p)
             (uint32_t)p->head_ts + atomic_load(&p->rtp_offset) !=
                 p->rtp_timestamp)
             LOG_ERROR("[AP2] Cannot re-anchor: RTP/head invariant already broken");
-        return false;
+        goto done;
     }
     uint64_t shifted_frames = recovery.shifted_frames;
     if ((uint32_t)recovery.head + recovery.offset != p->rtp_timestamp) {
         LOG_ERROR("[AP2] Cannot re-anchor: RTP/head invariant already broken");
-        return false;
+        goto done;
     }
     p->head_ts = recovery.head;
     atomic_store(&p->rtp_offset, recovery.offset);
@@ -2331,11 +2436,14 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p)
     ap2_send_result_t sync_result =
         p->use_ptp ? ap2_send_sync_packet_ptp(p, true)
                    : ap2_send_sync_packet(p, true);
-    if (sync_result == AP2_SEND_FATAL) return false;
+    if (sync_result == AP2_SEND_FATAL) goto done;
     LOG_WARN("[AP2] Re-anchored after PCM starvation: shifted_frames=%" PRIu64
              " lead_frames=%" PRIu64 " count=%" PRIu64,
              shifted_frames, recovery_lead, p->timeline_reanchors);
-    return true;
+    recovered = true;
+done:
+    pthread_mutex_unlock(&p->media_lock);
+    return recovered;
 }
 
 void ap2cl_log_diagnostics(struct ap2cl_s *p)
@@ -2354,13 +2462,18 @@ void ap2cl_log_diagnostics(struct ap2cl_s *p)
                " audio_dropped=%" PRIu64 " sync_sent=%" PRIu64
                " sync_dropped=%" PRIu64 " anchor_valid=%d "
                "anchor_wall=%" PRIu64 " anchor_pos=%u ptp_now=%" PRIu64
-               " clock=%016" PRIx64 " reanchors=%" PRIu64,
+               " clock=%016" PRIx64 " reanchors=%" PRIu64
+               " rtsp_dead=%d media_healthy=%d event_status=%d pending=%u",
                p->state, p->use_ptp, p->use_buffered, p->seq_number,
                p->rtp_timestamp, p->head_ts, pacing_ahead, window,
                p->audio_packets_sent, p->audio_packets_dropped,
                p->sync_packets_sent, p->sync_packets_dropped,
                p->rt_anchor_valid, p->rt_anchor_wall0, p->rt_anchor_pos0,
-               ptp_now, clock_id, p->timeline_reanchors);
+               ptp_now, clock_id, p->timeline_reanchors,
+               atomic_load(&p->rtsp_dead) ? 1 : 0,
+               atomic_load(&p->media_healthy) ? 1 : 0,
+               atomic_load(&p->mrp_event_status),
+               atomic_load(&p->mrp_pending));
 }
 
 static void ap2_mrp_publish_playback_state(
@@ -2385,48 +2498,65 @@ static void ap2_mrp_publish_playback_state(
 void ap2cl_pause(struct ap2cl_s *p)
 {
     if (!p) return;
+    atomic_store(&p->media_transition, true);
+    pthread_mutex_lock(&p->media_lock);
     if (p->use_buffered && p->buffered_sock >= 0) {
         /* Freeze the buffered timeline in place with a rate-0 anchor. */
         ap2_send_setrateanchortime(p, p->rtp_timestamp, ap2_ptp_master_now_ns(p->ptp), 0);
         ap2_mrp_publish_playback_state(
             p, AP2_PAUSED, AP2_MRP_PLAYBACK_PAUSED);
-        return;
+    } else {
+        if (p->raopcl) {
+            raopcl_pause(p->raopcl);
+            raopcl_flush(p->raopcl);
+        }
+        p->rt_anchor_valid = false;    /* resume re-anchors on a fresh line */
+        ap2_mrp_publish_playback_state(
+            p, AP2_PAUSED, AP2_MRP_PLAYBACK_PAUSED);
     }
-    if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
-    p->rt_anchor_valid = false;    /* resume re-anchors on a fresh line */
-    ap2_mrp_publish_playback_state(
-        p, AP2_PAUSED, AP2_MRP_PLAYBACK_PAUSED);
+    pthread_mutex_unlock(&p->media_lock);
+    atomic_store(&p->media_transition, false);
 }
 
 void ap2cl_play(struct ap2cl_s *p)
 {
     if (!p) return;
+    atomic_store(&p->media_transition, true);
+    pthread_mutex_lock(&p->media_lock);
     if (p->use_buffered && p->buffered_sock >= 0) {
         /* Re-anchor at rate 1 a short lead ahead to resume the buffered stream. */
         uint64_t anchor_ns = ap2_ptp_master_now_ns(p->ptp) + (uint64_t)p->latency_ms * 1000000ULL;
         ap2_send_setrateanchortime(p, p->rtp_timestamp, anchor_ns, 1);
         ap2_mrp_publish_playback_state(
             p, AP2_STREAMING, AP2_MRP_PLAYBACK_PLAYING);
-        return;
+    } else {
+        if (p->raopcl) {
+            int lat = raopcl_latency(p->raopcl);
+            uint64_t now = raopcl_get_ntp(NULL);
+            raopcl_start_at(
+                p->raopcl,
+                now + MS2NTP(200) -
+                    TS2NTP(lat, raopcl_sample_rate(p->raopcl)));
+        }
+        ap2_mrp_publish_playback_state(
+            p, AP2_STREAMING, AP2_MRP_PLAYBACK_PLAYING);
     }
-    if (p->raopcl) {
-        int lat = raopcl_latency(p->raopcl);
-        uint64_t now = raopcl_get_ntp(NULL);
-        raopcl_start_at(p->raopcl, now + MS2NTP(200) - TS2NTP(lat, raopcl_sample_rate(p->raopcl)));
-    }
-    ap2_mrp_publish_playback_state(
-        p, AP2_STREAMING, AP2_MRP_PLAYBACK_PLAYING);
+    pthread_mutex_unlock(&p->media_lock);
+    atomic_store(&p->media_transition, false);
 }
 
 void ap2cl_stop(struct ap2cl_s *p)
 {
     if (!p) return;
+    atomic_store(&p->media_transition, true);
+    pthread_mutex_lock(&p->media_lock);
     if (p->use_buffered && p->buffered_sock >= 0)
         ap2_send_flushbuffered(p);
     if (p->raopcl) raopcl_stop(p->raopcl);
     ap2_mrp_publish_playback_state(
         p, AP2_DOWN, AP2_MRP_PLAYBACK_STOPPED);
     p->rt_anchor_valid = false;
+    pthread_mutex_unlock(&p->media_lock);
 }
 
 bool ap2cl_feedback(struct ap2cl_s *p)
@@ -2445,7 +2575,9 @@ bool ap2cl_feedback(struct ap2cl_s *p)
 bool ap2cl_control_healthy(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2) return true;
-    if (atomic_load(&p->rtsp_dead)) return false;
+    if (atomic_load(&p->rtsp_dead) ||
+        !atomic_load(&p->media_healthy))
+        return false;
     return atomic_load(&p->mrp_event_status) != 0;
 }
 
@@ -2551,6 +2683,7 @@ static void ap2_mrp_ready_locked(struct ap2cl_s *p)
         atomic_store(&p->mrp_event_status, -1);
         return;
     }
+    p->events_sock = -1;
     atomic_store(&p->mrp_event_status, 1);
     ap2_mrp_set_playing(p->mrp, p->state == AP2_STREAMING);
 }
@@ -2603,7 +2736,7 @@ static int ap2_mrp_post_command(struct ap2cl_s *p,
     if (!built) return -1;
     while (atomic_load(&p->feedback_waiting) &&
            !atomic_load(&p->rtsp_dead) &&
-           !atomic_load(&p->feedback_stop))
+           !atomic_load(&p->workers_stopping))
         usleep(1000);
     uint8_t *resp = NULL;
     int resp_len = 0;

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -20,7 +20,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stdatomic.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -28,6 +30,7 @@
 #include <netdb.h>
 #include <errno.h>
 #include <pthread.h>
+#include <time.h>
 
 #include <openssl/rand.h>
 #include <openssl/evp.h>
@@ -44,11 +47,13 @@
 #include "ap2_plist.h"
 #include "ap2_bplist.h"
 #include "ap2_ptp.h"
+#include "ap2_timeline.h"
 
 extern log_level *loglevel;
 
 #define AP2_FRAMES_PER_CHUNK 352
 #define AP2_CHACHA_TAG_SIZE  16
+#define AP2_RTSP_TIMEOUT_S 8
 
 typedef enum {
     FLOW_RAOP_COMPAT = 0,
@@ -91,6 +96,7 @@ struct ap2cl_s {
      * This lock serializes the cycles so a response cannot be attributed to
      * the wrong request and the HAP nonce sequence stays intact. */
     pthread_mutex_t rtsp_lock;
+    _Atomic bool rtsp_healthy;
     struct ap2_hap_ctx *hap;      /* HAP encryption context */
     struct ap2_ptp_ctx *ptp;      /* Timing */
     /* MRP now-playing over POST /command (path A, see DESIGN.md §8):
@@ -111,6 +117,12 @@ struct ap2cl_s {
     uint32_t ssrc;
     uint64_t head_ts;
     bool first_packet;
+    uint64_t audio_packets_sent;
+    uint64_t audio_packets_dropped;
+    uint64_t sync_packets_sent;
+    uint64_t sync_packets_dropped;
+    _Atomic unsigned feedback_failures;
+    uint64_t timeline_reanchors;
 
     /* Frozen realtime anchor line (PTP): the rtp<->wall mapping is fixed once
      * at stream start and every periodic time-announce extrapolates along it.
@@ -122,7 +134,7 @@ struct ap2cl_s {
     uint64_t rt_anchor_wall0;      /* master-clock ns of the anchor point */
     uint32_t rt_anchor_pos0;       /* rtp timestamp at the anchor point */
     uint64_t start_ntp;            /* shared group start (NTP fixed-point), 0 = none */
-    uint32_t rtp_offset;           /* per-process timeline offset (see start_at) */
+    _Atomic uint32_t rtp_offset;   /* effective timeline offset (see start_at) */
     uint64_t audio_nonce_counter;
     char session_url[128];
     char session_uuid[40];
@@ -150,6 +162,39 @@ static int ap2_mrp_send_playback_state(struct ap2cl_s *p,
 
 /* ---- Native AP2 RTSP I/O ---- */
 
+static uint64_t ap2_monotonic_ms(void)
+{
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return (uint64_t)now.tv_sec * 1000 + now.tv_nsec / 1000000;
+}
+
+static bool ap2_write_all(int fd, const uint8_t *data, int len)
+{
+    int off = 0;
+    while (off < len) {
+#ifdef MSG_NOSIGNAL
+        ssize_t written = send(fd, data + off, (size_t)(len - off), MSG_NOSIGNAL);
+#else
+        ssize_t written = send(fd, data + off, (size_t)(len - off), 0);
+#endif
+        if (written > 0) {
+            off += (int)written;
+        } else if (written < 0 && errno == EINTR) {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool ap2_set_nonblocking(int fd)
+{
+    int flags = fcntl(fd, F_GETFL, 0);
+    return flags >= 0 && fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+}
+
 static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, const char *uri,
                           const uint8_t *body, int body_len, const char *ct,
                           const char *extra_hdr,
@@ -166,6 +211,10 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         ct ? "Content-Type: " : "", ct ? ct : "", ct ? "\r\n" : "",
         extra_hdr ? extra_hdr : "",
         body_len);
+    if (hdr_len <= 0 || hdr_len >= (int)sizeof(hdr)) {
+        LOG_ERROR("[AP2] RTSP request headers too large for %s %s", method, uri);
+        return 0;
+    }
 
     uint8_t *msg = NULL;
     int msg_len = 0;
@@ -174,6 +223,7 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         /* Encrypt RTSP via HAP framing */
         int raw_len = hdr_len + body_len;
         uint8_t *raw = malloc(raw_len);
+        if (!raw) return 0;
         memcpy(raw, hdr, hdr_len);
         if (body && body_len > 0) memcpy(raw + hdr_len, body, body_len);
         msg_len = ap2_hap_encrypt(p->hap, raw, raw_len, &msg);
@@ -182,11 +232,17 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
     } else {
         msg_len = hdr_len + body_len;
         msg = malloc(msg_len);
+        if (!msg) return 0;
         memcpy(msg, hdr, hdr_len);
         if (body && body_len > 0) memcpy(msg + hdr_len, body, body_len);
     }
 
-    if (write(p->sock_fd, msg, msg_len) != msg_len) { free(msg); return 0; }
+    if (!ap2_write_all(p->sock_fd, msg, msg_len)) {
+        LOG_ERROR("[AP2] RTSP write failed for %s %s: %s",
+                  method, uri, strerror(errno));
+        free(msg);
+        return 0;
+    }
     free(msg);
 
     /* Read encrypted response.
@@ -194,15 +250,17 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
      * We accumulate raw bytes, then decrypt complete frames. */
     uint8_t buf[16384];
     int total = 0;
-    struct timeval tv = {.tv_sec = 8};
+    struct timeval tv = {.tv_sec = AP2_RTSP_TIMEOUT_S};
     setsockopt(p->sock_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
     if (!p->hap) {
         /* Unencrypted: simple read */
         while (total < (int)sizeof(buf) - 1) {
-            int n = read(p->sock_fd, buf + total, sizeof(buf) - total);
+            int n = read(p->sock_fd, buf + total,
+                         sizeof(buf) - 1 - (size_t)total);
             if (n <= 0) break;
             total += n;
+            buf[total] = '\0';
             char *end = strstr((char *)buf, "\r\n\r\n");
             if (end) {
                 int h_len = (end - (char *)buf) + 4;
@@ -227,9 +285,11 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
 
     /* Encrypted: read all HAP frames, then decrypt */
     while (total < (int)sizeof(buf) - 1) {
-        int n = read(p->sock_fd, buf + total, sizeof(buf) - total);
+        int n = read(p->sock_fd, buf + total,
+                     sizeof(buf) - 1 - (size_t)total);
         if (n <= 0) break;
         total += n;
+        buf[total] = '\0';
 
         /* Check if we have at least one complete HAP frame to peek at */
         if (total >= 2) {
@@ -241,6 +301,14 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
                 uint64_t saved_counter = ap2_hap_save_read_counter(p->hap);
                 int dec_len = ap2_hap_decrypt(p->hap, buf, total, &dec);
                 if (dec_len > 0 && dec) {
+                    uint8_t *terminated = realloc(dec, (size_t)dec_len + 1);
+                    if (!terminated) {
+                        free(dec);
+                        ap2_hap_restore_read_counter(p->hap, saved_counter);
+                        break;
+                    }
+                    dec = terminated;
+                    dec[dec_len] = '\0';
                     /* Check if decrypted data contains a complete RTSP response */
                     if (strstr((char *)dec, "\r\n\r\n")) {
                         int h_len = (strstr((char *)dec, "\r\n\r\n") - (char *)dec) + 4;
@@ -294,10 +362,30 @@ static int ap2_rtsp_send_ex(struct ap2cl_s *p, const char *method, const char *u
                           const char *extra_hdr,
                           uint8_t **resp_body, int *resp_len)
 {
+    uint64_t started_ms = ap2_monotonic_ms();
+    if (resp_body) *resp_body = NULL;
+    if (resp_len) *resp_len = 0;
+    if (!atomic_load(&p->rtsp_healthy)) return 0;
     pthread_mutex_lock(&p->rtsp_lock);
-    int status = ap2_rtsp_send_ex_unlocked(p, method, uri, body, body_len, ct,
+    int status = 0;
+    if (atomic_load(&p->rtsp_healthy)) {
+        status = ap2_rtsp_send_ex_unlocked(p, method, uri, body, body_len, ct,
                                            extra_hdr, resp_body, resp_len);
+        if (status == 0) {
+            /* A timed-out request may still have a late encrypted response in
+             * flight. Reusing this TCP/HAP stream would misattribute that
+             * response and desynchronize nonce counters, so fail it closed. */
+            atomic_store(&p->rtsp_healthy, false);
+            shutdown(p->sock_fd, SHUT_RDWR);
+        }
+    }
     pthread_mutex_unlock(&p->rtsp_lock);
+    uint64_t duration_ms = ap2_monotonic_ms() - started_ms;
+    LOG_SDEBUG("[AP2DIAG] RTSP %s %s -> %d duration_ms=%" PRIu64,
+               method, uri, status, duration_ms);
+    if (duration_ms >= (uint64_t)AP2_RTSP_TIMEOUT_S * 1000)
+        LOG_WARN("[AP2] Slow RTSP %s %s: status=%d duration=%" PRIu64 "ms",
+                 method, uri, status, duration_ms);
     return status;
 }
 
@@ -610,6 +698,15 @@ static bool ap2_native_connect(struct ap2cl_s *p)
         return false;
     }
     freeaddrinfo(res);
+    atomic_store(&p->rtsp_healthy, true);
+    struct timeval rtsp_tv = {.tv_sec = AP2_RTSP_TIMEOUT_S};
+    setsockopt(p->sock_fd, SOL_SOCKET, SO_SNDTIMEO, &rtsp_tv, sizeof(rtsp_tv));
+    setsockopt(p->sock_fd, SOL_SOCKET, SO_RCVTIMEO, &rtsp_tv, sizeof(rtsp_tv));
+#ifdef SO_NOSIGPIPE
+    int no_sigpipe = 1;
+    setsockopt(p->sock_fd, SOL_SOCKET, SO_NOSIGPIPE,
+               &no_sigpipe, sizeof(no_sigpipe));
+#endif
 
     /* Get local address for session URL */
     struct sockaddr_in local;
@@ -859,14 +956,28 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     /* Open UDP sockets */
     p->data_sock = socket(AF_INET, SOCK_DGRAM, 0);
     struct sockaddr_in bind_addr = {.sin_family = AF_INET, .sin_addr = p->bind_addr};
-    bind(p->data_sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr));
+    if (p->data_sock < 0 ||
+        bind(p->data_sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) != 0 ||
+        !ap2_set_nonblocking(p->data_sock)) {
+        LOG_ERROR("[AP2] Cannot create non-blocking RTP data socket: %s",
+                  strerror(errno));
+        if (p->data_sock >= 0) { close(p->data_sock); p->data_sock = -1; }
+        return false;
+    }
     struct sockaddr_in ds_local;
     len = sizeof(ds_local);
     getsockname(p->data_sock, (struct sockaddr *)&ds_local, &len);
     int local_data_port = ntohs(ds_local.sin_port);
 
     p->ctrl_sock = socket(AF_INET, SOCK_DGRAM, 0);
-    bind(p->ctrl_sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr));
+    if (p->ctrl_sock < 0 ||
+        bind(p->ctrl_sock, (struct sockaddr *)&bind_addr, sizeof(bind_addr)) != 0 ||
+        !ap2_set_nonblocking(p->ctrl_sock)) {
+        LOG_ERROR("[AP2] Cannot create non-blocking RTP control socket: %s",
+                  strerror(errno));
+        if (p->ctrl_sock >= 0) { close(p->ctrl_sock); p->ctrl_sock = -1; }
+        return false;
+    }
     struct sockaddr_in cs_local;
     len = sizeof(cs_local);
     getsockname(p->ctrl_sock, (struct sockaddr *)&cs_local, &len);
@@ -1133,8 +1244,17 @@ static void ap2_send_sync_packet(struct ap2cl_s *p, bool first)
     uint32_t cur_ts_be = htonl(p->rtp_timestamp);
     memcpy(pkt + 16, &cur_ts_be, 4);
 
-    sendto(p->ctrl_sock, pkt, sizeof(pkt), 0,
-           (struct sockaddr *)&p->ctrl_addr, sizeof(p->ctrl_addr));
+    ssize_t sent = sendto(p->ctrl_sock, pkt, sizeof(pkt), 0,
+                          (struct sockaddr *)&p->ctrl_addr,
+                          sizeof(p->ctrl_addr));
+    if (sent == (ssize_t)sizeof(pkt)) {
+        p->sync_packets_sent++;
+    } else {
+        p->sync_packets_dropped++;
+        if (p->sync_packets_dropped <= 3 ||
+            (p->sync_packets_dropped % 100) == 0)
+            LOG_WARN("[AP2] NTP sync send dropped: %s", strerror(errno));
+    }
 }
 
 /* Send AP2 PTP sync (anchor) packet (28 bytes) to the control port.
@@ -1179,14 +1299,14 @@ static void ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
                              + (((p->start_ntp & 0xFFFFFFFFULL) * 1000000000ULL) >> 32);
             p->rt_anchor_wall0 = unix_ns - (uint64_t)p->latency_ms * 1000000ULL;
             p->rt_anchor_pos0 = (uint32_t)NTP2TS(p->start_ntp, p->format.sample_rate)
-                              + p->rtp_offset;
+                              + atomic_load(&p->rtp_offset);
         } else {
             p->rt_anchor_wall0 = wall;
             p->rt_anchor_pos0 = p->rtp_timestamp;
         }
         p->rt_anchor_valid = true;
     }
-    int64_t elapsed_ns = (int64_t)(wall - p->rt_anchor_wall0)
+    int64_t elapsed_ns = (int64_t)wall - (int64_t)p->rt_anchor_wall0
                        - (int64_t)p->latency_ms * 1000000LL;
     uint32_t play_pos = p->rt_anchor_pos0
                       + (uint32_t)((elapsed_ns * p->format.sample_rate) / 1000000000LL);
@@ -1210,8 +1330,17 @@ static void ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
     memcpy(pkt + 20, &cid_hi, 4);
     memcpy(pkt + 24, &cid_lo, 4);
 
-    sendto(p->ctrl_sock, pkt, sizeof(pkt), 0,
-           (struct sockaddr *)&p->ctrl_addr, sizeof(p->ctrl_addr));
+    ssize_t sent = sendto(p->ctrl_sock, pkt, sizeof(pkt), 0,
+                          (struct sockaddr *)&p->ctrl_addr,
+                          sizeof(p->ctrl_addr));
+    if (sent == (ssize_t)sizeof(pkt)) {
+        p->sync_packets_sent++;
+    } else {
+        p->sync_packets_dropped++;
+        if (p->sync_packets_dropped <= 3 ||
+            (p->sync_packets_dropped % 100) == 0)
+            LOG_WARN("[AP2] PTP sync send dropped: %s", strerror(errno));
+    }
     LOG_DEBUG("[AP2] TX PTP sync %s play_pos=%u wall=%" PRIu64 "ns",
               first ? "(initial)" : "", play_pos, wall);
 }
@@ -1460,11 +1589,25 @@ static bool ap2_native_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames
                            (struct sockaddr *)&p->data_addr, sizeof(p->data_addr));
     free(pkt);
 
+    bool delivered = sent == actual_pkt_size;
+    if (delivered) {
+        p->audio_packets_sent++;
+    } else {
+        p->audio_packets_dropped++;
+        if (p->audio_packets_dropped <= 3 ||
+            (p->audio_packets_dropped % 100) == 0)
+            LOG_WARN("[AP2] RTP send dropped: sent=%zd expected=%d error=%s",
+                     sent, actual_pkt_size,
+                     sent < 0 ? strerror(errno) : "short datagram");
+    }
+    /* Realtime RTP follows the wall timeline even when the local UDP queue
+     * drops a packet; advancing exposes a sequence gap instead of replaying an
+     * old timestamp late. */
     p->seq_number++;
     p->rtp_timestamp += frames;
     p->head_ts += frames;
 
-    return sent > 0;
+    return delivered;
 }
 
 /* ---- RAOP-compat connect ---- */
@@ -1691,12 +1834,14 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
          * Sonos household stream tracking then cross-wires them and one
          * device goes silent. The anchor line carries the same offset, so
          * the audible schedule is untouched. */
-        p->rtp_offset = (uint32_t)(getpid() * 2654435761u) & 0x0FFFFF00u;
+        atomic_store(&p->rtp_offset,
+                     (uint32_t)(getpid() * 2654435761u) & 0x0FFFFF00u);
         /* head_ts stays in the pure scheduling domain (pacing compares it to
          * the wall frame clock); the offset is applied only to the on-wire
          * RTP timestamps and the anchor, which advance in lockstep. */
         p->head_ts = NTP2TS(ntp_start, p->format.sample_rate);
-        p->rtp_timestamp = (uint32_t)p->head_ts + p->rtp_offset;
+        p->rtp_timestamp = (uint32_t)p->head_ts +
+                           atomic_load(&p->rtp_offset);
         p->seq_number = (uint16_t)(getpid() * 40503u);
         p->start_ntp = ntp_start;
         p->state = AP2_STREAMING;
@@ -1756,6 +1901,11 @@ bool ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames)
     return raopcl_send_chunk(p->raopcl, sample, frames, &playtime);
 }
 
+static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
+{
+    return p->dev_latency_max > 11025 ? p->dev_latency_max - 11025 : 77175;
+}
+
 bool ap2cl_accept_frames(struct ap2cl_s *p)
 {
     if (!p || p->state != AP2_STREAMING) return false;
@@ -1777,12 +1927,80 @@ bool ap2cl_accept_frames(struct ap2cl_s *p)
          * matter how far ahead the start lies. */
         uint64_t now_ntp = raopcl_get_ntp(NULL);
         uint64_t now_ts = NTP2TS(now_ntp, p->format.sample_rate);
-        uint64_t window = p->dev_latency_max > 11025
-                          ? p->dev_latency_max - 11025 : 77175;
+        uint64_t window = ap2_pacing_window_frames(p);
         return (now_ts + window) >= p->head_ts;
     }
     if (!p->raopcl) return false;
     return raopcl_accept_frames(p->raopcl);
+}
+
+bool ap2cl_recover_input_gap(struct ap2cl_s *p)
+{
+    if (!p || p->flow != FLOW_NATIVE_AP2 || p->use_buffered ||
+        p->state != AP2_STREAMING)
+        return false;
+
+    uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
+    uint64_t floor = MS2TS(250, p->format.sample_rate);
+    uint64_t window = ap2_pacing_window_frames(p);
+    uint64_t latency = MS2TS(p->latency_ms, p->format.sample_rate);
+    uint64_t recovery_lead = latency < window ? latency : window;
+    ap2_timeline_recovery_t recovery;
+    if (!ap2_timeline_plan_recovery(
+            p->head_ts, p->rtp_timestamp, atomic_load(&p->rtp_offset),
+            now_ts, floor, recovery_lead, &recovery)) {
+        if (p->head_ts <= now_ts + floor &&
+            (uint32_t)p->head_ts + atomic_load(&p->rtp_offset) !=
+                p->rtp_timestamp)
+            LOG_ERROR("[AP2] Cannot re-anchor: RTP/head invariant already broken");
+        return false;
+    }
+    uint64_t shifted_frames = recovery.shifted_frames;
+    if ((uint32_t)recovery.head + recovery.offset != p->rtp_timestamp) {
+        LOG_ERROR("[AP2] Cannot re-anchor: RTP/head invariant already broken");
+        return false;
+    }
+    p->head_ts = recovery.head;
+    atomic_store(&p->rtp_offset, recovery.offset);
+    if (p->use_ptp && p->rt_anchor_valid) {
+        uint64_t shift_ns =
+            (shifted_frames / (uint64_t)p->format.sample_rate) * 1000000000ULL +
+            ((shifted_frames % (uint64_t)p->format.sample_rate) *
+             1000000000ULL) / (uint64_t)p->format.sample_rate;
+        p->rt_anchor_wall0 += shift_ns;
+    }
+    p->timeline_reanchors++;
+    if (p->use_ptp) ap2_send_sync_packet_ptp(p, true);
+    else ap2_send_sync_packet(p, true);
+    LOG_WARN("[AP2] Re-anchored after PCM starvation: shifted_frames=%" PRIu64
+             " lead_frames=%" PRIu64 " count=%" PRIu64,
+             shifted_frames, recovery_lead, p->timeline_reanchors);
+    return true;
+}
+
+void ap2cl_log_diagnostics(struct ap2cl_s *p)
+{
+    if (!p || p->flow != FLOW_NATIVE_AP2 || *loglevel < lSDEBUG) return;
+    uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
+    int64_t pacing_ahead = p->head_ts >= now_ts
+                               ? (int64_t)(p->head_ts - now_ts)
+                               : -(int64_t)(now_ts - p->head_ts);
+    uint64_t window = ap2_pacing_window_frames(p);
+    uint64_t ptp_now = p->use_ptp ? ap2_ptp_master_now_ns(p->ptp) : 0;
+    uint64_t clock_id = p->use_ptp ? ap2_ptp_master_clock_id(p->ptp) : 0;
+    LOG_SDEBUG("[AP2DIAG] state=%d ptp=%d buffered=%d seq=%u rtp=%u "
+               "head=%" PRIu64 " pacing_ahead_frames=%" PRId64
+               " window_frames=%" PRIu64 " audio_sent=%" PRIu64
+               " audio_dropped=%" PRIu64 " sync_sent=%" PRIu64
+               " sync_dropped=%" PRIu64 " anchor_valid=%d "
+               "anchor_wall=%" PRIu64 " anchor_pos=%u ptp_now=%" PRIu64
+               " clock=%016" PRIx64 " reanchors=%" PRIu64,
+               p->state, p->use_ptp, p->use_buffered, p->seq_number,
+               p->rtp_timestamp, p->head_ts, pacing_ahead, window,
+               p->audio_packets_sent, p->audio_packets_dropped,
+               p->sync_packets_sent, p->sync_packets_dropped,
+               p->rt_anchor_valid, p->rt_anchor_wall0, p->rt_anchor_pos0,
+               ptp_now, clock_id, p->timeline_reanchors);
 }
 
 void ap2cl_pause(struct ap2cl_s *p)
@@ -1853,14 +2071,36 @@ bool ap2cl_feedback(struct ap2cl_s *p)
      * is raopcl_keepalive(). The response body carries stream status we do
      * not need; the POST itself is what resets the receiver's idle timer. */
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return false;
-    /* Ride the same 2s cadence to answer encrypted reverse event requests and,
-     * when enabled, drain the type-130 channel. */
-    if (p->mrp) ap2_mrp_tick(p->mrp);
     uint8_t *resp = NULL; int resp_len = 0;
     int status = ap2_rtsp_send(p, "POST", "/feedback", NULL, 0, NULL, &resp, &resp_len);
     free(resp);
     LOG_DEBUG("[AP2] /feedback keepalive -> %d", status);
+    if (status == 200) {
+        unsigned failures = atomic_exchange(&p->feedback_failures, 0);
+        if (failures)
+            LOG_INFO("[AP2] /feedback recovered after %u failure(s)",
+                     failures);
+    } else {
+        unsigned failures = atomic_fetch_add(&p->feedback_failures, 1) + 1;
+        if (failures <= 3 || (failures % 10) == 0)
+            LOG_WARN("[AP2] /feedback failed: status=%d consecutive=%u",
+                     status, failures);
+    }
     return status == 200;
+}
+
+void ap2cl_tick(struct ap2cl_s *p)
+{
+    if (p && p->mrp) ap2_mrp_tick(p->mrp);
+}
+
+bool ap2cl_control_healthy(struct ap2cl_s *p)
+{
+    if (!p || p->flow != FLOW_NATIVE_AP2) return true;
+    if (!atomic_load(&p->rtsp_healthy) ||
+        atomic_load(&p->feedback_failures) >= 3)
+        return false;
+    return !p->mrp || ap2_mrp_event_status(p->mrp) != 0;
 }
 
 bool ap2cl_set_volume(struct ap2cl_s *p, int volume)
@@ -2171,7 +2411,7 @@ bool ap2cl_set_progress(struct ap2cl_s *p, int elapsed_s, int duration_s)
          * units (the per-process timeline offset included, so the values match
          * the timestamps the receiver sees on the audio packets). */
         uint32_t now_w = (uint32_t)NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate)
-                       + p->rtp_offset;
+                       + atomic_load(&p->rtp_offset);
         uint32_t start = now_w - (uint32_t)((uint64_t)elapsed_s * p->format.sample_rate);
         uint32_t end = duration_s
                        ? start + (uint32_t)((uint64_t)duration_s * p->format.sample_rate)

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -18,7 +18,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "ap2_io.h"
 #include <netinet/in.h>
 
 struct ap2cl_s;
@@ -175,7 +174,6 @@ bool ap2cl_test_attach_mrp(struct ap2cl_s *p, int event_socket,
                            const uint8_t shared_secret[32]);
 void ap2cl_test_stop_feedback_worker(struct ap2cl_s *p);
 int ap2cl_test_post_command(struct ap2cl_s *p);
-int ap2cl_test_parse_response(uint8_t *data, int len, int expected_cseq);
 #endif
 
 /* Emit a debug-level snapshot of RTP pacing/timeline/send health. */

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -17,6 +17,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+
+#include "ap2_io.h"
 #include <netinet/in.h>
 
 struct ap2cl_s;
@@ -128,11 +130,13 @@ bool ap2cl_disconnect(struct ap2cl_s *p);
 bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start);
 
 /* Send a chunk of PCM audio data.
- * Returns true on success.
+ * Returns AP2_SEND_SENT, AP2_SEND_DROPPED for transient realtime UDP
+ * backpressure (the timeline still advances), or AP2_SEND_FATAL.
  * :param sample: Raw PCM audio bytes (interleaved, little-endian).
  * :param frames: Number of audio frames in the sample buffer.
  */
-bool ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames);
+ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample,
+                                   int frames);
 
 /* Check if the client is ready to accept more audio frames. */
 bool ap2cl_accept_frames(struct ap2cl_s *p);
@@ -150,15 +154,9 @@ void ap2cl_play(struct ap2cl_s *p);
 /* Stop playback. */
 void ap2cl_stop(struct ap2cl_s *p);
 
-/* Session keepalive: POST /feedback over the encrypted RTSP channel, as real
- * Apple senders do every ~2 s (long sessions can otherwise hit receiver-side
- * idle timeouts). Native AP2 flow only; a no-op returning false otherwise.
- * Returns true when the receiver answered 200. */
+/* Issue one immediate native-session feedback request. Normal session
+ * maintenance is owned by the client's dedicated worker. */
 bool ap2cl_feedback(struct ap2cl_s *p);
-
-/* Service non-RTSP session channels without blocking on a feedback request.
- * Call regularly (about once per second) for native AP2 sessions. */
-void ap2cl_tick(struct ap2cl_s *p);
 
 /* False when the encrypted RTSP channel is unusable or feedback repeatedly
  * fails. The caller should terminate so its supervisor can reconnect. */

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -137,6 +137,10 @@ bool ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample, int frames);
 /* Check if the client is ready to accept more audio frames. */
 bool ap2cl_accept_frames(struct ap2cl_s *p);
 
+/* If PCM starvation exhausted the receiver lead, move the realtime deadline
+ * and PTP anchor forward so resumed samples are not permanently late. */
+bool ap2cl_recover_input_gap(struct ap2cl_s *p);
+
 /* Pause playback. */
 void ap2cl_pause(struct ap2cl_s *p);
 
@@ -151,6 +155,17 @@ void ap2cl_stop(struct ap2cl_s *p);
  * idle timeouts). Native AP2 flow only; a no-op returning false otherwise.
  * Returns true when the receiver answered 200. */
 bool ap2cl_feedback(struct ap2cl_s *p);
+
+/* Service non-RTSP session channels without blocking on a feedback request.
+ * Call regularly (about once per second) for native AP2 sessions. */
+void ap2cl_tick(struct ap2cl_s *p);
+
+/* False when the encrypted RTSP channel is unusable or feedback repeatedly
+ * fails. The caller should terminate so its supervisor can reconnect. */
+bool ap2cl_control_healthy(struct ap2cl_s *p);
+
+/* Emit a debug-level snapshot of RTP pacing/timeline/send health. */
+void ap2cl_log_diagnostics(struct ap2cl_s *p);
 
 /* Set volume (0-100). */
 bool ap2cl_set_volume(struct ap2cl_s *p, int volume);

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -129,14 +129,20 @@ bool ap2cl_disconnect(struct ap2cl_s *p);
 /* Start playback at the given NTP timestamp. */
 bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start);
 
+typedef enum {
+    AP2_SEND_FATAL = -1,
+    AP2_SEND_DROPPED = 0,
+    AP2_SEND_SENT = 1,
+} ap2_send_result_t;
+
 /* Send a chunk of PCM audio data.
- * Returns AP2_SEND_SENT, AP2_SEND_DROPPED for transient realtime UDP
- * backpressure (the timeline still advances), or AP2_SEND_FATAL.
+ * A transient realtime UDP drop still consumes the chunk and advances the RTP
+ * timeline; callers must only terminate playback for AP2_SEND_FATAL.
  * :param sample: Raw PCM audio bytes (interleaved, little-endian).
  * :param frames: Number of audio frames in the sample buffer.
  */
-ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample,
-                                   int frames);
+ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p,
+                                   uint8_t *sample, int frames);
 
 /* Check if the client is ready to accept more audio frames. */
 bool ap2cl_accept_frames(struct ap2cl_s *p);
@@ -162,6 +168,16 @@ bool ap2cl_feedback(struct ap2cl_s *p);
  * fails. The caller should terminate so its supervisor can reconnect. */
 bool ap2cl_control_healthy(struct ap2cl_s *p);
 
+#ifdef AP2_TESTING
+bool ap2cl_test_start_feedback_worker(struct ap2cl_s *p, int socket_fd,
+                                      int interval_ms);
+bool ap2cl_test_attach_mrp(struct ap2cl_s *p, int event_socket,
+                           const uint8_t shared_secret[32]);
+void ap2cl_test_stop_feedback_worker(struct ap2cl_s *p);
+int ap2cl_test_post_command(struct ap2cl_s *p);
+int ap2cl_test_parse_response(uint8_t *data, int len, int expected_cseq);
+#endif
+
 /* Emit a debug-level snapshot of RTP pacing/timeline/send health. */
 void ap2cl_log_diagnostics(struct ap2cl_s *p);
 
@@ -178,10 +194,10 @@ bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size, co
 /* Set playback progress. */
 bool ap2cl_set_progress(struct ap2cl_s *p, int elapsed_s, int duration_s);
 
-/* Push the current now-playing state and any pending MediaRemote extended
- * metadata over POST /command. Enabled for pair-verified native sessions;
- * CLIAIRPLAY_MRP=0 disables it. Returns the HTTP status, 0 on registration
- * failure, or -1 when the push does not apply to this session. */
+/* Queue the current now-playing state and any pending MediaRemote extended
+ * metadata for POST /command. Enabled for pair-verified native sessions;
+ * CLIAIRPLAY_MRP=0 disables it. Returns 202 when queued or -1 when the push
+ * does not apply to this session; receiver responses are logged by the worker. */
 int ap2cl_mrp_push(struct ap2cl_s *p);
 
 /* Status of the type-130 MRP data channel (path B) for the [STATUS] mrp line:
@@ -189,9 +205,9 @@ int ap2cl_mrp_push(struct ap2cl_s *p);
  * 1 = channel established. */
 int ap2cl_mrp_channel_status(struct ap2cl_s *p);
 
-/* Perform the /command DEVICE_INFO origin registration before now-playing.
- * Extended metadata is sent immediately after the first now-playing update.
- * Returns 1 (2xx), 0, or -1 (not applicable). */
+/* Queue /command DEVICE_INFO origin registration before now-playing.
+ * Extended metadata is sent after the first queued now-playing update.
+ * Returns 202 when queued or -1 when not applicable. */
 int ap2cl_mrp_register(struct ap2cl_s *p);
 
 /* Set RAOP-compatible properties (mDNS fields, interface, credentials).

--- a/src/ap2_feedback.c
+++ b/src/ap2_feedback.c
@@ -6,10 +6,15 @@
 
 #include "ap2_io.h"
 
-static struct timespec ap2_realtime_after_ms(uint64_t delay_ms)
+static struct timespec ap2_after_ms(uint64_t delay_ms)
 {
     struct timespec deadline;
-    clock_gettime(CLOCK_REALTIME, &deadline);
+#ifdef __APPLE__
+    deadline.tv_sec = 0;
+    deadline.tv_nsec = 0;
+#else
+    clock_gettime(CLOCK_MONOTONIC, &deadline);
+#endif
     deadline.tv_sec += (time_t)(delay_ms / 1000);
     deadline.tv_nsec += (long)(delay_ms % 1000) * 1000000L;
     if (deadline.tv_nsec >= 1000000000L) {
@@ -30,8 +35,13 @@ static void *ap2_periodic_worker_main(void *arg)
         if (now < next_tick) {
             uint64_t delay = next_tick - now;
             if (delay > 100) delay = 100;
-            struct timespec deadline = ap2_realtime_after_ms(delay);
+            struct timespec deadline = ap2_after_ms(delay);
+#ifdef __APPLE__
+            pthread_cond_timedwait_relative_np(
+                &worker->wake, &worker->lock, &deadline);
+#else
             pthread_cond_timedwait(&worker->wake, &worker->lock, &deadline);
+#endif
             continue;
         }
 
@@ -58,10 +68,24 @@ bool ap2_periodic_worker_init(ap2_periodic_worker_t *worker,
     worker->callback = callback;
     worker->arg = arg;
     if (pthread_mutex_init(&worker->lock, NULL) != 0) return false;
-    if (pthread_cond_init(&worker->wake, NULL) != 0) {
+    pthread_condattr_t attr;
+    if (pthread_condattr_init(&attr) != 0) {
         pthread_mutex_destroy(&worker->lock);
         return false;
     }
+#ifndef __APPLE__
+    if (pthread_condattr_setclock(&attr, CLOCK_MONOTONIC) != 0) {
+        pthread_condattr_destroy(&attr);
+        pthread_mutex_destroy(&worker->lock);
+        return false;
+    }
+#endif
+    if (pthread_cond_init(&worker->wake, &attr) != 0) {
+        pthread_condattr_destroy(&attr);
+        pthread_mutex_destroy(&worker->lock);
+        return false;
+    }
+    pthread_condattr_destroy(&attr);
     return true;
 }
 

--- a/src/ap2_feedback.c
+++ b/src/ap2_feedback.c
@@ -1,0 +1,99 @@
+#include "ap2_feedback.h"
+
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+
+#include "ap2_io.h"
+
+static struct timespec ap2_realtime_after_ms(uint64_t delay_ms)
+{
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += (time_t)(delay_ms / 1000);
+    deadline.tv_nsec += (long)(delay_ms % 1000) * 1000000L;
+    if (deadline.tv_nsec >= 1000000000L) {
+        deadline.tv_sec++;
+        deadline.tv_nsec -= 1000000000L;
+    }
+    return deadline;
+}
+
+static void *ap2_periodic_worker_main(void *arg)
+{
+    ap2_periodic_worker_t *worker = arg;
+    uint64_t next_tick = ap2_io_monotonic_ms() + worker->interval_ms;
+
+    pthread_mutex_lock(&worker->lock);
+    while (!worker->stop) {
+        uint64_t now = ap2_io_monotonic_ms();
+        if (now < next_tick) {
+            uint64_t delay = next_tick - now;
+            if (delay > 100) delay = 100;
+            struct timespec deadline = ap2_realtime_after_ms(delay);
+            pthread_cond_timedwait(&worker->wake, &worker->lock, &deadline);
+            continue;
+        }
+
+        pthread_mutex_unlock(&worker->lock);
+        bool keep_running = worker->callback(worker->arg);
+        pthread_mutex_lock(&worker->lock);
+        if (!keep_running) worker->stop = true;
+
+        now = ap2_io_monotonic_ms();
+        next_tick += worker->interval_ms;
+        if (next_tick <= now) next_tick = now + worker->interval_ms;
+    }
+    pthread_mutex_unlock(&worker->lock);
+    return NULL;
+}
+
+bool ap2_periodic_worker_init(ap2_periodic_worker_t *worker,
+                              unsigned interval_ms,
+                              ap2_periodic_callback_t callback, void *arg)
+{
+    if (!worker || !interval_ms || !callback) return false;
+    memset(worker, 0, sizeof(*worker));
+    worker->interval_ms = interval_ms;
+    worker->callback = callback;
+    worker->arg = arg;
+    if (pthread_mutex_init(&worker->lock, NULL) != 0) return false;
+    if (pthread_cond_init(&worker->wake, NULL) != 0) {
+        pthread_mutex_destroy(&worker->lock);
+        return false;
+    }
+    return true;
+}
+
+bool ap2_periodic_worker_start(ap2_periodic_worker_t *worker)
+{
+    if (!worker || worker->started) return false;
+    worker->stop = false;
+    int error = pthread_create(&worker->thread, NULL,
+                               ap2_periodic_worker_main, worker);
+    if (error != 0) {
+        errno = error;
+        return false;
+    }
+    worker->started = true;
+    return true;
+}
+
+void ap2_periodic_worker_stop(ap2_periodic_worker_t *worker)
+{
+    if (!worker || !worker->started) return;
+    pthread_mutex_lock(&worker->lock);
+    worker->stop = true;
+    pthread_cond_broadcast(&worker->wake);
+    pthread_mutex_unlock(&worker->lock);
+    pthread_join(worker->thread, NULL);
+    worker->started = false;
+}
+
+void ap2_periodic_worker_destroy(ap2_periodic_worker_t *worker)
+{
+    if (!worker) return;
+    ap2_periodic_worker_stop(worker);
+    pthread_cond_destroy(&worker->wake);
+    pthread_mutex_destroy(&worker->lock);
+}

--- a/src/ap2_feedback.h
+++ b/src/ap2_feedback.h
@@ -1,0 +1,27 @@
+#ifndef __AP2_FEEDBACK_H_
+#define __AP2_FEEDBACK_H_
+
+#include <stdbool.h>
+#include <pthread.h>
+
+typedef bool (*ap2_periodic_callback_t)(void *arg);
+
+typedef struct {
+    pthread_t thread;
+    pthread_mutex_t lock;
+    pthread_cond_t wake;
+    ap2_periodic_callback_t callback;
+    void *arg;
+    unsigned interval_ms;
+    bool stop;
+    bool started;
+} ap2_periodic_worker_t;
+
+bool ap2_periodic_worker_init(ap2_periodic_worker_t *worker,
+                              unsigned interval_ms,
+                              ap2_periodic_callback_t callback, void *arg);
+bool ap2_periodic_worker_start(ap2_periodic_worker_t *worker);
+void ap2_periodic_worker_stop(ap2_periodic_worker_t *worker);
+void ap2_periodic_worker_destroy(ap2_periodic_worker_t *worker);
+
+#endif

--- a/src/ap2_hap.c
+++ b/src/ap2_hap.c
@@ -1388,7 +1388,7 @@ int ap2_hap_decrypt(struct ap2_hap_ctx *ctx, const uint8_t *in, int in_len,
     if (!ctx || !ctx->verified || !in || in_len <= 0) return -1;
 
     /* Worst case: output is slightly smaller than input */
-    *out = malloc(in_len);
+    *out = malloc((size_t)in_len + 1);
     if (!*out) return -1;
 
     int out_offset = 0, in_offset = 0;
@@ -1426,5 +1426,6 @@ int ap2_hap_decrypt(struct ap2_hap_ctx *ctx, const uint8_t *in, int in_len,
         in_offset += chunk + HAP_TAG_SIZE;
     }
 
+    (*out)[out_offset] = '\0';
     return out_offset;
 }

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -2,7 +2,12 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 #include <time.h>
 
 uint64_t ap2_io_monotonic_ms(void)
@@ -28,7 +33,8 @@ int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms)
             errno = ETIMEDOUT;
             return 0;
         }
-        int timeout = (int)(deadline_ms - now);
+        uint64_t remaining = deadline_ms - now;
+        int timeout = remaining > INT_MAX ? INT_MAX : (int)remaining;
         struct pollfd pfd = {.fd = fd, .events = events};
         int ret = poll(&pfd, 1, timeout);
         if (ret < 0 && errno == EINTR) continue;
@@ -53,7 +59,7 @@ static int ap2_io_send_flags(void)
     return flags;
 }
 
-bool ap2_io_write_all_deadline(int fd, const uint8_t *data, int len,
+bool ap2_io_write_all_deadline(int fd, const uint8_t *data, size_t len,
                                uint64_t deadline_ms)
 {
     int original_flags = fcntl(fd, F_GETFL);
@@ -64,15 +70,18 @@ bool ap2_io_write_all_deadline(int fd, const uint8_t *data, int len,
         return false;
 
     bool ok = false;
-    int off = 0;
+    size_t off = 0;
     while (off < len) {
+        if (ap2_io_monotonic_ms() >= deadline_ms) {
+            errno = ETIMEDOUT;
+            break;
+        }
         if (ap2_io_poll_fd(fd, POLLOUT, deadline_ms) <= 0) break;
-        ssize_t n = send(fd, data + off, (size_t)(len - off),
-                         ap2_io_send_flags());
+        ssize_t n = send(fd, data + off, len - off, ap2_io_send_flags());
         if (n > 0) {
-            off += (int)n;
+            off += (size_t)n;
         } else if (n < 0 && (errno == EINTR || errno == EAGAIN ||
-                             errno == EWOULDBLOCK)) {
+                             errno == EWOULDBLOCK || errno == ENOBUFS)) {
             continue;
         } else {
             if (n == 0) errno = EPIPE;
@@ -138,12 +147,113 @@ ap2_io_datagram_result_t ap2_io_send_datagram_deadline(
             }
             continue;
         }
-        if (errno == ENOBUFS) return AP2_IO_DATAGRAM_DROPPED;
-        if (errno != EAGAIN && errno != EWOULDBLOCK)
+        if (errno != EAGAIN && errno != EWOULDBLOCK && errno != ENOBUFS)
             return AP2_IO_DATAGRAM_FATAL;
         int ready = ap2_io_poll_fd(fd, POLLOUT, deadline_ms);
         if (ready > 0) continue;
         if (ready == 0) return AP2_IO_DATAGRAM_DROPPED;
         return AP2_IO_DATAGRAM_FATAL;
     }
+}
+
+static size_t ap2_find_header_end(const uint8_t *data, size_t len)
+{
+    for (size_t i = 0; i + 3 < len; i++) {
+        if (data[i] == '\r' && data[i + 1] == '\n' &&
+            data[i + 2] == '\r' && data[i + 3] == '\n')
+            return i + 4;
+    }
+    return 0;
+}
+
+static bool ap2_parse_decimal(const uint8_t *data, size_t len, long *value)
+{
+    if (!len || len >= 32) return false;
+    char text[32];
+    memcpy(text, data, len);
+    text[len] = '\0';
+    char *end = NULL;
+    errno = 0;
+    long parsed = strtol(text, &end, 10);
+    if (errno || end == text || *end != '\0' || parsed < 0) return false;
+    *value = parsed;
+    return true;
+}
+
+int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
+                               ap2_rtsp_response_t *response)
+{
+    if (!data || !response) return -1;
+    size_t header_len = ap2_find_header_end(data, len);
+    if (!header_len) return 0;
+
+    const uint8_t *line_end = NULL;
+    for (size_t i = 0; i + 1 < header_len; i++) {
+        if (data[i] == '\r' && data[i + 1] == '\n') {
+            line_end = data + i;
+            break;
+        }
+    }
+    if (!line_end) return -1;
+
+    int status = 0;
+    char status_line[128];
+    size_t status_len = (size_t)(line_end - data);
+    if (status_len >= sizeof(status_line)) return -1;
+    memcpy(status_line, data, status_len);
+    status_line[status_len] = '\0';
+    if (sscanf(status_line, "RTSP/%*s %d", &status) != 1 || status <= 0)
+        return -1;
+
+    size_t body_len = 0;
+    int cseq = -1;
+    size_t offset = status_len + 2;
+    while (offset + 2 <= header_len) {
+        size_t end = offset;
+        while (end + 1 < header_len &&
+               !(data[end] == '\r' && data[end + 1] == '\n'))
+            end++;
+        if (end == offset) break;
+
+        size_t colon = offset;
+        while (colon < end && data[colon] != ':') colon++;
+        if (colon == end) return -1;
+        size_t value = colon + 1;
+        while (value < end && (data[value] == ' ' || data[value] == '\t'))
+            value++;
+        size_t value_end = end;
+        while (value_end > value &&
+               (data[value_end - 1] == ' ' || data[value_end - 1] == '\t'))
+            value_end--;
+
+        long parsed = 0;
+        size_t name_len = colon - offset;
+        if (name_len == 14 &&
+            strncasecmp((const char *)data + offset,
+                        "Content-Length", 14) == 0) {
+            if (!ap2_parse_decimal(
+                    data + value, value_end - value, &parsed))
+                return -1;
+            body_len = (size_t)parsed;
+        } else if (name_len == 4 &&
+                   strncasecmp((const char *)data + offset,
+                               "CSeq", 4) == 0) {
+            if (!ap2_parse_decimal(
+                    data + value, value_end - value, &parsed) ||
+                parsed > INT_MAX)
+                return -1;
+            cseq = (int)parsed;
+        }
+        offset = end + 2;
+    }
+
+    if (body_len > SIZE_MAX - header_len) return -1;
+    size_t message_len = header_len + body_len;
+    if (len < message_len) return 0;
+    response->status = status;
+    response->cseq = cseq;
+    response->header_len = header_len;
+    response->body_len = body_len;
+    response->message_len = message_len;
+    return 1;
 }

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -2,19 +2,22 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <limits.h>
 #include <poll.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <strings.h>
 #include <time.h>
 
 uint64_t ap2_io_monotonic_ms(void)
 {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)ts.tv_nsec / 1000000ULL;
+    return (uint64_t)ts.tv_sec * 1000ULL +
+           (uint64_t)ts.tv_nsec / 1000000ULL;
+}
+
+bool ap2_io_set_nonblocking(int fd)
+{
+    int flags = fcntl(fd, F_GETFL, 0);
+    return flags >= 0 && (flags & O_NONBLOCK ||
+                          fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0);
 }
 
 int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms)
@@ -25,14 +28,13 @@ int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms)
             errno = ETIMEDOUT;
             return 0;
         }
-        uint64_t remaining = deadline_ms - now;
-        int timeout = remaining > INT_MAX ? INT_MAX : (int)remaining;
+        int timeout = (int)(deadline_ms - now);
         struct pollfd pfd = {.fd = fd, .events = events};
-        int status = poll(&pfd, 1, timeout);
-        if (status < 0 && errno == EINTR) continue;
-        if (status <= 0) {
-            if (status == 0) errno = ETIMEDOUT;
-            return status;
+        int ret = poll(&pfd, 1, timeout);
+        if (ret < 0 && errno == EINTR) continue;
+        if (ret <= 0) {
+            if (ret == 0) errno = ETIMEDOUT;
+            return ret;
         }
         if (pfd.revents & events) return 1;
         if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
@@ -42,7 +44,16 @@ int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms)
     }
 }
 
-bool ap2_io_write_all_deadline(int fd, const uint8_t *data, size_t len,
+static int ap2_io_send_flags(void)
+{
+    int flags = MSG_DONTWAIT;
+#ifdef MSG_NOSIGNAL
+    flags |= MSG_NOSIGNAL;
+#endif
+    return flags;
+}
+
+bool ap2_io_write_all_deadline(int fd, const uint8_t *data, int len,
                                uint64_t deadline_ms)
 {
     int original_flags = fcntl(fd, F_GETFL);
@@ -53,31 +64,22 @@ bool ap2_io_write_all_deadline(int fd, const uint8_t *data, size_t len,
         return false;
 
     bool ok = false;
-    size_t offset = 0;
-    while (offset < len) {
-        if (ap2_io_monotonic_ms() >= deadline_ms) {
-            errno = ETIMEDOUT;
-            break;
-        }
+    int off = 0;
+    while (off < len) {
         if (ap2_io_poll_fd(fd, POLLOUT, deadline_ms) <= 0) break;
-#ifdef MSG_NOSIGNAL
-        ssize_t written = send(fd, data + offset, len - offset,
-                               MSG_DONTWAIT | MSG_NOSIGNAL);
-#else
-        ssize_t written = send(fd, data + offset, len - offset, MSG_DONTWAIT);
-#endif
-        if (written > 0) {
-            offset += (size_t)written;
-        } else if (written < 0 &&
-                   (errno == EINTR || errno == EAGAIN ||
-                    errno == EWOULDBLOCK || errno == ENOBUFS)) {
+        ssize_t n = send(fd, data + off, (size_t)(len - off),
+                         ap2_io_send_flags());
+        if (n > 0) {
+            off += (int)n;
+        } else if (n < 0 && (errno == EINTR || errno == EAGAIN ||
+                             errno == EWOULDBLOCK)) {
             continue;
         } else {
-            if (written == 0) errno = EPIPE;
+            if (n == 0) errno = EPIPE;
             break;
         }
     }
-    if (offset == len) ok = true;
+    if (off == len) ok = true;
     int saved_errno = errno;
     if (restore_flags) fcntl(fd, F_SETFL, original_flags);
     errno = saved_errno;
@@ -94,14 +96,18 @@ ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
         fcntl(fd, F_SETFL, original_flags | O_NONBLOCK) < 0)
         return -1;
 
-    ssize_t result = -1;
+    ssize_t result;
     for (;;) {
-        if (ap2_io_poll_fd(fd, POLLIN, deadline_ms) <= 0) break;
-        result = recv(fd, buf, len, MSG_DONTWAIT);
-        if (result < 0 &&
-            (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK))
+        if (ap2_io_poll_fd(fd, POLLIN, deadline_ms) <= 0) {
+            result = -1;
+            break;
+        }
+        ssize_t n = recv(fd, buf, len, MSG_DONTWAIT);
+        if (n < 0 && (errno == EINTR || errno == EAGAIN ||
+                      errno == EWOULDBLOCK))
             continue;
-        if (result == 0) errno = ECONNRESET;
+        if (n == 0) errno = ECONNRESET;
+        result = n;
         break;
     }
     int saved_errno = errno;
@@ -110,133 +116,34 @@ ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
     return result;
 }
 
-ap2_send_result_t ap2_io_send_datagram_deadline(
+ap2_io_datagram_result_t ap2_io_send_datagram_deadline(
     int fd, const uint8_t *data, size_t len,
-    const struct sockaddr *addr, socklen_t addr_len, uint64_t deadline_ms)
+    const struct sockaddr *address, socklen_t address_len,
+    uint64_t deadline_ms)
 {
-    bool backpressured = false;
     for (;;) {
-        if (backpressured && ap2_io_monotonic_ms() >= deadline_ms) {
-            errno = ETIMEDOUT;
-            return AP2_SEND_DROPPED;
-        }
-        ssize_t sent;
-        if (addr) {
-            sent = sendto(fd, data, len, MSG_DONTWAIT, addr, addr_len);
-        } else {
-            sent = send(fd, data, len, MSG_DONTWAIT);
-        }
-        if (sent == (ssize_t)len) return AP2_SEND_SENT;
+        ssize_t sent = address
+                           ? sendto(fd, data, len, ap2_io_send_flags(),
+                                    address, address_len)
+                           : send(fd, data, len, ap2_io_send_flags());
+        if (sent == (ssize_t)len) return AP2_IO_DATAGRAM_SENT;
         if (sent >= 0) {
-            errno = EMSGSIZE;
-            return AP2_SEND_FATAL;
+            errno = EIO;
+            return AP2_IO_DATAGRAM_FATAL;
         }
-        if (errno == EINTR) continue;
-        if (errno != EAGAIN && errno != EWOULDBLOCK && errno != ENOBUFS)
-            return AP2_SEND_FATAL;
-
-        backpressured = true;
+        if (errno == EINTR) {
+            if (ap2_io_monotonic_ms() >= deadline_ms) {
+                errno = ETIMEDOUT;
+                return AP2_IO_DATAGRAM_DROPPED;
+            }
+            continue;
+        }
+        if (errno == ENOBUFS) return AP2_IO_DATAGRAM_DROPPED;
+        if (errno != EAGAIN && errno != EWOULDBLOCK)
+            return AP2_IO_DATAGRAM_FATAL;
         int ready = ap2_io_poll_fd(fd, POLLOUT, deadline_ms);
         if (ready > 0) continue;
-        if (ready == 0 && backpressured) return AP2_SEND_DROPPED;
-        return AP2_SEND_FATAL;
+        if (ready == 0) return AP2_IO_DATAGRAM_DROPPED;
+        return AP2_IO_DATAGRAM_FATAL;
     }
-}
-
-static size_t ap2_find_header_end(const uint8_t *data, size_t len)
-{
-    for (size_t i = 0; i + 3 < len; i++) {
-        if (data[i] == '\r' && data[i + 1] == '\n' &&
-            data[i + 2] == '\r' && data[i + 3] == '\n')
-            return i + 4;
-    }
-    return 0;
-}
-
-static bool ap2_parse_decimal(const uint8_t *data, size_t len, long *value)
-{
-    if (!len || len >= 32) return false;
-    char text[32];
-    memcpy(text, data, len);
-    text[len] = '\0';
-    char *end = NULL;
-    errno = 0;
-    long parsed = strtol(text, &end, 10);
-    if (errno || end == text || *end != '\0' || parsed < 0) return false;
-    *value = parsed;
-    return true;
-}
-
-int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
-                               ap2_rtsp_response_t *response)
-{
-    if (!data || !response) return -1;
-    size_t header_len = ap2_find_header_end(data, len);
-    if (!header_len) return 0;
-
-    const uint8_t *line_end = NULL;
-    for (size_t i = 0; i + 1 < header_len; i++) {
-        if (data[i] == '\r' && data[i + 1] == '\n') {
-            line_end = data + i;
-            break;
-        }
-    }
-    if (!line_end) return -1;
-
-    int status = 0;
-    char status_line[128];
-    size_t status_len = (size_t)(line_end - data);
-    if (status_len >= sizeof(status_line)) return -1;
-    memcpy(status_line, data, status_len);
-    status_line[status_len] = '\0';
-    if (sscanf(status_line, "RTSP/%*s %d", &status) != 1 || status <= 0)
-        return -1;
-
-    size_t body_len = 0;
-    int cseq = -1;
-    size_t offset = status_len + 2;
-    while (offset + 2 <= header_len) {
-        size_t end = offset;
-        while (end + 1 < header_len &&
-               !(data[end] == '\r' && data[end + 1] == '\n'))
-            end++;
-        if (end == offset) break;
-
-        size_t colon = offset;
-        while (colon < end && data[colon] != ':') colon++;
-        if (colon == end) return -1;
-        size_t value = colon + 1;
-        while (value < end && (data[value] == ' ' || data[value] == '\t'))
-            value++;
-        size_t value_end = end;
-        while (value_end > value &&
-               (data[value_end - 1] == ' ' || data[value_end - 1] == '\t'))
-            value_end--;
-
-        long parsed = 0;
-        size_t name_len = colon - offset;
-        if (name_len == 14 &&
-            strncasecmp((const char *)data + offset, "Content-Length", 14) == 0) {
-            if (!ap2_parse_decimal(data + value, value_end - value, &parsed))
-                return -1;
-            body_len = (size_t)parsed;
-        } else if (name_len == 4 &&
-                   strncasecmp((const char *)data + offset, "CSeq", 4) == 0) {
-            if (!ap2_parse_decimal(data + value, value_end - value, &parsed) ||
-                parsed > INT_MAX)
-                return -1;
-            cseq = (int)parsed;
-        }
-        offset = end + 2;
-    }
-
-    if (body_len > SIZE_MAX - header_len) return -1;
-    size_t message_len = header_len + body_len;
-    if (len < message_len) return 0;
-    response->status = status;
-    response->cseq = cseq;
-    response->header_len = header_len;
-    response->body_len = body_len;
-    response->message_len = message_len;
-    return 1;
 }

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -1,0 +1,242 @@
+#include "ap2_io.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <time.h>
+
+uint64_t ap2_io_monotonic_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)ts.tv_nsec / 1000000ULL;
+}
+
+int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms)
+{
+    for (;;) {
+        uint64_t now = ap2_io_monotonic_ms();
+        if (now >= deadline_ms) {
+            errno = ETIMEDOUT;
+            return 0;
+        }
+        uint64_t remaining = deadline_ms - now;
+        int timeout = remaining > INT_MAX ? INT_MAX : (int)remaining;
+        struct pollfd pfd = {.fd = fd, .events = events};
+        int status = poll(&pfd, 1, timeout);
+        if (status < 0 && errno == EINTR) continue;
+        if (status <= 0) {
+            if (status == 0) errno = ETIMEDOUT;
+            return status;
+        }
+        if (pfd.revents & events) return 1;
+        if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            errno = ECONNRESET;
+            return -1;
+        }
+    }
+}
+
+bool ap2_io_write_all_deadline(int fd, const uint8_t *data, size_t len,
+                               uint64_t deadline_ms)
+{
+    int original_flags = fcntl(fd, F_GETFL);
+    if (original_flags < 0) return false;
+    bool restore_flags = !(original_flags & O_NONBLOCK);
+    if (restore_flags &&
+        fcntl(fd, F_SETFL, original_flags | O_NONBLOCK) < 0)
+        return false;
+
+    bool ok = false;
+    size_t offset = 0;
+    while (offset < len) {
+        if (ap2_io_monotonic_ms() >= deadline_ms) {
+            errno = ETIMEDOUT;
+            break;
+        }
+        if (ap2_io_poll_fd(fd, POLLOUT, deadline_ms) <= 0) break;
+#ifdef MSG_NOSIGNAL
+        ssize_t written = send(fd, data + offset, len - offset,
+                               MSG_DONTWAIT | MSG_NOSIGNAL);
+#else
+        ssize_t written = send(fd, data + offset, len - offset, MSG_DONTWAIT);
+#endif
+        if (written > 0) {
+            offset += (size_t)written;
+        } else if (written < 0 &&
+                   (errno == EINTR || errno == EAGAIN ||
+                    errno == EWOULDBLOCK || errno == ENOBUFS)) {
+            continue;
+        } else {
+            if (written == 0) errno = EPIPE;
+            break;
+        }
+    }
+    if (offset == len) ok = true;
+    int saved_errno = errno;
+    if (restore_flags) fcntl(fd, F_SETFL, original_flags);
+    errno = saved_errno;
+    return ok;
+}
+
+ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
+                             uint64_t deadline_ms)
+{
+    int original_flags = fcntl(fd, F_GETFL);
+    if (original_flags < 0) return -1;
+    bool restore_flags = !(original_flags & O_NONBLOCK);
+    if (restore_flags &&
+        fcntl(fd, F_SETFL, original_flags | O_NONBLOCK) < 0)
+        return -1;
+
+    ssize_t result = -1;
+    for (;;) {
+        if (ap2_io_poll_fd(fd, POLLIN, deadline_ms) <= 0) break;
+        result = recv(fd, buf, len, MSG_DONTWAIT);
+        if (result < 0 &&
+            (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK))
+            continue;
+        if (result == 0) errno = ECONNRESET;
+        break;
+    }
+    int saved_errno = errno;
+    if (restore_flags) fcntl(fd, F_SETFL, original_flags);
+    errno = saved_errno;
+    return result;
+}
+
+ap2_send_result_t ap2_io_send_datagram_deadline(
+    int fd, const uint8_t *data, size_t len,
+    const struct sockaddr *addr, socklen_t addr_len, uint64_t deadline_ms)
+{
+    bool backpressured = false;
+    for (;;) {
+        if (backpressured && ap2_io_monotonic_ms() >= deadline_ms) {
+            errno = ETIMEDOUT;
+            return AP2_SEND_DROPPED;
+        }
+        ssize_t sent;
+        if (addr) {
+            sent = sendto(fd, data, len, MSG_DONTWAIT, addr, addr_len);
+        } else {
+            sent = send(fd, data, len, MSG_DONTWAIT);
+        }
+        if (sent == (ssize_t)len) return AP2_SEND_SENT;
+        if (sent >= 0) {
+            errno = EMSGSIZE;
+            return AP2_SEND_FATAL;
+        }
+        if (errno == EINTR) continue;
+        if (errno != EAGAIN && errno != EWOULDBLOCK && errno != ENOBUFS)
+            return AP2_SEND_FATAL;
+
+        backpressured = true;
+        int ready = ap2_io_poll_fd(fd, POLLOUT, deadline_ms);
+        if (ready > 0) continue;
+        if (ready == 0 && backpressured) return AP2_SEND_DROPPED;
+        return AP2_SEND_FATAL;
+    }
+}
+
+static size_t ap2_find_header_end(const uint8_t *data, size_t len)
+{
+    for (size_t i = 0; i + 3 < len; i++) {
+        if (data[i] == '\r' && data[i + 1] == '\n' &&
+            data[i + 2] == '\r' && data[i + 3] == '\n')
+            return i + 4;
+    }
+    return 0;
+}
+
+static bool ap2_parse_decimal(const uint8_t *data, size_t len, long *value)
+{
+    if (!len || len >= 32) return false;
+    char text[32];
+    memcpy(text, data, len);
+    text[len] = '\0';
+    char *end = NULL;
+    errno = 0;
+    long parsed = strtol(text, &end, 10);
+    if (errno || end == text || *end != '\0' || parsed < 0) return false;
+    *value = parsed;
+    return true;
+}
+
+int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
+                               ap2_rtsp_response_t *response)
+{
+    if (!data || !response) return -1;
+    size_t header_len = ap2_find_header_end(data, len);
+    if (!header_len) return 0;
+
+    const uint8_t *line_end = NULL;
+    for (size_t i = 0; i + 1 < header_len; i++) {
+        if (data[i] == '\r' && data[i + 1] == '\n') {
+            line_end = data + i;
+            break;
+        }
+    }
+    if (!line_end) return -1;
+
+    int status = 0;
+    char status_line[128];
+    size_t status_len = (size_t)(line_end - data);
+    if (status_len >= sizeof(status_line)) return -1;
+    memcpy(status_line, data, status_len);
+    status_line[status_len] = '\0';
+    if (sscanf(status_line, "RTSP/%*s %d", &status) != 1 || status <= 0)
+        return -1;
+
+    size_t body_len = 0;
+    int cseq = -1;
+    size_t offset = status_len + 2;
+    while (offset + 2 <= header_len) {
+        size_t end = offset;
+        while (end + 1 < header_len &&
+               !(data[end] == '\r' && data[end + 1] == '\n'))
+            end++;
+        if (end == offset) break;
+
+        size_t colon = offset;
+        while (colon < end && data[colon] != ':') colon++;
+        if (colon == end) return -1;
+        size_t value = colon + 1;
+        while (value < end && (data[value] == ' ' || data[value] == '\t'))
+            value++;
+        size_t value_end = end;
+        while (value_end > value &&
+               (data[value_end - 1] == ' ' || data[value_end - 1] == '\t'))
+            value_end--;
+
+        long parsed = 0;
+        size_t name_len = colon - offset;
+        if (name_len == 14 &&
+            strncasecmp((const char *)data + offset, "Content-Length", 14) == 0) {
+            if (!ap2_parse_decimal(data + value, value_end - value, &parsed))
+                return -1;
+            body_len = (size_t)parsed;
+        } else if (name_len == 4 &&
+                   strncasecmp((const char *)data + offset, "CSeq", 4) == 0) {
+            if (!ap2_parse_decimal(data + value, value_end - value, &parsed) ||
+                parsed > INT_MAX)
+                return -1;
+            cseq = (int)parsed;
+        }
+        offset = end + 2;
+    }
+
+    if (body_len > SIZE_MAX - header_len) return -1;
+    size_t message_len = header_len + body_len;
+    if (len < message_len) return 0;
+    response->status = status;
+    response->cseq = cseq;
+    response->header_len = header_len;
+    response->body_len = body_len;
+    response->message_len = message_len;
+    return 1;
+}

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -8,32 +8,21 @@
 #include <sys/types.h>
 
 typedef enum {
-    AP2_SEND_FATAL = -1,
-    AP2_SEND_DROPPED = 0,
-    AP2_SEND_SENT = 1,
-} ap2_send_result_t;
-
-typedef struct {
-    int status;
-    int cseq;
-    size_t header_len;
-    size_t body_len;
-    size_t message_len;
-} ap2_rtsp_response_t;
+    AP2_IO_DATAGRAM_FATAL = -1,
+    AP2_IO_DATAGRAM_DROPPED = 0,
+    AP2_IO_DATAGRAM_SENT = 1,
+} ap2_io_datagram_result_t;
 
 uint64_t ap2_io_monotonic_ms(void);
+bool ap2_io_set_nonblocking(int fd);
 int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms);
-bool ap2_io_write_all_deadline(int fd, const uint8_t *data, size_t len,
+bool ap2_io_write_all_deadline(int fd, const uint8_t *data, int len,
                                uint64_t deadline_ms);
 ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
                              uint64_t deadline_ms);
-ap2_send_result_t ap2_io_send_datagram_deadline(
+ap2_io_datagram_result_t ap2_io_send_datagram_deadline(
     int fd, const uint8_t *data, size_t len,
-    const struct sockaddr *addr, socklen_t addr_len, uint64_t deadline_ms);
+    const struct sockaddr *address, socklen_t address_len,
+    uint64_t deadline_ms);
 
-/* Returns 1 for a complete response, 0 for incomplete input, and -1 for
- * malformed input. */
-int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
-                               ap2_rtsp_response_t *response);
-
-#endif
+#endif /* __AP2_IO_H_ */

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -1,0 +1,39 @@
+#ifndef __AP2_IO_H_
+#define __AP2_IO_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+typedef enum {
+    AP2_SEND_FATAL = -1,
+    AP2_SEND_DROPPED = 0,
+    AP2_SEND_SENT = 1,
+} ap2_send_result_t;
+
+typedef struct {
+    int status;
+    int cseq;
+    size_t header_len;
+    size_t body_len;
+    size_t message_len;
+} ap2_rtsp_response_t;
+
+uint64_t ap2_io_monotonic_ms(void);
+int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms);
+bool ap2_io_write_all_deadline(int fd, const uint8_t *data, size_t len,
+                               uint64_t deadline_ms);
+ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
+                             uint64_t deadline_ms);
+ap2_send_result_t ap2_io_send_datagram_deadline(
+    int fd, const uint8_t *data, size_t len,
+    const struct sockaddr *addr, socklen_t addr_len, uint64_t deadline_ms);
+
+/* Returns 1 for a complete response, 0 for incomplete input, and -1 for
+ * malformed input. */
+int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
+                               ap2_rtsp_response_t *response);
+
+#endif

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -13,10 +13,18 @@ typedef enum {
     AP2_IO_DATAGRAM_SENT = 1,
 } ap2_io_datagram_result_t;
 
+typedef struct {
+    int status;
+    int cseq;
+    size_t header_len;
+    size_t body_len;
+    size_t message_len;
+} ap2_rtsp_response_t;
+
 uint64_t ap2_io_monotonic_ms(void);
 bool ap2_io_set_nonblocking(int fd);
 int ap2_io_poll_fd(int fd, short events, uint64_t deadline_ms);
-bool ap2_io_write_all_deadline(int fd, const uint8_t *data, int len,
+bool ap2_io_write_all_deadline(int fd, const uint8_t *data, size_t len,
                                uint64_t deadline_ms);
 ssize_t ap2_io_read_deadline(int fd, uint8_t *buf, size_t len,
                              uint64_t deadline_ms);
@@ -24,5 +32,9 @@ ap2_io_datagram_result_t ap2_io_send_datagram_deadline(
     int fd, const uint8_t *data, size_t len,
     const struct sockaddr *address, socklen_t address_len,
     uint64_t deadline_ms);
+/* Returns 1 for a complete response, 0 for incomplete input, and -1 for
+ * malformed input. */
+int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
+                               ap2_rtsp_response_t *response);
 
 #endif /* __AP2_IO_H_ */

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -140,7 +140,6 @@ enum mrp_ext_field {
 
 /* Cadence of the defensive state re-push from ap2_mrp_tick (seconds). */
 #define MRP_STATE_REPUSH_S 15
-#define MRP_WRITE_TIMEOUT_MS 1000
 
 struct ap2_mrp_ctx {
     /* Target + identity */
@@ -178,8 +177,7 @@ struct ap2_mrp_ctx {
     int rx_msg_len;
 
     /* Encrypted reverse event channel. It has independent HKDF keys/counters
-     * from both RTSP control and the optional type-130 data channel. The socket
-     * remains owned by ap2_client. */
+     * from both RTSP control and the optional type-130 data channel. */
     int event_sock;
     _Atomic bool event_connected;
     bool event_attached;
@@ -719,6 +717,26 @@ static bool mrp_write_all(int fd, const uint8_t *data, int len)
         ap2_io_monotonic_ms() + MRP_WRITE_TIMEOUT_MS);
 }
 
+static void mrp_close_data_channel(struct ap2_mrp_ctx *m)
+{
+    m->connected = false;
+    if (m->sock >= 0) {
+        shutdown(m->sock, SHUT_RDWR);
+        close(m->sock);
+        m->sock = -1;
+    }
+}
+
+static void mrp_close_event_channel(struct ap2_mrp_ctx *m)
+{
+    atomic_store(&m->event_connected, false);
+    if (m->event_sock >= 0) {
+        shutdown(m->event_sock, SHUT_RDWR);
+        close(m->event_sock);
+        m->event_sock = -1;
+    }
+}
+
 /* Write the 32-byte big-endian data-frame header. */
 static void mrp_write_data_header(uint8_t hdr[MRP_DATA_HDR_LEN],
                                   const char msg_type4[4], const char cmd4[4],
@@ -753,9 +771,7 @@ static bool mrp_send_raw(struct ap2_mrp_ctx *m, const uint8_t *data, int len)
     free(enc);
     if (!ok) {
         LOG_ERROR("[MRP] data channel write failed: %s", strerror(errno));
-        m->connected = false;
-        close(m->sock);
-        m->sock = -1;
+        mrp_close_data_channel(m);
     }
     pthread_mutex_unlock(&m->send_lock);
     return ok;
@@ -910,7 +926,7 @@ static void mrp_process_frames(struct ap2_mrp_ctx *m)
         if (memcmp(h + 4, "sync", 4) == 0) {
             LOG_DEBUG("[MRP] inbound sync frame (%u bytes, seq %llu)",
                       size, (unsigned long long)seqno);
-            mrp_send_reply(m, seqno);
+            if (!mrp_send_reply(m, seqno)) return;
         } else {
             LOG_DEBUG("[MRP] inbound frame %.4s (%u bytes)", (const char *)(h + 4), size);
         }
@@ -979,8 +995,7 @@ static bool mrp_event_send_response(struct ap2_mrp_ctx *m,
     free(enc);
     if (!ok) {
         LOG_ERROR("[MRP] event channel write failed: %s", strerror(errno));
-        atomic_store(&m->event_connected, false);
-        shutdown(m->event_sock, SHUT_RDWR);
+        mrp_close_event_channel(m);
     }
     pthread_mutex_unlock(&m->send_lock);
     return ok;
@@ -1433,6 +1448,7 @@ void ap2_mrp_tick(struct ap2_mrp_ctx *m)
         }
         m->rx_enc_len += (int)n;
         mrp_drain_encrypted(m);
+        if (!m->connected) return;
         mrp_process_frames(m);
         if (!m->connected) return;
     }

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <strings.h>
 #include <stdbool.h>
+#include <stdatomic.h>
 #include <unistd.h>
 #include <errno.h>
 #include <time.h>
@@ -177,7 +178,7 @@ struct ap2_mrp_ctx {
      * from both RTSP control and the optional type-130 data channel. The socket
      * remains owned by ap2_client. */
     int event_sock;
-    bool event_connected;
+    _Atomic bool event_connected;
     uint8_t event_out_key[MRP_KEY_SIZE]; /* Events-Read-Encryption-Key */
     uint8_t event_in_key[MRP_KEY_SIZE];  /* Events-Write-Encryption-Key */
     uint64_t event_out_counter;
@@ -1044,7 +1045,7 @@ static bool mrp_process_event_requests(struct ap2_mrp_ctx *m)
 
 static void mrp_tick_events(struct ap2_mrp_ctx *m)
 {
-    if (!m->event_connected || m->event_sock < 0) return;
+    if (!atomic_load(&m->event_connected) || m->event_sock < 0) return;
 
     struct pollfd pfd = {
         .fd = m->event_sock,
@@ -1053,13 +1054,13 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
     while (poll(&pfd, 1, 0) > 0) {
         if (pfd.revents & (POLLERR | POLLNVAL)) {
             LOG_WARN("[MRP] event channel socket error");
-            m->event_connected = false;
+            atomic_store(&m->event_connected, false);
             return;
         }
         if (!(pfd.revents & POLLIN)) {
             if (pfd.revents & POLLHUP) {
                 LOG_WARN("[MRP] event channel closed by receiver");
-                m->event_connected = false;
+                atomic_store(&m->event_connected, false);
             }
             return;
         }
@@ -1067,7 +1068,7 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
         int space = (int)sizeof(m->event_rx_enc) - m->event_rx_enc_len;
         if (space <= 0) {
             LOG_ERROR("[MRP] event encrypted buffer full");
-            m->event_connected = false;
+            atomic_store(&m->event_connected, false);
             return;
         }
         ssize_t n = read(m->event_sock,
@@ -1076,7 +1077,7 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
         if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return;
         if (n <= 0) {
             LOG_WARN("[MRP] event channel closed by receiver");
-            m->event_connected = false;
+            atomic_store(&m->event_connected, false);
             return;
         }
         m->event_rx_enc_len += (int)n;
@@ -1086,7 +1087,7 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
                 (int)sizeof(m->event_plain),
                 m->event_in_key, &m->event_in_counter, "event channel") ||
             !mrp_process_event_requests(m)) {
-            m->event_connected = false;
+            atomic_store(&m->event_connected, false);
             return;
         }
         pfd.revents = 0;
@@ -1178,7 +1179,7 @@ bool ap2_mrp_attach_events(struct ap2_mrp_ctx *m, int event_sock)
         return false;
     }
     m->event_sock = event_sock;
-    m->event_connected = true;
+    atomic_store(&m->event_connected, true);
     m->event_out_counter = 0;
     m->event_in_counter = 0;
     m->event_rx_enc_len = 0;
@@ -1287,7 +1288,7 @@ void ap2_mrp_stop(struct ap2_mrp_ctx *m)
         close(m->sock);
         m->sock = -1;
     }
-    m->event_connected = false;
+    atomic_store(&m->event_connected, false);
     m->event_sock = -1;
     m->rx_enc_len = 0;
     m->rx_msg_len = 0;
@@ -1416,6 +1417,12 @@ void ap2_mrp_tick(struct ap2_mrp_ctx *m)
 bool ap2_mrp_is_connected(struct ap2_mrp_ctx *m)
 {
     return m && m->connected;
+}
+
+int ap2_mrp_event_status(struct ap2_mrp_ctx *m)
+{
+    if (!m || m->event_sock < 0) return -1;
+    return atomic_load(&m->event_connected) ? 1 : 0;
 }
 
 bool ap2_mrp_build_nowplaying_command(struct ap2_mrp_ctx *m,

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <stdbool.h>
 #include <unistd.h>
 #include <errno.h>
@@ -171,6 +172,20 @@ struct ap2_mrp_ctx {
     int rx_enc_len;
     uint8_t rx_msg[16384];    /* decrypted data-frame bytes */
     int rx_msg_len;
+
+    /* Encrypted reverse event channel. It has independent HKDF keys/counters
+     * from both RTSP control and the optional type-130 data channel. The socket
+     * remains owned by ap2_client. */
+    int event_sock;
+    bool event_connected;
+    uint8_t event_out_key[MRP_KEY_SIZE]; /* Events-Read-Encryption-Key */
+    uint8_t event_in_key[MRP_KEY_SIZE];  /* Events-Write-Encryption-Key */
+    uint64_t event_out_counter;
+    uint64_t event_in_counter;
+    uint8_t event_rx_enc[8192];
+    int event_rx_enc_len;
+    uint8_t event_plain[16384];
+    int event_plain_len;
 
     /* Now-playing state (owned copies) */
     char *title;
@@ -639,10 +654,11 @@ static int mrp_chacha_decrypt(const uint8_t *key, const uint8_t *nonce,
     return ok == 1 ? pt_len : -1;
 }
 
-/* Encrypt a plaintext blob into HAP channel frames with our out_key/counter.
- * Caller frees *out. Returns total byte count or -1. */
-static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
-                               int in_len, uint8_t **out)
+/* Encrypt a plaintext blob into HAP channel frames. Caller frees *out. */
+static int mrp_channel_encrypt_with(const uint8_t key[MRP_KEY_SIZE],
+                                    uint64_t *counter,
+                                    const uint8_t *in, int in_len,
+                                    uint8_t **out)
 {
     int num_frames = (in_len + MRP_FRAME_MAX - 1) / MRP_FRAME_MAX;
     int total = num_frames * (2 + MRP_TAG_SIZE) + in_len;
@@ -659,10 +675,10 @@ static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
         out_off += 2;
 
         uint8_t nonce[MRP_NONCE_SIZE];
-        mrp_make_nonce(m->out_counter++, nonce);
+        mrp_make_nonce((*counter)++, nonce);
 
         uint8_t tag[MRP_TAG_SIZE];
-        if (mrp_chacha_encrypt(m->out_key, nonce, len_bytes, 2,
+        if (mrp_chacha_encrypt(key, nonce, len_bytes, 2,
                                in + in_off, chunk,
                                *out + out_off, tag) < 0) {
             free(*out);
@@ -677,7 +693,30 @@ static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
     return out_off;
 }
 
+static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
+                               int in_len, uint8_t **out)
+{
+    return mrp_channel_encrypt_with(m->out_key, &m->out_counter,
+                                    in, in_len, out);
+}
+
 /* ---- Data-frame construction and send ---- */
+
+static bool mrp_write_all(int fd, const uint8_t *data, int len)
+{
+    int off = 0;
+    while (off < len) {
+        ssize_t n = write(fd, data + off, (size_t)(len - off));
+        if (n > 0) {
+            off += (int)n;
+        } else if (n < 0 && errno == EINTR) {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
 
 /* Write the 32-byte big-endian data-frame header. */
 static void mrp_write_data_header(uint8_t hdr[MRP_DATA_HDR_LEN],
@@ -706,7 +745,7 @@ static bool mrp_send_raw(struct ap2_mrp_ctx *m, const uint8_t *data, int len)
     int enc_len = mrp_channel_encrypt(m, data, len, &enc);
     bool ok = false;
     if (enc_len > 0 && enc)
-        ok = write(m->sock, enc, enc_len) == enc_len;
+        ok = mrp_write_all(m->sock, enc, enc_len);
     free(enc);
     pthread_mutex_unlock(&m->send_lock);
     return ok;
@@ -780,38 +819,57 @@ static bool mrp_push_state(struct ap2_mrp_ctx *m, bool include_artwork)
 
 /* ---- Inbound handling ---- */
 
-/* Decrypt whatever channel frames are complete in rx_enc into rx_msg. */
-static void mrp_drain_encrypted(struct ap2_mrp_ctx *m)
+static bool mrp_drain_channel_frames(uint8_t *enc, int *enc_len,
+                                     uint8_t *plain, int *plain_len,
+                                     int plain_cap,
+                                     const uint8_t key[MRP_KEY_SIZE],
+                                     uint64_t *counter,
+                                     const char *label)
 {
     int off = 0;
-    while (off + 2 <= m->rx_enc_len) {
-        int chunk = m->rx_enc[off] | (m->rx_enc[off + 1] << 8);
-        if (off + 2 + chunk + MRP_TAG_SIZE > m->rx_enc_len) break;
-
-        uint8_t len_bytes[2] = { m->rx_enc[off], m->rx_enc[off + 1] };
-        uint8_t nonce[MRP_NONCE_SIZE];
-        mrp_make_nonce(m->in_counter++, nonce);
-
-        if (m->rx_msg_len + chunk <= (int)sizeof(m->rx_msg)) {
-            int n = mrp_chacha_decrypt(m->in_key, nonce, len_bytes, 2,
-                                       m->rx_enc + off + 2, chunk,
-                                       m->rx_enc + off + 2 + chunk,
-                                       m->rx_msg + m->rx_msg_len);
-            if (n < 0) {
-                LOG_ERROR("[MRP] channel frame decryption failed");
-                m->connected = false;
-                return;
-            }
-            m->rx_msg_len += n;
-        } else {
-            LOG_WARN("[MRP] inbound message buffer full, dropping frame");
+    while (off + 2 <= *enc_len) {
+        int chunk = enc[off] | (enc[off + 1] << 8);
+        if (chunk <= 0 || chunk > MRP_FRAME_MAX) {
+            LOG_ERROR("[MRP] invalid %s frame size %d", label, chunk);
+            return false;
         }
+        if (off + 2 + chunk + MRP_TAG_SIZE > *enc_len) break;
+
+        if (*plain_len + chunk > plain_cap) {
+            LOG_ERROR("[MRP] %s plaintext buffer full", label);
+            return false;
+        }
+
+        uint8_t len_bytes[2] = { enc[off], enc[off + 1] };
+        uint8_t nonce[MRP_NONCE_SIZE];
+        mrp_make_nonce((*counter)++, nonce);
+
+        int n = mrp_chacha_decrypt(key, nonce, len_bytes, 2,
+                                   enc + off + 2, chunk,
+                                   enc + off + 2 + chunk,
+                                   plain + *plain_len);
+        if (n < 0) {
+            LOG_ERROR("[MRP] %s frame decryption failed", label);
+            return false;
+        }
+        *plain_len += n;
         off += 2 + chunk + MRP_TAG_SIZE;
     }
     if (off > 0) {
-        memmove(m->rx_enc, m->rx_enc + off, m->rx_enc_len - off);
-        m->rx_enc_len -= off;
+        memmove(enc, enc + off, *enc_len - off);
+        *enc_len -= off;
     }
+    return true;
+}
+
+/* Decrypt whatever data-channel frames are complete into rx_msg. */
+static void mrp_drain_encrypted(struct ap2_mrp_ctx *m)
+{
+    if (!mrp_drain_channel_frames(m->rx_enc, &m->rx_enc_len,
+                                  m->rx_msg, &m->rx_msg_len,
+                                  (int)sizeof(m->rx_msg),
+                                  m->in_key, &m->in_counter, "data channel"))
+        m->connected = false;
 }
 
 /* Consume complete 32-byte-header data frames from rx_msg. Incoming protobufs
@@ -850,6 +908,191 @@ static void mrp_process_frames(struct ap2_mrp_ctx *m)
     }
 }
 
+/* ---- Reverse event-channel handling ---- */
+
+static int mrp_http_header_end(const uint8_t *data, int len)
+{
+    for (int i = 0; i + 3 < len; i++) {
+        if (data[i] == '\r' && data[i + 1] == '\n' &&
+            data[i + 2] == '\r' && data[i + 3] == '\n')
+            return i + 4;
+    }
+    return 0;
+}
+
+static bool mrp_http_header_value(const char *header, const char *name,
+                                  char *out, size_t out_size)
+{
+    size_t name_len = strlen(name);
+    const char *line = strstr(header, "\r\n");
+    if (!line) return false;
+    line += 2;
+
+    while (*line) {
+        const char *end = strstr(line, "\r\n");
+        if (!end || end == line) break;
+        size_t line_len = (size_t)(end - line);
+        if (line_len > name_len && line[name_len] == ':' &&
+            strncasecmp(line, name, name_len) == 0) {
+            const char *value = line + name_len + 1;
+            while (value < end && (*value == ' ' || *value == '\t')) value++;
+            while (end > value && (end[-1] == ' ' || end[-1] == '\t')) end--;
+            size_t value_len = (size_t)(end - value);
+            if (value_len >= out_size) value_len = out_size - 1;
+            memcpy(out, value, value_len);
+            out[value_len] = '\0';
+            return true;
+        }
+        line = end + 2;
+    }
+    return false;
+}
+
+static bool mrp_event_send_response(struct ap2_mrp_ctx *m,
+                                    const uint8_t *response, int response_len)
+{
+    pthread_mutex_lock(&m->send_lock);
+    uint8_t *enc = NULL;
+    int enc_len = mrp_channel_encrypt_with(
+        m->event_out_key, &m->event_out_counter,
+        response, response_len, &enc);
+    bool ok = enc_len > 0 && enc &&
+              mrp_write_all(m->event_sock, enc, enc_len);
+    free(enc);
+    pthread_mutex_unlock(&m->send_lock);
+    return ok;
+}
+
+static bool mrp_process_event_requests(struct ap2_mrp_ctx *m)
+{
+    int off = 0;
+    while (off < m->event_plain_len) {
+        int available = m->event_plain_len - off;
+        int header_len = mrp_http_header_end(m->event_plain + off, available);
+        if (!header_len) break;
+        if (header_len >= 8192) {
+            LOG_ERROR("[MRP] event HTTP header too large");
+            return false;
+        }
+
+        char header[8192];
+        memcpy(header, m->event_plain + off, (size_t)header_len);
+        header[header_len] = '\0';
+
+        int content_len = 0;
+        char value[256];
+        if (mrp_http_header_value(header, "Content-Length",
+                                  value, sizeof(value))) {
+            char *end = NULL;
+            long parsed = strtol(value, &end, 10);
+            if (!end || end == value || *end != '\0' || parsed < 0 ||
+                parsed > (long)sizeof(m->event_plain)) {
+                LOG_ERROR("[MRP] invalid event Content-Length: %s", value);
+                return false;
+            }
+            content_len = (int)parsed;
+        }
+        if (header_len + content_len > available) break;
+
+        char method[16] = "";
+        char path[256] = "";
+        char version[16] = "RTSP/1.0";
+        if (sscanf(header, "%15s %255s %15s", method, path, version) < 3) {
+            LOG_ERROR("[MRP] malformed event request line");
+            return false;
+        }
+
+        char cseq[64] = "";
+        char server[256] = "";
+        bool have_cseq = mrp_http_header_value(header, "CSeq",
+                                               cseq, sizeof(cseq));
+        bool have_server = mrp_http_header_value(header, "Server",
+                                                 server, sizeof(server));
+        char response[768];
+        int response_len = snprintf(
+            response, sizeof(response),
+            "%s 200 OK\r\n"
+            "Content-Length: 0\r\n"
+            "Audio-Latency: 0\r\n"
+            "%s%s%s"
+            "%s%s%s"
+            "\r\n",
+            version,
+            have_server ? "Server: " : "", have_server ? server : "",
+            have_server ? "\r\n" : "",
+            have_cseq ? "CSeq: " : "", have_cseq ? cseq : "",
+            have_cseq ? "\r\n" : "");
+        if (response_len <= 0 || response_len >= (int)sizeof(response) ||
+            !mrp_event_send_response(m, (const uint8_t *)response,
+                                     response_len)) {
+            LOG_ERROR("[MRP] event response send failed");
+            return false;
+        }
+        LOG_DEBUG("[MRP] event %s %s -> 200%s%s",
+                  method, path, have_cseq ? " cseq=" : "",
+                  have_cseq ? cseq : "");
+        off += header_len + content_len;
+    }
+
+    if (off > 0) {
+        memmove(m->event_plain, m->event_plain + off,
+                (size_t)(m->event_plain_len - off));
+        m->event_plain_len -= off;
+    }
+    return true;
+}
+
+static void mrp_tick_events(struct ap2_mrp_ctx *m)
+{
+    if (!m->event_connected || m->event_sock < 0) return;
+
+    struct pollfd pfd = {
+        .fd = m->event_sock,
+        .events = POLLIN,
+    };
+    while (poll(&pfd, 1, 0) > 0) {
+        if (pfd.revents & (POLLERR | POLLNVAL)) {
+            LOG_WARN("[MRP] event channel socket error");
+            m->event_connected = false;
+            return;
+        }
+        if (!(pfd.revents & POLLIN)) {
+            if (pfd.revents & POLLHUP) {
+                LOG_WARN("[MRP] event channel closed by receiver");
+                m->event_connected = false;
+            }
+            return;
+        }
+
+        int space = (int)sizeof(m->event_rx_enc) - m->event_rx_enc_len;
+        if (space <= 0) {
+            LOG_ERROR("[MRP] event encrypted buffer full");
+            m->event_connected = false;
+            return;
+        }
+        ssize_t n = read(m->event_sock,
+                         m->event_rx_enc + m->event_rx_enc_len,
+                         (size_t)space);
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return;
+        if (n <= 0) {
+            LOG_WARN("[MRP] event channel closed by receiver");
+            m->event_connected = false;
+            return;
+        }
+        m->event_rx_enc_len += (int)n;
+        if (!mrp_drain_channel_frames(
+                m->event_rx_enc, &m->event_rx_enc_len,
+                m->event_plain, &m->event_plain_len,
+                (int)sizeof(m->event_plain),
+                m->event_in_key, &m->event_in_counter, "event channel") ||
+            !mrp_process_event_requests(m)) {
+            m->event_connected = false;
+            return;
+        }
+        pfd.revents = 0;
+    }
+}
+
 /* ---- Public API ---- */
 
 struct ap2_mrp_ctx *ap2_mrp_create(const char *host, int port,
@@ -875,6 +1118,7 @@ struct ap2_mrp_ctx *ap2_mrp_create(const char *host, int port,
     m->playback_state = AP2_MRP_PLAYBACK_PAUSED;
     m->elapsed_set_at = mrp_cf_now();
     m->sock = -1;
+    m->event_sock = -1;
     pthread_mutex_init(&m->send_lock, NULL);
 
     if (reuse_shared_secret) {
@@ -899,6 +1143,8 @@ void ap2_mrp_destroy(struct ap2_mrp_ctx *m)
     OPENSSL_cleanse(m->shared_secret, sizeof(m->shared_secret));
     OPENSSL_cleanse(m->out_key, sizeof(m->out_key));
     OPENSSL_cleanse(m->in_key, sizeof(m->in_key));
+    OPENSSL_cleanse(m->event_out_key, sizeof(m->event_out_key));
+    OPENSSL_cleanse(m->event_in_key, sizeof(m->event_in_key));
     free(m->host);
     free(m->auth_credentials);
     free(m->dacp_id);
@@ -911,6 +1157,34 @@ void ap2_mrp_destroy(struct ap2_mrp_ctx *m)
     free(m->artwork_mime);
     free(m->artwork);
     free(m);
+}
+
+bool ap2_mrp_attach_events(struct ap2_mrp_ctx *m, int event_sock)
+{
+    if (!m || event_sock < 0) return false;
+    if (!m->have_secret) {
+        LOG_ERROR("[MRP] event channel requires the pairing shared secret");
+        return false;
+    }
+    /* The receiver is the logical writer on this reverse channel, so the key
+     * labels are swapped from our perspective (pyatv EventChannel). */
+    if (!mrp_hkdf_sha512(m->shared_secret, MRP_KEY_SIZE, MRP_EVENTS_SALT,
+                         MRP_EVENTS_READ_INFO,
+                         m->event_out_key, MRP_KEY_SIZE) ||
+        !mrp_hkdf_sha512(m->shared_secret, MRP_KEY_SIZE, MRP_EVENTS_SALT,
+                         MRP_EVENTS_WRITE_INFO,
+                         m->event_in_key, MRP_KEY_SIZE)) {
+        LOG_ERROR("[MRP] event channel key derivation failed");
+        return false;
+    }
+    m->event_sock = event_sock;
+    m->event_connected = true;
+    m->event_out_counter = 0;
+    m->event_in_counter = 0;
+    m->event_rx_enc_len = 0;
+    m->event_plain_len = 0;
+    LOG_INFO("[MRP] encrypted event channel attached");
+    return true;
 }
 
 bool ap2_mrp_attach(struct ap2_mrp_ctx *m, int data_port, uint64_t seed)
@@ -1013,8 +1287,12 @@ void ap2_mrp_stop(struct ap2_mrp_ctx *m)
         close(m->sock);
         m->sock = -1;
     }
+    m->event_connected = false;
+    m->event_sock = -1;
     m->rx_enc_len = 0;
     m->rx_msg_len = 0;
+    m->event_rx_enc_len = 0;
+    m->event_plain_len = 0;
 }
 
 bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
@@ -1105,7 +1383,9 @@ bool ap2_mrp_set_stopped(struct ap2_mrp_ctx *m)
 
 void ap2_mrp_tick(struct ap2_mrp_ctx *m)
 {
-    if (!m || !m->connected || m->sock < 0) return;
+    if (!m) return;
+    mrp_tick_events(m);
+    if (!m->connected || m->sock < 0) return;
 
     /* Drain inbound bytes without blocking */
     struct pollfd pfd = { .fd = m->sock, .events = POLLIN };

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -68,6 +68,7 @@ extern log_level *loglevel;
 #define MRP_TAG_SIZE     16
 #define MRP_NONCE_SIZE   12
 #define MRP_KEY_SIZE     32
+#define MRP_WRITE_TIMEOUT_MS 1000
 
 /* Data-frame header: 32 bytes big-endian — size:u32 (includes the header),
  * message_type:12 raw bytes ("sync"+NULs from us, "rply"+NULs in replies),
@@ -204,7 +205,10 @@ struct ap2_mrp_ctx {
     int artwork_len;
     char artwork_id[17];      /* 16-hex ArtworkIdentifier for the current art */
     bool artwork_sent;        /* bytes already pushed once (then ref by id) */
+    uint64_t artwork_generation;
     uint64_t np_uid;          /* per-track now-playing UniqueIdentifier */
+    bool state_dirty;         /* type-130 state queued for the tick worker */
+    bool artwork_dirty;
 
     time_t last_state_push;
 };
@@ -711,28 +715,8 @@ static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
 static bool mrp_write_all(int fd, const uint8_t *data, int len)
 {
     return ap2_io_write_all_deadline(
-        fd, data, (size_t)len,
+        fd, data, len,
         ap2_io_monotonic_ms() + MRP_WRITE_TIMEOUT_MS);
-}
-
-static void mrp_close_data_channel(struct ap2_mrp_ctx *m)
-{
-    m->connected = false;
-    if (m->sock >= 0) {
-        shutdown(m->sock, SHUT_RDWR);
-        close(m->sock);
-        m->sock = -1;
-    }
-}
-
-static void mrp_close_event_channel(struct ap2_mrp_ctx *m)
-{
-    atomic_store(&m->event_connected, false);
-    if (m->event_sock >= 0) {
-        shutdown(m->event_sock, SHUT_RDWR);
-        close(m->event_sock);
-        m->event_sock = -1;
-    }
 }
 
 /* Write the 32-byte big-endian data-frame header. */
@@ -769,7 +753,9 @@ static bool mrp_send_raw(struct ap2_mrp_ctx *m, const uint8_t *data, int len)
     free(enc);
     if (!ok) {
         LOG_ERROR("[MRP] data channel write failed: %s", strerror(errno));
-        mrp_close_data_channel(m);
+        m->connected = false;
+        close(m->sock);
+        m->sock = -1;
     }
     pthread_mutex_unlock(&m->send_lock);
     return ok;
@@ -835,7 +821,11 @@ static bool mrp_push_state(struct ap2_mrp_ctx *m, bool include_artwork)
     bool ok = build_set_state(m, include_artwork, &msg);
     ok = ok && mrp_send_protobuf(m, &msg);
     mbuf_free(&msg);
-    if (ok) m->last_state_push = time(NULL);
+    if (ok) {
+        m->last_state_push = time(NULL);
+        m->state_dirty = false;
+        if (include_artwork) m->artwork_dirty = false;
+    }
     LOG_DEBUG("[MRP] SET_STATE push (%s artwork) -> %s",
               include_artwork ? "with" : "without", ok ? "sent" : "failed");
     return ok;
@@ -989,7 +979,8 @@ static bool mrp_event_send_response(struct ap2_mrp_ctx *m,
     free(enc);
     if (!ok) {
         LOG_ERROR("[MRP] event channel write failed: %s", strerror(errno));
-        mrp_close_event_channel(m);
+        atomic_store(&m->event_connected, false);
+        shutdown(m->event_sock, SHUT_RDWR);
     }
     pthread_mutex_unlock(&m->send_lock);
     return ok;
@@ -1105,6 +1096,7 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
         ssize_t n = read(m->event_sock,
                          m->event_rx_enc + m->event_rx_enc_len,
                          (size_t)space);
+        if (n < 0 && errno == EINTR) continue;
         if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return;
         if (n <= 0) {
             LOG_WARN("[MRP] event channel closed by receiver");
@@ -1261,6 +1253,13 @@ bool ap2_mrp_attach(struct ap2_mrp_ctx *m, int data_port, uint64_t seed)
         m->sock = -1;
         return false;
     }
+    if (!ap2_io_set_nonblocking(m->sock)) {
+        LOG_ERROR("[MRP] failed to make data channel nonblocking: %s",
+                  strerror(errno));
+        close(m->sock);
+        m->sock = -1;
+        return false;
+    }
     int one = 1;
     setsockopt(m->sock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     m->connected = true;
@@ -1339,8 +1338,8 @@ bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
     uint64_t uid = 0;
     RAND_bytes((uint8_t *)&uid, sizeof(uid));
     m->np_uid = uid & 0x7FFFFFFFFFFFFFFFULL;
-    if (!m->connected) return true;
-    return mrp_push_state(m, false);
+    m->state_dirty = true;
+    return true;
 }
 
 bool ap2_mrp_set_artwork(struct ap2_mrp_ctx *m, const char *mime,
@@ -1363,8 +1362,10 @@ bool ap2_mrp_set_artwork(struct ap2_mrp_ctx *m, const char *mime,
              "%02x%02x%02x%02x%02x%02x%02x%02x",
              idb[0], idb[1], idb[2], idb[3], idb[4], idb[5], idb[6], idb[7]);
     m->artwork_sent = false;
-    if (!m->connected) return true;
-    return mrp_push_state(m, true);
+    m->artwork_generation++;
+    m->state_dirty = true;
+    m->artwork_dirty = true;
+    return true;
 }
 
 bool ap2_mrp_set_progress(struct ap2_mrp_ctx *m, int elapsed_ms,
@@ -1376,10 +1377,8 @@ bool ap2_mrp_set_progress(struct ap2_mrp_ctx *m, int elapsed_ms,
     m->playback_state = playing ? AP2_MRP_PLAYBACK_PLAYING
                                 : AP2_MRP_PLAYBACK_PAUSED;
     m->elapsed_set_at = mrp_cf_now();
-    if (!m->connected) return true;
-    /* The receiver extrapolates position from elapsedTime + timestamp +
-     * playbackRate, so a progress change is a state push, not a stream. */
-    return mrp_push_state(m, false);
+    m->state_dirty = true;
+    return true;
 }
 
 bool ap2_mrp_set_playing(struct ap2_mrp_ctx *m, bool playing)
@@ -1397,8 +1396,8 @@ bool ap2_mrp_set_playing(struct ap2_mrp_ctx *m, bool playing)
     m->playback_state = playing ? AP2_MRP_PLAYBACK_PLAYING
                                 : AP2_MRP_PLAYBACK_PAUSED;
     m->elapsed_set_at = now;
-    if (!m->connected) return true;
-    return mrp_push_state(m, false);
+    m->state_dirty = true;
+    return true;
 }
 
 bool ap2_mrp_set_stopped(struct ap2_mrp_ctx *m)
@@ -1406,8 +1405,8 @@ bool ap2_mrp_set_stopped(struct ap2_mrp_ctx *m)
     if (!m) return false;
     m->playback_state = AP2_MRP_PLAYBACK_STOPPED;
     m->elapsed_set_at = mrp_cf_now();
-    if (!m->connected) return true;
-    return mrp_push_state(m, false);
+    m->state_dirty = true;
+    return true;
 }
 
 void ap2_mrp_tick(struct ap2_mrp_ctx *m)
@@ -1422,6 +1421,11 @@ void ap2_mrp_tick(struct ap2_mrp_ctx *m)
         int space = (int)sizeof(m->rx_enc) - m->rx_enc_len;
         if (space <= 0) break;
         ssize_t n = read(m->sock, m->rx_enc + m->rx_enc_len, (size_t)space);
+        if (n < 0 && errno == EINTR) {
+            pfd.revents = 0;
+            continue;
+        }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return;
         if (n <= 0) {
             LOG_WARN("[MRP] data channel closed by receiver");
             mrp_close_data_channel(m);
@@ -1431,6 +1435,11 @@ void ap2_mrp_tick(struct ap2_mrp_ctx *m)
         mrp_drain_encrypted(m);
         mrp_process_frames(m);
         if (!m->connected) return;
+    }
+
+    if (m->state_dirty || m->artwork_dirty) {
+        mrp_push_state(m, m->artwork_dirty);
+        return;
     }
 
     /* Defensive periodic re-push: keeps the system now-playing session warm
@@ -1521,9 +1530,15 @@ bool ap2_mrp_build_nowplaying_command(struct ap2_mrp_ctx *m,
     return true;
 }
 
-void ap2_mrp_mark_artwork_sent(struct ap2_mrp_ctx *m)
+uint64_t ap2_mrp_artwork_generation(struct ap2_mrp_ctx *m)
 {
-    if (m && m->artwork && m->artwork_len > 0)
+    return m ? m->artwork_generation : 0;
+}
+
+void ap2_mrp_mark_artwork_sent(struct ap2_mrp_ctx *m, uint64_t generation)
+{
+    if (m && m->artwork_generation == generation &&
+        m->artwork && m->artwork_len > 0)
         m->artwork_sent = true;
 }
 

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -38,6 +38,7 @@
 #include <openssl/crypto.h>
 
 #include "cross_log.h"
+#include "ap2_io.h"
 #include "ap2_plist.h"
 #include "ap2_mrp.h"
 
@@ -138,6 +139,7 @@ enum mrp_ext_field {
 
 /* Cadence of the defensive state re-push from ap2_mrp_tick (seconds). */
 #define MRP_STATE_REPUSH_S 15
+#define MRP_WRITE_TIMEOUT_MS 1000
 
 struct ap2_mrp_ctx {
     /* Target + identity */
@@ -179,6 +181,7 @@ struct ap2_mrp_ctx {
      * remains owned by ap2_client. */
     int event_sock;
     _Atomic bool event_connected;
+    bool event_attached;
     uint8_t event_out_key[MRP_KEY_SIZE]; /* Events-Read-Encryption-Key */
     uint8_t event_in_key[MRP_KEY_SIZE];  /* Events-Write-Encryption-Key */
     uint64_t event_out_counter;
@@ -675,6 +678,8 @@ static int mrp_channel_encrypt_with(const uint8_t key[MRP_KEY_SIZE],
         memcpy(*out + out_off, len_bytes, 2);
         out_off += 2;
 
+        /* Encryption consumes the nonce even if the eventual write fails.
+         * Callers close the channel on failure rather than retrying ciphertext. */
         uint8_t nonce[MRP_NONCE_SIZE];
         mrp_make_nonce((*counter)++, nonce);
 
@@ -705,18 +710,29 @@ static int mrp_channel_encrypt(struct ap2_mrp_ctx *m, const uint8_t *in,
 
 static bool mrp_write_all(int fd, const uint8_t *data, int len)
 {
-    int off = 0;
-    while (off < len) {
-        ssize_t n = write(fd, data + off, (size_t)(len - off));
-        if (n > 0) {
-            off += (int)n;
-        } else if (n < 0 && errno == EINTR) {
-            continue;
-        } else {
-            return false;
-        }
+    return ap2_io_write_all_deadline(
+        fd, data, (size_t)len,
+        ap2_io_monotonic_ms() + MRP_WRITE_TIMEOUT_MS);
+}
+
+static void mrp_close_data_channel(struct ap2_mrp_ctx *m)
+{
+    m->connected = false;
+    if (m->sock >= 0) {
+        shutdown(m->sock, SHUT_RDWR);
+        close(m->sock);
+        m->sock = -1;
     }
-    return true;
+}
+
+static void mrp_close_event_channel(struct ap2_mrp_ctx *m)
+{
+    atomic_store(&m->event_connected, false);
+    if (m->event_sock >= 0) {
+        shutdown(m->event_sock, SHUT_RDWR);
+        close(m->event_sock);
+        m->event_sock = -1;
+    }
 }
 
 /* Write the 32-byte big-endian data-frame header. */
@@ -740,14 +756,21 @@ static void mrp_write_data_header(uint8_t hdr[MRP_DATA_HDR_LEN],
 /* Send raw bytes through the encrypted channel (holds send_lock). */
 static bool mrp_send_raw(struct ap2_mrp_ctx *m, const uint8_t *data, int len)
 {
-    if (m->sock < 0) return false;
     pthread_mutex_lock(&m->send_lock);
+    if (m->sock < 0) {
+        pthread_mutex_unlock(&m->send_lock);
+        return false;
+    }
     uint8_t *enc = NULL;
     int enc_len = mrp_channel_encrypt(m, data, len, &enc);
     bool ok = false;
     if (enc_len > 0 && enc)
         ok = mrp_write_all(m->sock, enc, enc_len);
     free(enc);
+    if (!ok) {
+        LOG_ERROR("[MRP] data channel write failed: %s", strerror(errno));
+        mrp_close_data_channel(m);
+    }
     pthread_mutex_unlock(&m->send_lock);
     return ok;
 }
@@ -870,7 +893,7 @@ static void mrp_drain_encrypted(struct ap2_mrp_ctx *m)
                                   m->rx_msg, &m->rx_msg_len,
                                   (int)sizeof(m->rx_msg),
                                   m->in_key, &m->in_counter, "data channel"))
-        m->connected = false;
+        mrp_close_data_channel(m);
 }
 
 /* Consume complete 32-byte-header data frames from rx_msg. Incoming protobufs
@@ -953,6 +976,10 @@ static bool mrp_event_send_response(struct ap2_mrp_ctx *m,
                                     const uint8_t *response, int response_len)
 {
     pthread_mutex_lock(&m->send_lock);
+    if (!atomic_load(&m->event_connected) || m->event_sock < 0) {
+        pthread_mutex_unlock(&m->send_lock);
+        return false;
+    }
     uint8_t *enc = NULL;
     int enc_len = mrp_channel_encrypt_with(
         m->event_out_key, &m->event_out_counter,
@@ -960,6 +987,10 @@ static bool mrp_event_send_response(struct ap2_mrp_ctx *m,
     bool ok = enc_len > 0 && enc &&
               mrp_write_all(m->event_sock, enc, enc_len);
     free(enc);
+    if (!ok) {
+        LOG_ERROR("[MRP] event channel write failed: %s", strerror(errno));
+        mrp_close_event_channel(m);
+    }
     pthread_mutex_unlock(&m->send_lock);
     return ok;
 }
@@ -1054,13 +1085,13 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
     while (poll(&pfd, 1, 0) > 0) {
         if (pfd.revents & (POLLERR | POLLNVAL)) {
             LOG_WARN("[MRP] event channel socket error");
-            atomic_store(&m->event_connected, false);
+            mrp_close_event_channel(m);
             return;
         }
         if (!(pfd.revents & POLLIN)) {
             if (pfd.revents & POLLHUP) {
                 LOG_WARN("[MRP] event channel closed by receiver");
-                atomic_store(&m->event_connected, false);
+                mrp_close_event_channel(m);
             }
             return;
         }
@@ -1068,7 +1099,7 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
         int space = (int)sizeof(m->event_rx_enc) - m->event_rx_enc_len;
         if (space <= 0) {
             LOG_ERROR("[MRP] event encrypted buffer full");
-            atomic_store(&m->event_connected, false);
+            mrp_close_event_channel(m);
             return;
         }
         ssize_t n = read(m->event_sock,
@@ -1077,7 +1108,7 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
         if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return;
         if (n <= 0) {
             LOG_WARN("[MRP] event channel closed by receiver");
-            atomic_store(&m->event_connected, false);
+            mrp_close_event_channel(m);
             return;
         }
         m->event_rx_enc_len += (int)n;
@@ -1087,7 +1118,7 @@ static void mrp_tick_events(struct ap2_mrp_ctx *m)
                 (int)sizeof(m->event_plain),
                 m->event_in_key, &m->event_in_counter, "event channel") ||
             !mrp_process_event_requests(m)) {
-            atomic_store(&m->event_connected, false);
+            mrp_close_event_channel(m);
             return;
         }
         pfd.revents = 0;
@@ -1180,6 +1211,7 @@ bool ap2_mrp_attach_events(struct ap2_mrp_ctx *m, int event_sock)
     }
     m->event_sock = event_sock;
     atomic_store(&m->event_connected, true);
+    m->event_attached = true;
     m->event_out_counter = 0;
     m->event_in_counter = 0;
     m->event_rx_enc_len = 0;
@@ -1284,12 +1316,8 @@ void ap2_mrp_stop(struct ap2_mrp_ctx *m)
         mbuf_free(&msg);
         m->connected = false;
     }
-    if (m->sock >= 0) {
-        close(m->sock);
-        m->sock = -1;
-    }
-    atomic_store(&m->event_connected, false);
-    m->event_sock = -1;
+    mrp_close_data_channel(m);
+    mrp_close_event_channel(m);
     m->rx_enc_len = 0;
     m->rx_msg_len = 0;
     m->event_rx_enc_len = 0;
@@ -1396,9 +1424,7 @@ void ap2_mrp_tick(struct ap2_mrp_ctx *m)
         ssize_t n = read(m->sock, m->rx_enc + m->rx_enc_len, (size_t)space);
         if (n <= 0) {
             LOG_WARN("[MRP] data channel closed by receiver");
-            m->connected = false;
-            close(m->sock);
-            m->sock = -1;
+            mrp_close_data_channel(m);
             return;
         }
         m->rx_enc_len += (int)n;
@@ -1421,7 +1447,7 @@ bool ap2_mrp_is_connected(struct ap2_mrp_ctx *m)
 
 int ap2_mrp_event_status(struct ap2_mrp_ctx *m)
 {
-    if (!m || m->event_sock < 0) return -1;
+    if (!m || !m->event_attached) return -1;
     return atomic_load(&m->event_connected) ? 1 : 0;
 }
 

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -179,8 +179,9 @@ int ap2_mrp_event_status(struct ap2_mrp_ctx *m);
 bool ap2_mrp_build_nowplaying_command(struct ap2_mrp_ctx *m,
                                       uint8_t **out, int *out_len);
 
-/* Mark the one-shot artwork bytes as accepted after a successful POST. */
-void ap2_mrp_mark_artwork_sent(struct ap2_mrp_ctx *m);
+/* Mark one artwork generation as accepted after a successful POST. */
+uint64_t ap2_mrp_artwork_generation(struct ap2_mrp_ctx *m);
+void ap2_mrp_mark_artwork_sent(struct ap2_mrp_ctx *m, uint64_t generation);
 
 /*
  * Build the origin-registration bodies a real iPhone POSTs to /command before

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -92,6 +92,13 @@ void ap2_mrp_destroy(struct ap2_mrp_ctx *m);
 bool ap2_mrp_attach(struct ap2_mrp_ctx *m, int data_port, uint64_t seed);
 
 /*
+ * Attach the session event socket. The socket stays owned by ap2_client; this
+ * derives the independent Events-Salt keys and services encrypted reverse HTTP
+ * requests with 200 responses from ap2_mrp_tick().
+ */
+bool ap2_mrp_attach_events(struct ap2_mrp_ctx *m, int event_sock);
+
+/*
  * Bootstrap a standalone remote-control-only session (sidecar model, for the
  * metadata-only display mode): own TCP connection, pair-verify, session SETUP
  * with isRemoteControlOnly=true, event channel, RECORD, type-130 data channel.
@@ -147,10 +154,10 @@ bool ap2_mrp_set_playing(struct ap2_mrp_ctx *m, bool playing);
 bool ap2_mrp_set_stopped(struct ap2_mrp_ctx *m);
 
 /*
- * Keep-alive tick: drain any incoming frames (answering sync/heartbeat
- * requests) and re-push the current now-playing state to hold the system
- * now-playing session open (standby prevention). Call about every 2 s from the
- * caller's existing loop; harmless when not connected.
+ * Keep-alive tick: answer encrypted event-channel HTTP requests, drain any
+ * type-130 frames (answering sync/heartbeat requests), and re-push the current
+ * type-130 state when applicable. Call about every 2 s from the caller's
+ * existing loop.
  */
 void ap2_mrp_tick(struct ap2_mrp_ctx *m);
 

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -164,6 +164,9 @@ void ap2_mrp_tick(struct ap2_mrp_ctx *m);
 /* True once the data channel is established. */
 bool ap2_mrp_is_connected(struct ap2_mrp_ctx *m);
 
+/* Reverse event-channel status: -1 unattached, 0 closed/failed, 1 active. */
+int ap2_mrp_event_status(struct ap2_mrp_ctx *m);
+
 /*
  * Build a binary-plist body for POST /command on the MAIN encrypted RTSP
  * channel (push path A in DESIGN.md §8: real iOS senders push MediaRemote

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -92,9 +92,9 @@ void ap2_mrp_destroy(struct ap2_mrp_ctx *m);
 bool ap2_mrp_attach(struct ap2_mrp_ctx *m, int data_port, uint64_t seed);
 
 /*
- * Attach the session event socket. The socket stays owned by ap2_client; this
- * derives the independent Events-Salt keys and services encrypted reverse HTTP
- * requests with 200 responses from ap2_mrp_tick().
+ * Attach the session event socket. Ownership transfers to the MRP context on
+ * success. This derives the independent Events-Salt keys and services encrypted
+ * reverse HTTP requests with 200 responses from ap2_mrp_tick().
  */
 bool ap2_mrp_attach_events(struct ap2_mrp_ctx *m, int event_sock);
 

--- a/src/ap2_plist.c
+++ b/src/ap2_plist.c
@@ -12,6 +12,7 @@
  *   0x1 = int (low nibble = log2(byte count): 0=1B, 1=2B, 2=4B, 3=8B)
  *   0x4 = data (low nibble = length, or 0xF + int length)
  *   0x5 = string (ASCII, low nibble = length, or 0xF + int length)
+ *   0x6 = string (UTF-16BE, count is UTF-16 code units)
  *   0xa = array (low nibble = count, or 0xF + int count)
  *   0xd = dict (low nibble = count, or 0xF + int count)
  *
@@ -193,6 +194,90 @@ static void write_size(buf_t *b, uint8_t type_nibble, size_t count) {
     }
 }
 
+/* Binary plist's 0x5 string is strictly ASCII. Encode non-ASCII UTF-8 as
+ * UTF-16BE (0x6); writing raw UTF-8 under an ASCII marker produces mojibake on
+ * tvOS (for example U+2019 becomes "â..."). Invalid UTF-8 is replaced with
+ * U+FFFD so the plist itself remains valid. */
+static uint32_t decode_utf8(const uint8_t *src, size_t len, size_t *consumed)
+{
+    uint8_t c = src[0];
+    *consumed = 1;
+    if (c < 0x80) return c;
+    if (c >= 0xC2 && c <= 0xDF && len >= 2 &&
+        (src[1] & 0xC0) == 0x80) {
+        *consumed = 2;
+        return ((uint32_t)(c & 0x1F) << 6) |
+               (uint32_t)(src[1] & 0x3F);
+    }
+    if (c >= 0xE0 && c <= 0xEF && len >= 3 &&
+        (src[1] & 0xC0) == 0x80 && (src[2] & 0xC0) == 0x80 &&
+        !(c == 0xE0 && src[1] < 0xA0) &&
+        !(c == 0xED && src[1] >= 0xA0)) {
+        *consumed = 3;
+        return ((uint32_t)(c & 0x0F) << 12) |
+               ((uint32_t)(src[1] & 0x3F) << 6) |
+               (uint32_t)(src[2] & 0x3F);
+    }
+    if (c >= 0xF0 && c <= 0xF4 && len >= 4 &&
+        (src[1] & 0xC0) == 0x80 && (src[2] & 0xC0) == 0x80 &&
+        (src[3] & 0xC0) == 0x80 &&
+        !(c == 0xF0 && src[1] < 0x90) &&
+        !(c == 0xF4 && src[1] >= 0x90)) {
+        *consumed = 4;
+        return ((uint32_t)(c & 0x07) << 18) |
+               ((uint32_t)(src[1] & 0x3F) << 12) |
+               ((uint32_t)(src[2] & 0x3F) << 6) |
+               (uint32_t)(src[3] & 0x3F);
+    }
+    return 0xFFFD;
+}
+
+static void write_plist_string(buf_t *b, const char *str)
+{
+    const uint8_t *src = (const uint8_t *)(str ? str : "");
+    size_t src_len = strlen((const char *)src);
+    bool ascii = true;
+    for (size_t i = 0; i < src_len; i++) {
+        if (src[i] & 0x80) {
+            ascii = false;
+            break;
+        }
+    }
+    if (ascii) {
+        write_size(b, 0x50, src_len);
+        buf_append(b, src, (int)src_len);
+        return;
+    }
+
+    size_t in = 0, units = 0;
+    while (in < src_len) {
+        size_t consumed;
+        uint32_t cp = decode_utf8(src + in, src_len - in, &consumed);
+        in += consumed;
+        units += cp <= 0xFFFF ? 1 : 2;
+    }
+    write_size(b, 0x60, units);
+
+    in = 0;
+    while (in < src_len) {
+        size_t consumed;
+        uint32_t cp = decode_utf8(src + in, src_len - in, &consumed);
+        in += consumed;
+        if (cp <= 0xFFFF) {
+            buf_append_byte(b, (uint8_t)(cp >> 8));
+            buf_append_byte(b, (uint8_t)cp);
+        } else {
+            cp -= 0x10000;
+            uint16_t high = 0xD800 | (uint16_t)(cp >> 10);
+            uint16_t low = 0xDC00 | (uint16_t)(cp & 0x3FF);
+            buf_append_byte(b, (uint8_t)(high >> 8));
+            buf_append_byte(b, (uint8_t)high);
+            buf_append_byte(b, (uint8_t)(low >> 8));
+            buf_append_byte(b, (uint8_t)low);
+        }
+    }
+}
+
 static void write_int_value(buf_t *b, int64_t val) {
     if (val >= 0 && val <= 0xFF) {
         buf_append_byte(b, 0x10); buf_append_byte(b, (uint8_t)val);
@@ -281,8 +366,7 @@ int ap2_plist_serialize(struct ap2_plist *p, uint8_t **out)
         offsets[key_idx + i] = objs.len;
         objs.data[root_keys_pos + i] = key_idx + i;
         const char *key = p->root_entries[i].key;
-        write_size(&objs, 0x50, strlen(key));
-        buf_append(&objs, key, strlen(key));
+        write_plist_string(&objs, key);
 
         /* Value */
         offsets[val_idx + i] = objs.len;
@@ -290,8 +374,7 @@ int ap2_plist_serialize(struct ap2_plist *p, uint8_t **out)
         object_t *vo = &p->objects[p->root_entries[i].val_obj];
         switch (vo->type) {
             case OBJ_STRING:
-                write_size(&objs, 0x50, strlen(vo->string.val));
-                buf_append(&objs, vo->string.val, strlen(vo->string.val));
+                write_plist_string(&objs, vo->string.val);
                 break;
             case OBJ_INT:
                 write_int_value(&objs, vo->integer.val);
@@ -341,8 +424,7 @@ int ap2_plist_serialize(struct ap2_plist *p, uint8_t **out)
             offsets[skey_start + i] = objs.len;
             objs.data[sdict_keys_pos + i] = skey_start + i;
             const char *key = p->stream_entries[i].key;
-            write_size(&objs, 0x50, strlen(key));
-            buf_append(&objs, key, strlen(key));
+            write_plist_string(&objs, key);
 
             /* Value */
             offsets[sval_start + i] = objs.len;
@@ -350,8 +432,7 @@ int ap2_plist_serialize(struct ap2_plist *p, uint8_t **out)
             object_t *vo = &p->objects[p->stream_entries[i].val_obj];
             switch (vo->type) {
                 case OBJ_STRING:
-                    write_size(&objs, 0x50, strlen(vo->string.val));
-                    buf_append(&objs, vo->string.val, strlen(vo->string.val));
+                    write_plist_string(&objs, vo->string.val);
                     break;
                 case OBJ_INT:
                     write_int_value(&objs, vo->integer.val);
@@ -574,8 +655,7 @@ int ap2_pl_serialize(const ap2_pl_node *root, uint8_t **out)
             for (int k = 0; k < n->n; k++) write_ref(&objs, n->vals[k]->index, ref_size);
             break;
         case PLN_STRING:
-            write_size(&objs, 0x50, strlen(n->str));
-            buf_append(&objs, n->str, strlen(n->str));
+            write_plist_string(&objs, n->str);
             break;
         case PLN_INT:
             write_int_value(&objs, n->ival);

--- a/src/ap2_timeline.h
+++ b/src/ap2_timeline.h
@@ -1,0 +1,41 @@
+#ifndef __AP2_TIMELINE_H_
+#define __AP2_TIMELINE_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    uint64_t head;
+    uint64_t shifted_frames;
+    uint32_t offset;
+} ap2_timeline_recovery_t;
+
+/*
+ * Plan a recovery after PCM starvation exhausted the realtime lead.
+ *
+ * Audio RTP stays contiguous (no content is skipped); the scheduling head is
+ * moved into the future and the effective offset moves backward by the same
+ * amount, preserving the modulo-32-bit invariant:
+ *
+ *     rtp_timestamp == (uint32_t)head + offset
+ */
+static inline bool ap2_timeline_plan_recovery(
+    uint64_t head, uint32_t rtp_timestamp, uint32_t offset,
+    uint64_t now, uint64_t floor, uint64_t recovery_lead,
+    ap2_timeline_recovery_t *plan)
+{
+    if (!plan || head > now + floor) return false;
+    uint64_t desired = now + recovery_lead;
+    if (desired <= head) return false;
+
+    uint64_t shifted = desired - head;
+    uint32_t adjusted = offset - (uint32_t)shifted;
+    if ((uint32_t)desired + adjusted != rtp_timestamp) return false;
+
+    plan->head = desired;
+    plan->shifted_frames = shifted;
+    plan->offset = adjusted;
+    return true;
+}
+
+#endif /* __AP2_TIMELINE_H_ */

--- a/src/ap2_timeline.h
+++ b/src/ap2_timeline.h
@@ -10,11 +10,35 @@ typedef struct {
     uint32_t offset;
 } ap2_timeline_recovery_t;
 
+typedef struct {
+    uint32_t frame_1;
+    uint32_t frame_2;
+} ap2_timeline_ptp_anchor_t;
+
 static inline uint64_t ap2_timeline_frames_to_ns(uint64_t frames,
                                                  uint32_t sample_rate)
 {
+    if (!sample_rate) return 0;
     return (frames / sample_rate) * 1000000000ULL +
            ((frames % sample_rate) * 1000000000ULL) / sample_rate;
+}
+
+static inline bool ap2_timeline_ptp_anchor(
+    uint64_t wall_ns, uint64_t anchor_wall_ns, uint32_t anchor_position,
+    uint32_t sample_rate, int latency_ms, ap2_timeline_ptp_anchor_t *anchor)
+{
+    if (!anchor || !sample_rate) return false;
+    int64_t elapsed_ns = (int64_t)wall_ns - (int64_t)anchor_wall_ns -
+                         (int64_t)latency_ms * 1000000LL;
+    int64_t elapsed_seconds = elapsed_ns / 1000000000LL;
+    int64_t remainder_ns = elapsed_ns % 1000000000LL;
+    int64_t elapsed_frames =
+        elapsed_seconds * sample_rate +
+        (remainder_ns * sample_rate) / 1000000000LL;
+    uint32_t play_position = anchor_position + (uint32_t)elapsed_frames;
+    anchor->frame_1 = play_position + 11035;
+    anchor->frame_2 = anchor->frame_1 + 77175;
+    return true;
 }
 
 /*

--- a/src/ap2_timeline.h
+++ b/src/ap2_timeline.h
@@ -10,6 +10,13 @@ typedef struct {
     uint32_t offset;
 } ap2_timeline_recovery_t;
 
+static inline uint64_t ap2_timeline_frames_to_ns(uint64_t frames,
+                                                 uint32_t sample_rate)
+{
+    return (frames / sample_rate) * 1000000000ULL +
+           ((frames % sample_rate) * 1000000000ULL) / sample_rate;
+}
+
 /*
  * Plan a recovery after PCM starvation exhausted the realtime lead.
  *

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -20,6 +20,7 @@
 #define HTTP_HEADER_MAX    (64 * 1024)
 #define ARTWORK_FETCH_TIMEOUT_MS 5000
 #define ARTWORK_DNS_TIMEOUT_MS   2000
+#define ARTWORK_CONNECT_ATTEMPT_MS 1000
 #define ARTWORK_IMAGEPROXY_SIZE  512
 
 typedef struct {
@@ -372,8 +373,11 @@ static int artwork_connect(const artwork_url_t *url, int64_t deadline_ms,
         }
         int status = connect(fd, addr->ai_addr, addr->ai_addrlen);
         if (status == 0) break;
+        int64_t attempt_deadline =
+            artwork_now_ms() + ARTWORK_CONNECT_ATTEMPT_MS;
+        if (attempt_deadline > deadline_ms) attempt_deadline = deadline_ms;
         if (errno == EINPROGRESS &&
-            artwork_wait_fd(fd, POLLOUT, deadline_ms)) {
+            artwork_wait_fd(fd, POLLOUT, attempt_deadline)) {
             int socket_error = 0;
             socklen_t error_len = sizeof(socket_error);
             if (getsockopt(fd, SOL_SOCKET, SO_ERROR,

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -682,8 +682,7 @@ read_error:
 }
 
 bool artwork_load(const char *source, uint8_t **data, size_t *size,
-                  char content_type[32],
-                  char *error, size_t error_size)
+                  char content_type[32], char *error, size_t error_size)
 {
     if (!source || !*source || !data || !size || !content_type) {
         artwork_error(error, error_size, "invalid artwork source");

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -251,7 +251,6 @@ static void *artwork_resolver_thread(void *arg)
 static bool artwork_resolve(const artwork_url_t *url,
                             struct addrinfo **addresses,
                             int64_t deadline_ms,
-                            artwork_pump_cb pump, void *pump_arg,
                             char *error, size_t error_size)
 {
     artwork_resolver_t *job = calloc(1, sizeof(*job));
@@ -314,7 +313,6 @@ static bool artwork_resolve(const artwork_url_t *url,
             artwork_error(error, error_size, "artwork DNS lookup failed");
             return false;
         }
-        if (pump) pump(pump_arg);
     }
     pthread_join(thread, NULL);
 
@@ -331,8 +329,7 @@ static bool artwork_resolve(const artwork_url_t *url,
     return ok;
 }
 
-static bool artwork_wait_fd(int fd, short events, int64_t deadline_ms,
-                            artwork_pump_cb pump, void *pump_arg)
+static bool artwork_wait_fd(int fd, short events, int64_t deadline_ms)
 {
     while (true) {
         int remaining = artwork_remaining_ms(deadline_ms);
@@ -348,17 +345,14 @@ static bool artwork_wait_fd(int fd, short events, int64_t deadline_ms,
         }
         if (status < 0 && errno == EINTR) continue;
         if (status < 0) return false;
-        if (pump) pump(pump_arg);
     }
 }
 
 static int artwork_connect(const artwork_url_t *url, int64_t deadline_ms,
-                           artwork_pump_cb pump, void *pump_arg,
                            char *error, size_t error_size)
 {
     struct addrinfo *addresses = NULL;
-    if (!artwork_resolve(url, &addresses, deadline_ms, pump, pump_arg,
-                         error, error_size))
+    if (!artwork_resolve(url, &addresses, deadline_ms, error, error_size))
         return -1;
 
     int fd = -1;
@@ -379,7 +373,7 @@ static int artwork_connect(const artwork_url_t *url, int64_t deadline_ms,
         int status = connect(fd, addr->ai_addr, addr->ai_addrlen);
         if (status == 0) break;
         if (errno == EINPROGRESS &&
-            artwork_wait_fd(fd, POLLOUT, deadline_ms, pump, pump_arg)) {
+            artwork_wait_fd(fd, POLLOUT, deadline_ms)) {
             int socket_error = 0;
             socklen_t error_len = sizeof(socket_error);
             if (getsockopt(fd, SOL_SOCKET, SO_ERROR,
@@ -397,12 +391,11 @@ static int artwork_connect(const artwork_url_t *url, int64_t deadline_ms,
 }
 
 static bool artwork_write_all(int fd, const uint8_t *data, size_t size,
-                              int64_t deadline_ms,
-                              artwork_pump_cb pump, void *pump_arg)
+                              int64_t deadline_ms)
 {
     size_t off = 0;
     while (off < size) {
-        if (!artwork_wait_fd(fd, POLLOUT, deadline_ms, pump, pump_arg))
+        if (!artwork_wait_fd(fd, POLLOUT, deadline_ms))
             return false;
 #ifdef MSG_NOSIGNAL
         ssize_t written = send(fd, data + off, size - off, MSG_NOSIGNAL);
@@ -508,14 +501,12 @@ malformed:
 
 static bool artwork_fetch_http(const char *source, uint8_t **data, size_t *size,
                                char content_type[32],
-                               artwork_pump_cb pump, void *pump_arg,
                                char *error, size_t error_size)
 {
     artwork_url_t url = {0};
     if (!artwork_parse_url(source, &url, error, error_size)) return false;
     int64_t deadline_ms = artwork_now_ms() + ARTWORK_FETCH_TIMEOUT_MS;
-    int fd = artwork_connect(&url, deadline_ms, pump, pump_arg,
-                             error, error_size);
+    int fd = artwork_connect(&url, deadline_ms, error, error_size);
     if (fd < 0) return false;
 
     char request[4608];
@@ -529,8 +520,7 @@ static bool artwork_fetch_http(const char *source, uint8_t **data, size_t *size,
         url.path, url.host_header);
     if (request_len <= 0 || request_len >= (int)sizeof(request) ||
         !artwork_write_all(fd, (const uint8_t *)request,
-                           (size_t)request_len, deadline_ms,
-                           pump, pump_arg)) {
+                           (size_t)request_len, deadline_ms)) {
         artwork_error(error, error_size, "cannot send artwork request");
         close(fd);
         return false;
@@ -551,7 +541,7 @@ static bool artwork_fetch_http(const char *source, uint8_t **data, size_t *size,
             response = grown;
             cap = next;
         }
-        if (!artwork_wait_fd(fd, POLLIN, deadline_ms, pump, pump_arg)) break;
+        if (!artwork_wait_fd(fd, POLLIN, deadline_ms)) break;
         ssize_t got = recv(fd, response + used, cap - used, 0);
         if (got > 0) {
             used += (size_t)got;
@@ -692,7 +682,7 @@ read_error:
 }
 
 bool artwork_load(const char *source, uint8_t **data, size_t *size,
-                  char content_type[32], artwork_pump_cb pump, void *pump_arg,
+                  char content_type[32],
                   char *error, size_t error_size)
 {
     if (!source || !*source || !data || !size || !content_type) {
@@ -704,7 +694,6 @@ bool artwork_load(const char *source, uint8_t **data, size_t *size,
     content_type[0] = '\0';
     if (strncmp(source, "http://", 7) == 0)
         return artwork_fetch_http(source, data, size, content_type,
-                                  pump, pump_arg,
                                   error, error_size);
     if (strncmp(source, "https://", 8) == 0) {
         artwork_error(error, error_size,

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -251,6 +251,7 @@ static void *artwork_resolver_thread(void *arg)
 static bool artwork_resolve(const artwork_url_t *url,
                             struct addrinfo **addresses,
                             int64_t deadline_ms,
+                            artwork_pump_cb pump, void *pump_arg,
                             char *error, size_t error_size)
 {
     artwork_resolver_t *job = calloc(1, sizeof(*job));
@@ -272,29 +273,49 @@ static bool artwork_resolve(const artwork_url_t *url,
         return false;
     }
 
-    int remaining = artwork_remaining_ms(deadline_ms);
-    if (remaining > ARTWORK_DNS_TIMEOUT_MS) remaining = ARTWORK_DNS_TIMEOUT_MS;
-    struct timespec timeout;
-    clock_gettime(CLOCK_REALTIME, &timeout);
-    timeout.tv_sec += remaining / 1000;
-    timeout.tv_nsec += (long)(remaining % 1000) * 1000000L;
-    if (timeout.tv_nsec >= 1000000000L) {
-        timeout.tv_sec++;
-        timeout.tv_nsec -= 1000000000L;
-    }
-
-    pthread_mutex_lock(&job->lock);
-    int wait_status = 0;
-    while (!job->done && wait_status == 0)
-        wait_status = pthread_cond_timedwait(&job->ready, &job->lock, &timeout);
-    if (!job->done) {
-        job->abandoned = true;
+    int64_t dns_deadline = artwork_now_ms() + ARTWORK_DNS_TIMEOUT_MS;
+    if (dns_deadline > deadline_ms) dns_deadline = deadline_ms;
+    while (true) {
+        int remaining = artwork_remaining_ms(dns_deadline);
+        pthread_mutex_lock(&job->lock);
+        if (job->done) {
+            pthread_mutex_unlock(&job->lock);
+            break;
+        }
+        if (!remaining) {
+            job->abandoned = true;
+            pthread_mutex_unlock(&job->lock);
+            pthread_detach(thread);
+            artwork_error(error, error_size, "artwork DNS lookup timed out");
+            return false;
+        }
+        int slice = remaining > 250 ? 250 : remaining;
+        struct timespec timeout;
+        clock_gettime(CLOCK_REALTIME, &timeout);
+        timeout.tv_nsec += (long)slice * 1000000L;
+        if (timeout.tv_nsec >= 1000000000L) {
+            timeout.tv_sec++;
+            timeout.tv_nsec -= 1000000000L;
+        }
+        int wait_status = pthread_cond_timedwait(
+            &job->ready, &job->lock, &timeout);
+        bool done = job->done;
         pthread_mutex_unlock(&job->lock);
-        pthread_detach(thread);
-        artwork_error(error, error_size, "artwork DNS lookup timed out");
-        return false;
+        if (done) break;
+        if (wait_status != 0 && wait_status != ETIMEDOUT) {
+            pthread_mutex_lock(&job->lock);
+            if (job->done) {
+                pthread_mutex_unlock(&job->lock);
+                break;
+            }
+            job->abandoned = true;
+            pthread_mutex_unlock(&job->lock);
+            pthread_detach(thread);
+            artwork_error(error, error_size, "artwork DNS lookup failed");
+            return false;
+        }
+        if (pump) pump(pump_arg);
     }
-    pthread_mutex_unlock(&job->lock);
     pthread_join(thread, NULL);
 
     bool ok = job->status == 0 && job->addresses;
@@ -310,13 +331,15 @@ static bool artwork_resolve(const artwork_url_t *url,
     return ok;
 }
 
-static bool artwork_wait_fd(int fd, short events, int64_t deadline_ms)
+static bool artwork_wait_fd(int fd, short events, int64_t deadline_ms,
+                            artwork_pump_cb pump, void *pump_arg)
 {
     while (true) {
         int remaining = artwork_remaining_ms(deadline_ms);
         if (!remaining) return false;
+        int slice = remaining > 250 ? 250 : remaining;
         struct pollfd pfd = {.fd = fd, .events = events};
-        int status = poll(&pfd, 1, remaining);
+        int status = poll(&pfd, 1, slice);
         if (status > 0) {
             if (pfd.revents & (POLLERR | POLLNVAL)) return false;
             if (pfd.revents & events) return true;
@@ -324,15 +347,18 @@ static bool artwork_wait_fd(int fd, short events, int64_t deadline_ms)
             return false;
         }
         if (status < 0 && errno == EINTR) continue;
-        return false;
+        if (status < 0) return false;
+        if (pump) pump(pump_arg);
     }
 }
 
 static int artwork_connect(const artwork_url_t *url, int64_t deadline_ms,
+                           artwork_pump_cb pump, void *pump_arg,
                            char *error, size_t error_size)
 {
     struct addrinfo *addresses = NULL;
-    if (!artwork_resolve(url, &addresses, deadline_ms, error, error_size))
+    if (!artwork_resolve(url, &addresses, deadline_ms, pump, pump_arg,
+                         error, error_size))
         return -1;
 
     int fd = -1;
@@ -353,7 +379,7 @@ static int artwork_connect(const artwork_url_t *url, int64_t deadline_ms,
         int status = connect(fd, addr->ai_addr, addr->ai_addrlen);
         if (status == 0) break;
         if (errno == EINPROGRESS &&
-            artwork_wait_fd(fd, POLLOUT, deadline_ms)) {
+            artwork_wait_fd(fd, POLLOUT, deadline_ms, pump, pump_arg)) {
             int socket_error = 0;
             socklen_t error_len = sizeof(socket_error);
             if (getsockopt(fd, SOL_SOCKET, SO_ERROR,
@@ -371,11 +397,13 @@ static int artwork_connect(const artwork_url_t *url, int64_t deadline_ms,
 }
 
 static bool artwork_write_all(int fd, const uint8_t *data, size_t size,
-                              int64_t deadline_ms)
+                              int64_t deadline_ms,
+                              artwork_pump_cb pump, void *pump_arg)
 {
     size_t off = 0;
     while (off < size) {
-        if (!artwork_wait_fd(fd, POLLOUT, deadline_ms)) return false;
+        if (!artwork_wait_fd(fd, POLLOUT, deadline_ms, pump, pump_arg))
+            return false;
 #ifdef MSG_NOSIGNAL
         ssize_t written = send(fd, data + off, size - off, MSG_NOSIGNAL);
 #else
@@ -480,12 +508,14 @@ malformed:
 
 static bool artwork_fetch_http(const char *source, uint8_t **data, size_t *size,
                                char content_type[32],
+                               artwork_pump_cb pump, void *pump_arg,
                                char *error, size_t error_size)
 {
     artwork_url_t url = {0};
     if (!artwork_parse_url(source, &url, error, error_size)) return false;
     int64_t deadline_ms = artwork_now_ms() + ARTWORK_FETCH_TIMEOUT_MS;
-    int fd = artwork_connect(&url, deadline_ms, error, error_size);
+    int fd = artwork_connect(&url, deadline_ms, pump, pump_arg,
+                             error, error_size);
     if (fd < 0) return false;
 
     char request[4608];
@@ -499,7 +529,8 @@ static bool artwork_fetch_http(const char *source, uint8_t **data, size_t *size,
         url.path, url.host_header);
     if (request_len <= 0 || request_len >= (int)sizeof(request) ||
         !artwork_write_all(fd, (const uint8_t *)request,
-                           (size_t)request_len, deadline_ms)) {
+                           (size_t)request_len, deadline_ms,
+                           pump, pump_arg)) {
         artwork_error(error, error_size, "cannot send artwork request");
         close(fd);
         return false;
@@ -520,7 +551,7 @@ static bool artwork_fetch_http(const char *source, uint8_t **data, size_t *size,
             response = grown;
             cap = next;
         }
-        if (!artwork_wait_fd(fd, POLLIN, deadline_ms)) break;
+        if (!artwork_wait_fd(fd, POLLIN, deadline_ms, pump, pump_arg)) break;
         ssize_t got = recv(fd, response + used, cap - used, 0);
         if (got > 0) {
             used += (size_t)got;
@@ -661,7 +692,8 @@ read_error:
 }
 
 bool artwork_load(const char *source, uint8_t **data, size_t *size,
-                  char content_type[32], char *error, size_t error_size)
+                  char content_type[32], artwork_pump_cb pump, void *pump_arg,
+                  char *error, size_t error_size)
 {
     if (!source || !*source || !data || !size || !content_type) {
         artwork_error(error, error_size, "invalid artwork source");
@@ -672,6 +704,7 @@ bool artwork_load(const char *source, uint8_t **data, size_t *size,
     content_type[0] = '\0';
     if (strncmp(source, "http://", 7) == 0)
         return artwork_fetch_http(source, data, size, content_type,
+                                  pump, pump_arg,
                                   error, error_size);
     if (strncmp(source, "https://", 8) == 0) {
         artwork_error(error, error_size,

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -1,0 +1,683 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "artwork.h"
+
+#define ARTWORK_MAX_BYTES (5 * 1024 * 1024)
+#define HTTP_HEADER_MAX    (64 * 1024)
+#define ARTWORK_FETCH_TIMEOUT_MS 5000
+#define ARTWORK_DNS_TIMEOUT_MS   2000
+#define ARTWORK_IMAGEPROXY_SIZE  512
+
+typedef struct {
+    char host[256];
+    char port[8];
+    char host_header[288];
+    char path[4096];
+} artwork_url_t;
+
+typedef struct {
+    pthread_mutex_t lock;
+    pthread_cond_t ready;
+    bool done;
+    bool abandoned;
+    int status;
+    struct addrinfo *addresses;
+    char host[256];
+    char port[8];
+} artwork_resolver_t;
+
+static void artwork_error(char *error, size_t error_size, const char *fmt, ...)
+{
+    if (!error || !error_size) return;
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(error, error_size, fmt, args);
+    va_end(args);
+}
+
+static bool artwork_detect_type(const uint8_t *data, size_t size,
+                                char content_type[32])
+{
+    const char *mime = NULL;
+    if (size >= 3 && data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF) {
+        mime = "image/jpeg";
+    } else if (size >= 8 &&
+               memcmp(data, "\x89PNG\r\n\x1a\n", 8) == 0) {
+        mime = "image/png";
+    } else if (size >= 6 &&
+               (memcmp(data, "GIF87a", 6) == 0 ||
+                memcmp(data, "GIF89a", 6) == 0)) {
+        mime = "image/gif";
+    } else if (size >= 12 && memcmp(data, "RIFF", 4) == 0 &&
+               memcmp(data + 8, "WEBP", 4) == 0) {
+        mime = "image/webp";
+    }
+    if (!mime) return false;
+    snprintf(content_type, 32, "%s", mime);
+    return true;
+}
+
+static bool artwork_normalize_imageproxy_path(char path[4096],
+                                              char *error, size_t error_size)
+{
+    if (!strstr(path, "/imageproxy/")) return true;
+
+    char normalized[4096];
+    const char *query = strchr(path, '?');
+    size_t base_len = query ? (size_t)(query - path) : strlen(path);
+    if (base_len >= sizeof(normalized)) goto too_long;
+    memcpy(normalized, path, base_len);
+    size_t used = base_len;
+    bool have_param = false;
+
+    if (query) {
+        const char *param = query + 1;
+        while (*param) {
+            const char *end = strchr(param, '&');
+            if (!end) end = param + strlen(param);
+            const char *equals = memchr(param, '=', (size_t)(end - param));
+            size_t key_len = (size_t)((equals ? equals : end) - param);
+            bool replace = (key_len == 4 && strncmp(param, "size", 4) == 0) ||
+                           (key_len == 3 && strncmp(param, "fmt", 3) == 0);
+            if (!replace && end > param) {
+                size_t param_len = (size_t)(end - param);
+                if (used + 1 + param_len >= sizeof(normalized)) goto too_long;
+                normalized[used++] = have_param ? '&' : '?';
+                memcpy(normalized + used, param, param_len);
+                used += param_len;
+                have_param = true;
+            }
+            param = *end ? end + 1 : end;
+        }
+    }
+
+    int appended = snprintf(
+        normalized + used, sizeof(normalized) - used,
+        "%csize=%d&fmt=jpeg", have_param ? '&' : '?',
+        ARTWORK_IMAGEPROXY_SIZE);
+    if (appended <= 0 || (size_t)appended >= sizeof(normalized) - used)
+        goto too_long;
+    snprintf(path, 4096, "%s", normalized);
+    return true;
+
+too_long:
+    artwork_error(error, error_size, "normalized imageproxy URL is too long");
+    return false;
+}
+
+static bool artwork_parse_url(const char *url, artwork_url_t *parsed,
+                              char *error, size_t error_size)
+{
+    if (strncmp(url, "http://", 7) != 0) {
+        artwork_error(error, error_size,
+                      "only local files and http:// artwork URLs are supported");
+        return false;
+    }
+    const char *authority = url + 7;
+    const char *path = strchr(authority, '/');
+    const char *authority_end = path ? path : url + strlen(url);
+    if (authority == authority_end ||
+        memchr(authority, '@', (size_t)(authority_end - authority))) {
+        artwork_error(error, error_size, "invalid artwork URL authority");
+        return false;
+    }
+
+    const char *host_start = authority;
+    const char *host_end = authority_end;
+    const char *port_start = NULL;
+    if (*host_start == '[') {
+        const char *close = memchr(host_start, ']',
+                                   (size_t)(authority_end - host_start));
+        if (!close) {
+            artwork_error(error, error_size, "invalid bracketed artwork host");
+            return false;
+        }
+        host_start++;
+        host_end = close;
+        if (close + 1 < authority_end) {
+            if (close[1] != ':') {
+                artwork_error(error, error_size, "invalid artwork URL port");
+                return false;
+            }
+            port_start = close + 2;
+        }
+    } else {
+        const char *colon = memchr(authority, ':',
+                                   (size_t)(authority_end - authority));
+        if (colon) {
+            host_end = colon;
+            port_start = colon + 1;
+        }
+    }
+
+    size_t host_len = (size_t)(host_end - host_start);
+    if (!host_len || host_len >= sizeof(parsed->host)) {
+        artwork_error(error, error_size, "artwork URL host is too long");
+        return false;
+    }
+    memcpy(parsed->host, host_start, host_len);
+    parsed->host[host_len] = '\0';
+
+    if (port_start) {
+        size_t port_len = (size_t)(authority_end - port_start);
+        if (!port_len || port_len >= sizeof(parsed->port)) {
+            artwork_error(error, error_size, "invalid artwork URL port");
+            return false;
+        }
+        for (size_t i = 0; i < port_len; i++) {
+            if (port_start[i] < '0' || port_start[i] > '9') {
+                artwork_error(error, error_size, "invalid artwork URL port");
+                return false;
+            }
+        }
+        memcpy(parsed->port, port_start, port_len);
+        parsed->port[port_len] = '\0';
+    } else {
+        snprintf(parsed->port, sizeof(parsed->port), "80");
+    }
+
+    size_t authority_len = (size_t)(authority_end - authority);
+    if (authority_len >= sizeof(parsed->host_header)) {
+        artwork_error(error, error_size, "artwork URL authority is too long");
+        return false;
+    }
+    memcpy(parsed->host_header, authority, authority_len);
+    parsed->host_header[authority_len] = '\0';
+
+    const char *request_path = path ? path : "/";
+    size_t path_len = strcspn(request_path, "#");
+    if (!path_len || path_len >= sizeof(parsed->path)) {
+        artwork_error(error, error_size, "artwork URL path is too long");
+        return false;
+    }
+    memcpy(parsed->path, request_path, path_len);
+    parsed->path[path_len] = '\0';
+    return artwork_normalize_imageproxy_path(parsed->path, error, error_size);
+}
+
+static int64_t artwork_now_ms(void)
+{
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return (int64_t)now.tv_sec * 1000 + now.tv_nsec / 1000000;
+}
+
+static int artwork_remaining_ms(int64_t deadline_ms)
+{
+    int64_t remaining = deadline_ms - artwork_now_ms();
+    if (remaining <= 0) return 0;
+    return remaining > 0x7fffffff ? 0x7fffffff : (int)remaining;
+}
+
+static void *artwork_resolver_thread(void *arg)
+{
+    artwork_resolver_t *job = arg;
+    struct addrinfo hints = {0}, *addresses = NULL;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    int status = getaddrinfo(job->host, job->port, &hints, &addresses);
+
+    pthread_mutex_lock(&job->lock);
+    if (job->abandoned) {
+        pthread_mutex_unlock(&job->lock);
+        if (addresses) freeaddrinfo(addresses);
+        pthread_cond_destroy(&job->ready);
+        pthread_mutex_destroy(&job->lock);
+        free(job);
+        return NULL;
+    }
+    job->status = status;
+    job->addresses = addresses;
+    job->done = true;
+    pthread_cond_signal(&job->ready);
+    pthread_mutex_unlock(&job->lock);
+    return NULL;
+}
+
+static bool artwork_resolve(const artwork_url_t *url,
+                            struct addrinfo **addresses,
+                            int64_t deadline_ms,
+                            char *error, size_t error_size)
+{
+    artwork_resolver_t *job = calloc(1, sizeof(*job));
+    if (!job) {
+        artwork_error(error, error_size, "out of memory resolving artwork host");
+        return false;
+    }
+    pthread_mutex_init(&job->lock, NULL);
+    pthread_cond_init(&job->ready, NULL);
+    snprintf(job->host, sizeof(job->host), "%s", url->host);
+    snprintf(job->port, sizeof(job->port), "%s", url->port);
+
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, artwork_resolver_thread, job) != 0) {
+        pthread_cond_destroy(&job->ready);
+        pthread_mutex_destroy(&job->lock);
+        free(job);
+        artwork_error(error, error_size, "cannot start artwork DNS lookup");
+        return false;
+    }
+
+    int remaining = artwork_remaining_ms(deadline_ms);
+    if (remaining > ARTWORK_DNS_TIMEOUT_MS) remaining = ARTWORK_DNS_TIMEOUT_MS;
+    struct timespec timeout;
+    clock_gettime(CLOCK_REALTIME, &timeout);
+    timeout.tv_sec += remaining / 1000;
+    timeout.tv_nsec += (long)(remaining % 1000) * 1000000L;
+    if (timeout.tv_nsec >= 1000000000L) {
+        timeout.tv_sec++;
+        timeout.tv_nsec -= 1000000000L;
+    }
+
+    pthread_mutex_lock(&job->lock);
+    int wait_status = 0;
+    while (!job->done && wait_status == 0)
+        wait_status = pthread_cond_timedwait(&job->ready, &job->lock, &timeout);
+    if (!job->done) {
+        job->abandoned = true;
+        pthread_mutex_unlock(&job->lock);
+        pthread_detach(thread);
+        artwork_error(error, error_size, "artwork DNS lookup timed out");
+        return false;
+    }
+    pthread_mutex_unlock(&job->lock);
+    pthread_join(thread, NULL);
+
+    bool ok = job->status == 0 && job->addresses;
+    if (ok) {
+        *addresses = job->addresses;
+    } else {
+        if (job->addresses) freeaddrinfo(job->addresses);
+        artwork_error(error, error_size, "cannot resolve artwork host");
+    }
+    pthread_cond_destroy(&job->ready);
+    pthread_mutex_destroy(&job->lock);
+    free(job);
+    return ok;
+}
+
+static bool artwork_wait_fd(int fd, short events, int64_t deadline_ms)
+{
+    while (true) {
+        int remaining = artwork_remaining_ms(deadline_ms);
+        if (!remaining) return false;
+        struct pollfd pfd = {.fd = fd, .events = events};
+        int status = poll(&pfd, 1, remaining);
+        if (status > 0) {
+            if (pfd.revents & (POLLERR | POLLNVAL)) return false;
+            if (pfd.revents & events) return true;
+            if ((events & POLLIN) && (pfd.revents & POLLHUP)) return true;
+            return false;
+        }
+        if (status < 0 && errno == EINTR) continue;
+        return false;
+    }
+}
+
+static int artwork_connect(const artwork_url_t *url, int64_t deadline_ms,
+                           char *error, size_t error_size)
+{
+    struct addrinfo *addresses = NULL;
+    if (!artwork_resolve(url, &addresses, deadline_ms, error, error_size))
+        return -1;
+
+    int fd = -1;
+    for (struct addrinfo *addr = addresses; addr; addr = addr->ai_next) {
+        if (!artwork_remaining_ms(deadline_ms)) break;
+        fd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+        if (fd < 0) continue;
+#ifdef SO_NOSIGPIPE
+        int one = 1;
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
+#endif
+        int flags = fcntl(fd, F_GETFL, 0);
+        if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+            close(fd);
+            fd = -1;
+            continue;
+        }
+        int status = connect(fd, addr->ai_addr, addr->ai_addrlen);
+        if (status == 0) break;
+        if (errno == EINPROGRESS &&
+            artwork_wait_fd(fd, POLLOUT, deadline_ms)) {
+            int socket_error = 0;
+            socklen_t error_len = sizeof(socket_error);
+            if (getsockopt(fd, SOL_SOCKET, SO_ERROR,
+                           &socket_error, &error_len) == 0 &&
+                socket_error == 0)
+                break;
+        }
+        close(fd);
+        fd = -1;
+    }
+    freeaddrinfo(addresses);
+    if (fd < 0)
+        artwork_error(error, error_size, "cannot connect to artwork host");
+    return fd;
+}
+
+static bool artwork_write_all(int fd, const uint8_t *data, size_t size,
+                              int64_t deadline_ms)
+{
+    size_t off = 0;
+    while (off < size) {
+        if (!artwork_wait_fd(fd, POLLOUT, deadline_ms)) return false;
+#ifdef MSG_NOSIGNAL
+        ssize_t written = send(fd, data + off, size - off, MSG_NOSIGNAL);
+#else
+        ssize_t written = send(fd, data + off, size - off, 0);
+#endif
+        if (written > 0) {
+            off += (size_t)written;
+        } else if (written < 0 &&
+                   (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)) {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+static size_t artwork_header_end(const uint8_t *data, size_t size)
+{
+    for (size_t i = 0; i + 3 < size; i++) {
+        if (data[i] == '\r' && data[i + 1] == '\n' &&
+            data[i + 2] == '\r' && data[i + 3] == '\n')
+            return i + 4;
+    }
+    return 0;
+}
+
+static bool artwork_header_value(const char *header, const char *name,
+                                 char *out, size_t out_size)
+{
+    size_t name_len = strlen(name);
+    const char *line = strstr(header, "\r\n");
+    if (!line) return false;
+    line += 2;
+    while (*line) {
+        const char *end = strstr(line, "\r\n");
+        if (!end || end == line) break;
+        size_t line_len = (size_t)(end - line);
+        if (line_len > name_len && line[name_len] == ':' &&
+            strncasecmp(line, name, name_len) == 0) {
+            const char *value = line + name_len + 1;
+            while (value < end && (*value == ' ' || *value == '\t')) value++;
+            while (end > value && (end[-1] == ' ' || end[-1] == '\t')) end--;
+            size_t value_len = (size_t)(end - value);
+            if (value_len >= out_size) value_len = out_size - 1;
+            memcpy(out, value, value_len);
+            out[value_len] = '\0';
+            return true;
+        }
+        line = end + 2;
+    }
+    return false;
+}
+
+static bool artwork_decode_chunked(const uint8_t *body, size_t body_size,
+                                   uint8_t **decoded, size_t *decoded_size,
+                                   char *error, size_t error_size)
+{
+    uint8_t *out = malloc(ARTWORK_MAX_BYTES);
+    if (!out) {
+        artwork_error(error, error_size, "out of memory decoding artwork");
+        return false;
+    }
+    size_t in = 0, used = 0;
+    while (in < body_size) {
+        size_t line_end = in;
+        while (line_end + 1 < body_size &&
+               !(body[line_end] == '\r' && body[line_end + 1] == '\n'))
+            line_end++;
+        if (line_end + 1 >= body_size || line_end - in >= 32) goto malformed;
+
+        char size_text[33];
+        size_t size_len = line_end - in;
+        memcpy(size_text, body + in, size_len);
+        size_text[size_len] = '\0';
+        char *extension = strchr(size_text, ';');
+        if (extension) *extension = '\0';
+        char *end = NULL;
+        unsigned long chunk = strtoul(size_text, &end, 16);
+        if (!end || end == size_text || *end != '\0') goto malformed;
+        in = line_end + 2;
+        if (chunk == 0) {
+            *decoded = out;
+            *decoded_size = used;
+            return true;
+        }
+        if (chunk > ARTWORK_MAX_BYTES - used ||
+            chunk > body_size - in ||
+            in + chunk + 2 > body_size ||
+            body[in + chunk] != '\r' || body[in + chunk + 1] != '\n')
+            goto malformed;
+        memcpy(out + used, body + in, chunk);
+        used += chunk;
+        in += chunk + 2;
+    }
+
+malformed:
+    free(out);
+    artwork_error(error, error_size, "malformed chunked artwork response");
+    return false;
+}
+
+static bool artwork_fetch_http(const char *source, uint8_t **data, size_t *size,
+                               char content_type[32],
+                               char *error, size_t error_size)
+{
+    artwork_url_t url = {0};
+    if (!artwork_parse_url(source, &url, error, error_size)) return false;
+    int64_t deadline_ms = artwork_now_ms() + ARTWORK_FETCH_TIMEOUT_MS;
+    int fd = artwork_connect(&url, deadline_ms, error, error_size);
+    if (fd < 0) return false;
+
+    char request[4608];
+    int request_len = snprintf(
+        request, sizeof(request),
+        "GET %s HTTP/1.1\r\n"
+        "Host: %s\r\n"
+        "Accept: image/jpeg, image/png, image/*;q=0.8\r\n"
+        "Connection: close\r\n"
+        "User-Agent: cliairplay/0.1\r\n\r\n",
+        url.path, url.host_header);
+    if (request_len <= 0 || request_len >= (int)sizeof(request) ||
+        !artwork_write_all(fd, (const uint8_t *)request,
+                           (size_t)request_len, deadline_ms)) {
+        artwork_error(error, error_size, "cannot send artwork request");
+        close(fd);
+        return false;
+    }
+
+    size_t cap = HTTP_HEADER_MAX;
+    size_t used = 0;
+    uint8_t *response = malloc(cap);
+    bool ok = false;
+    while (response) {
+        if (used == cap) {
+            if (cap >= ARTWORK_MAX_BYTES + HTTP_HEADER_MAX) break;
+            size_t next = cap * 2;
+            if (next > ARTWORK_MAX_BYTES + HTTP_HEADER_MAX)
+                next = ARTWORK_MAX_BYTES + HTTP_HEADER_MAX;
+            uint8_t *grown = realloc(response, next);
+            if (!grown) break;
+            response = grown;
+            cap = next;
+        }
+        if (!artwork_wait_fd(fd, POLLIN, deadline_ms)) break;
+        ssize_t got = recv(fd, response + used, cap - used, 0);
+        if (got > 0) {
+            used += (size_t)got;
+        } else if (got == 0) {
+            ok = true;
+            break;
+        } else if (errno != EINTR && errno != EAGAIN &&
+                   errno != EWOULDBLOCK) {
+            break;
+        }
+    }
+    close(fd);
+    if (!ok || !response) {
+        free(response);
+        artwork_error(error, error_size, "incomplete artwork HTTP response");
+        return false;
+    }
+
+    size_t header_len = artwork_header_end(response, used);
+    if (!header_len || header_len >= HTTP_HEADER_MAX) {
+        free(response);
+        artwork_error(error, error_size, "invalid artwork HTTP response");
+        return false;
+    }
+    char *header = malloc(header_len + 1);
+    if (!header) {
+        free(response);
+        artwork_error(error, error_size, "out of memory parsing artwork");
+        return false;
+    }
+    memcpy(header, response, header_len);
+    header[header_len] = '\0';
+    int status = 0;
+    if (sscanf(header, "HTTP/%*s %d", &status) != 1 || status != 200) {
+        free(header);
+        free(response);
+        artwork_error(error, error_size, "artwork HTTP status %d", status);
+        return false;
+    }
+
+    uint8_t *body = response + header_len;
+    size_t body_size = used - header_len;
+    char value[128];
+    uint8_t *image = NULL;
+    size_t image_size = 0;
+    if (artwork_header_value(header, "Transfer-Encoding",
+                             value, sizeof(value)) &&
+        strcasestr(value, "chunked")) {
+        if (!artwork_decode_chunked(body, body_size, &image, &image_size,
+                                    error, error_size)) {
+            free(header);
+            free(response);
+            return false;
+        }
+    } else {
+        if (artwork_header_value(header, "Content-Length",
+                                 value, sizeof(value))) {
+            char *end = NULL;
+            unsigned long declared = strtoul(value, &end, 10);
+            if (!end || end == value || *end != '\0' ||
+                declared > ARTWORK_MAX_BYTES || declared > body_size) {
+                free(header);
+                free(response);
+                artwork_error(error, error_size,
+                              "invalid artwork Content-Length");
+                return false;
+            }
+            body_size = (size_t)declared;
+        }
+        if (!body_size || body_size > ARTWORK_MAX_BYTES) {
+            free(header);
+            free(response);
+            artwork_error(error, error_size, "artwork response is empty or too large");
+            return false;
+        }
+        image = malloc(body_size);
+        if (image) memcpy(image, body, body_size);
+        image_size = body_size;
+    }
+    free(header);
+    free(response);
+    if (!image) {
+        artwork_error(error, error_size, "out of memory loading artwork");
+        return false;
+    }
+    if (!artwork_detect_type(image, image_size, content_type)) {
+        free(image);
+        artwork_error(error, error_size, "artwork response is not a supported image");
+        return false;
+    }
+    *data = image;
+    *size = image_size;
+    return true;
+}
+
+static bool artwork_load_file(const char *path, uint8_t **data, size_t *size,
+                              char content_type[32],
+                              char *error, size_t error_size)
+{
+    FILE *file = fopen(path, "rb");
+    if (!file) {
+        artwork_error(error, error_size, "cannot open artwork file: %s",
+                      strerror(errno));
+        return false;
+    }
+    if (fseek(file, 0, SEEK_END) != 0) goto read_error;
+    long file_size = ftell(file);
+    if (file_size <= 0 || file_size > ARTWORK_MAX_BYTES) {
+        artwork_error(error, error_size, "artwork file is empty or too large");
+        fclose(file);
+        return false;
+    }
+    if (fseek(file, 0, SEEK_SET) != 0) goto read_error;
+    uint8_t *image = malloc((size_t)file_size);
+    if (!image) {
+        artwork_error(error, error_size, "out of memory loading artwork");
+        fclose(file);
+        return false;
+    }
+    if (fread(image, 1, (size_t)file_size, file) != (size_t)file_size) {
+        free(image);
+        goto read_error;
+    }
+    fclose(file);
+    if (!artwork_detect_type(image, (size_t)file_size, content_type)) {
+        free(image);
+        artwork_error(error, error_size, "artwork file is not a supported image");
+        return false;
+    }
+    *data = image;
+    *size = (size_t)file_size;
+    return true;
+
+read_error:
+    artwork_error(error, error_size, "cannot read artwork file");
+    fclose(file);
+    return false;
+}
+
+bool artwork_load(const char *source, uint8_t **data, size_t *size,
+                  char content_type[32], char *error, size_t error_size)
+{
+    if (!source || !*source || !data || !size || !content_type) {
+        artwork_error(error, error_size, "invalid artwork source");
+        return false;
+    }
+    *data = NULL;
+    *size = 0;
+    content_type[0] = '\0';
+    if (strncmp(source, "http://", 7) == 0)
+        return artwork_fetch_http(source, data, size, content_type,
+                                  error, error_size);
+    if (strncmp(source, "https://", 8) == 0) {
+        artwork_error(error, error_size,
+                      "https artwork URLs are not supported; use MA's local imageproxy");
+        return false;
+    }
+    return artwork_load_file(source, data, size, content_type,
+                             error, error_size);
+}

--- a/src/artwork.h
+++ b/src/artwork.h
@@ -5,8 +5,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-typedef void (*artwork_pump_cb)(void *arg);
-
 /*
  * Load artwork from a local path or an http:// URL.
  *
@@ -14,7 +12,7 @@ typedef void (*artwork_pump_cb)(void *arg);
  * from the image signature rather than a filename or HTTP header.
  */
 bool artwork_load(const char *source, uint8_t **data, size_t *size,
-                  char content_type[32], artwork_pump_cb pump, void *pump_arg,
+                  char content_type[32],
                   char *error, size_t error_size);
 
 #endif /* __ARTWORK_H_ */

--- a/src/artwork.h
+++ b/src/artwork.h
@@ -1,0 +1,17 @@
+#ifndef __ARTWORK_H_
+#define __ARTWORK_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Load artwork from a local path or an http:// URL.
+ *
+ * The returned byte buffer is owned by the caller. content_type is inferred
+ * from the image signature rather than a filename or HTTP header.
+ */
+bool artwork_load(const char *source, uint8_t **data, size_t *size,
+                  char content_type[32], char *error, size_t error_size);
+
+#endif /* __ARTWORK_H_ */

--- a/src/artwork.h
+++ b/src/artwork.h
@@ -5,6 +5,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+typedef void (*artwork_pump_cb)(void *arg);
+
 /*
  * Load artwork from a local path or an http:// URL.
  *
@@ -12,6 +14,7 @@
  * from the image signature rather than a filename or HTTP header.
  */
 bool artwork_load(const char *source, uint8_t **data, size_t *size,
-                  char content_type[32], char *error, size_t error_size);
+                  char content_type[32], artwork_pump_cb pump, void *pump_arg,
+                  char *error, size_t error_size);
 
 #endif /* __ARTWORK_H_ */

--- a/src/artwork.h
+++ b/src/artwork.h
@@ -12,7 +12,6 @@
  * from the image signature rather than a filename or HTTP header.
  */
 bool artwork_load(const char *source, uint8_t **data, size_t *size,
-                  char content_type[32],
-                  char *error, size_t error_size);
+                  char content_type[32], char *error, size_t error_size);
 
 #endif /* __ARTWORK_H_ */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -812,6 +812,7 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     uint64_t last_diag = 0;
     uint64_t input_wait_since = 0;
     uint64_t last_input_warn = 0;
+    int pending_n = 0;
 
     /* Main audio loop */
     while (g_status != STATUS_STOPPED && (!got_eof || ap2cl_is_playing(g_ap2cl))) {
@@ -854,42 +855,41 @@ static int run_airplay2(cli_config_t *cfg, int infile)
         /* Send audio chunk */
         if (atomic_load(&g_status) == STATUS_PLAYING &&
             ap2cl_accept_frames(g_ap2cl)) {
-            pthread_mutex_lock(&g_playback_lock);
-            if (atomic_load(&g_status) != STATUS_PLAYING) {
-                pthread_mutex_unlock(&g_playback_lock);
-                continue;
-            }
-            int n = input_ring_read(buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
-            if (n == INPUT_RING_WAIT) {
-                pthread_mutex_unlock(&g_playback_lock);
-                uint64_t wait_now = raopcl_get_ntp(NULL);
-                if (!input_wait_since) input_wait_since = wait_now;
-                uint64_t wait_ms = NTP2MS(wait_now - input_wait_since);
-                if (wait_ms >= 2000 &&
-                    wait_now - last_input_warn >= MS2NTP(5000)) {
-                    size_t ring_fill, ring_capacity;
-                    bool ring_eof;
-                    last_input_warn = wait_now;
-                    input_ring_stats(&ring_fill, &ring_capacity, &ring_eof);
-                    LOG_WARN("[AP2DIAG] PCM input starved for %" PRIu64
-                             "ms (fill=%zu/%zu eof=%d)",
-                             wait_ms, ring_fill, ring_capacity, ring_eof);
+            if (!pending_n) {
+                int n = input_ring_read(
+                    buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
+                if (n == INPUT_RING_WAIT) {
+                    uint64_t wait_now = raopcl_get_ntp(NULL);
+                    if (!input_wait_since) input_wait_since = wait_now;
+                    uint64_t wait_ms = NTP2MS(wait_now - input_wait_since);
+                    if (wait_ms >= 2000 &&
+                        wait_now - last_input_warn >= MS2NTP(5000)) {
+                        size_t ring_fill, ring_capacity;
+                        bool ring_eof;
+                        last_input_warn = wait_now;
+                        input_ring_stats(
+                            &ring_fill, &ring_capacity, &ring_eof);
+                        LOG_WARN("[AP2DIAG] PCM input starved for %" PRIu64
+                                 "ms (fill=%zu/%zu eof=%d)",
+                                 wait_ms, ring_fill, ring_capacity, ring_eof);
+                    }
+                    continue;
+                } else if (n < 0) {
+                    status_error("Error reading from audio source");
+                    failed = true;
+                    break;
+                } else if (n == 0) {
+                    if (!got_eof) {
+                        LOG_INFO("End of audio stream, draining buffer...");
+                        got_eof = true;
+                        eof_time = raopcl_get_ntp(NULL);
+                    }
+                    continue;
                 }
-                continue;
-            } else if (n < 0) {
-                pthread_mutex_unlock(&g_playback_lock);
-                status_error("Error reading from audio source");
-                failed = true;
-                break;
-            } else if (n == 0) {
-                if (!got_eof) {
-                    LOG_INFO("End of audio stream, draining buffer...");
-                    got_eof = true;
-                    eof_time = raopcl_get_ntp(NULL);
-                }
-                pthread_mutex_unlock(&g_playback_lock);
-                continue;
+                pending_n = n;
             }
+            if (atomic_load(&g_status) != STATUS_PLAYING) continue;
+
             if (input_wait_since) {
                 uint64_t waited_ms = NTP2MS(raopcl_get_ntp(NULL) -
                                             input_wait_since);
@@ -900,22 +900,25 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                 input_wait_since = 0;
             }
 
-            int af = n / ap2_input_bpf;
+            int af = pending_n / ap2_input_bpf;
             uint8_t *send = buf;
             if (ap2_alac_buf && cfg->bit_depth > 16) {
-                truncate_32to24(buf, n, ap2_alac_buf);
+                truncate_32to24(buf, pending_n, ap2_alac_buf);
                 send = ap2_alac_buf;
             }
             ap2_send_result_t send_result =
                 ap2cl_send_chunk(g_ap2cl, send, af);
             if (send_result == AP2_SEND_FATAL) {
-                pthread_mutex_unlock(&g_playback_lock);
+                if (errno == EAGAIN) {
+                    usleep(1000);
+                    continue;
+                }
                 status_error("AirPlay audio send failed");
                 failed = true;
                 break;
             }
             frames += af;
-            pthread_mutex_unlock(&g_playback_lock);
+            pending_n = 0;
         } else {
             usleep(1000);
         }

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#include <stdatomic.h>
 #include <assert.h>
 #include <getopt.h>
 #include <sys/stat.h>
@@ -105,8 +106,9 @@ typedef struct {
 } cli_config_t;
 
 /* Globals */
-static bool g_running = true;
-static playback_status_t g_status = STATUS_STOPPED;
+static atomic_bool g_running = true;
+static _Atomic playback_status_t g_status = STATUS_STOPPED;
+static pthread_mutex_t g_playback_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_t g_cmdpipe_thread;
 static int g_cmdpipe_fd = -1;
 static char g_cmdpipe_buf[512];
@@ -178,13 +180,12 @@ static void status_error(const char *msg)
     status_print("[ERROR] %s", msg);
 }
 
-/* Path-A MRP experiment: surface the POST /command response on stdout when it
- * changes, so the caller can log whether the device accepts the push. */
+/* Surface that a path-A MRP update was accepted for asynchronous delivery.
+ * The worker logs each receiver response without blocking audio startup. */
 static void mrp_status_report(int status)
 {
-    static int last;
-    if (status <= 0 || status == last) return;
-    last = status;
+    static atomic_int last;
+    if (status <= 0 || status == atomic_exchange(&last, status)) return;
     printf("[STATUS] mrp path=command status=%d\n", status);
     fflush(stdout);
 }
@@ -408,17 +409,22 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
             ap2cl_set_volume(g_ap2cl, vol);
         }
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "PAUSE") == 0) {
-        if (g_status == STATUS_PLAYING) {
+        bool paused = false;
+        pthread_mutex_lock(&g_playback_lock);
+        if (atomic_load(&g_status) == STATUS_PLAYING) {
             if (cfg->protocol == PROTO_RAOP && g_raopcl) {
                 raopcl_pause(g_raopcl);
                 raopcl_flush(g_raopcl);
             } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
                 ap2cl_pause(g_ap2cl);
             }
-            g_status = STATUS_PAUSED;
-            status_paused(0);
+            atomic_store(&g_status, STATUS_PAUSED);
+            paused = true;
         }
+        pthread_mutex_unlock(&g_playback_lock);
+        if (paused) status_paused(0);
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "PLAY") == 0) {
+        pthread_mutex_lock(&g_playback_lock);
         if (cfg->protocol == PROTO_RAOP && g_raopcl) {
             int latency = raopcl_latency(g_raopcl);
             uint64_t now = raopcl_get_ntp(NULL);
@@ -430,14 +436,17 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         /* No status emission here: reporting elapsed_ms=0 would snap the
          * sender's position display backwards. The periodic reporter (gated on
          * STATUS_PLAYING) re-reports the true elapsed within a second. */
-        g_status = STATUS_PLAYING;
+        atomic_store(&g_status, STATUS_PLAYING);
+        pthread_mutex_unlock(&g_playback_lock);
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "STOP") == 0) {
-        g_status = STATUS_STOPPED;
+        pthread_mutex_lock(&g_playback_lock);
+        atomic_store(&g_status, STATUS_STOPPED);
         if (cfg->protocol == PROTO_RAOP && g_raopcl) {
             raopcl_stop(g_raopcl);
         } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
             ap2cl_stop(g_ap2cl);
         }
+        pthread_mutex_unlock(&g_playback_lock);
         status_print("[STATUS] stopped");
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "SENDMETA") == 0) {
         if (cfg->protocol == PROTO_RAOP && g_raopcl) {
@@ -644,11 +653,19 @@ static int run_raop(cli_config_t *cfg, int infile)
         }
 
         /* Send audio chunk */
-        if (g_status == STATUS_PLAYING && raopcl_accept_frames(g_raopcl)) {
+        if (atomic_load(&g_status) == STATUS_PLAYING &&
+            raopcl_accept_frames(g_raopcl)) {
+            pthread_mutex_lock(&g_playback_lock);
+            if (atomic_load(&g_status) != STATUS_PLAYING) {
+                pthread_mutex_unlock(&g_playback_lock);
+                continue;
+            }
             int n = input_ring_read(buf, DEFAULT_FRAMES_PER_CHUNK * input_bpf);
             if (n == INPUT_RING_WAIT) {
+                pthread_mutex_unlock(&g_playback_lock);
                 continue;
             } else if (n < 0) {
+                pthread_mutex_unlock(&g_playback_lock);
                 status_error("Error reading from audio source");
                 break;
             } else if (n == 0) {
@@ -656,6 +673,7 @@ static int run_raop(cli_config_t *cfg, int infile)
                     LOG_INFO("End of audio stream, draining buffer...");
                     got_eof = true;
                 }
+                pthread_mutex_unlock(&g_playback_lock);
                 continue;
             }
 
@@ -669,6 +687,7 @@ static int run_raop(cli_config_t *cfg, int infile)
             uint64_t playtime;
             raopcl_send_chunk(g_raopcl, send_buf, audio_frames, &playtime);
             frames += audio_frames;
+            pthread_mutex_unlock(&g_playback_lock);
         } else {
             usleep(1000);
         }
@@ -740,11 +759,6 @@ static int run_airplay2(cli_config_t *cfg, int infile)
         }
     }
 
-    /* Register the sender identity before the first now-playing update. The
-     * supported commands, playback state and NowPlayingClient follow that first
-     * update inside ap2cl_mrp_push(), matching Apple's AirPlaySender ordering. */
-    ap2cl_mrp_register(g_ap2cl);
-
     /* Surface the effective lead and the receiver-reported buffering window so
      * the caller (MA) can plan group starts from real device capabilities. */
     {
@@ -780,7 +794,9 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     /* Placeholder metadata must follow ap2cl_start_at: that call sets the RTP
      * timeline the metadata's RTP-Info anchors to. Sent earlier it anchors to
      * rtptime=0 — metadata-gated receivers (Sonos) then show the title but do
-     * not treat it as the audio timeline's metadata and keep audio muted. */
+     * not treat it as the audio timeline's metadata and keep audio muted. The
+     * optional MRP mirror is queued to the maintenance worker, so it cannot
+     * delay entry into the audio loop. */
     send_initial_metadata(cfg);
 
     g_status = STATUS_PLAYING;
@@ -836,9 +852,16 @@ static int run_airplay2(cli_config_t *cfg, int infile)
         }
 
         /* Send audio chunk */
-        if (g_status == STATUS_PLAYING && ap2cl_accept_frames(g_ap2cl)) {
+        if (atomic_load(&g_status) == STATUS_PLAYING &&
+            ap2cl_accept_frames(g_ap2cl)) {
+            pthread_mutex_lock(&g_playback_lock);
+            if (atomic_load(&g_status) != STATUS_PLAYING) {
+                pthread_mutex_unlock(&g_playback_lock);
+                continue;
+            }
             int n = input_ring_read(buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
             if (n == INPUT_RING_WAIT) {
+                pthread_mutex_unlock(&g_playback_lock);
                 uint64_t wait_now = raopcl_get_ntp(NULL);
                 if (!input_wait_since) input_wait_since = wait_now;
                 uint64_t wait_ms = NTP2MS(wait_now - input_wait_since);
@@ -854,6 +877,7 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                 }
                 continue;
             } else if (n < 0) {
+                pthread_mutex_unlock(&g_playback_lock);
                 status_error("Error reading from audio source");
                 failed = true;
                 break;
@@ -863,6 +887,7 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                     got_eof = true;
                     eof_time = raopcl_get_ntp(NULL);
                 }
+                pthread_mutex_unlock(&g_playback_lock);
                 continue;
             }
             if (input_wait_since) {
@@ -884,11 +909,13 @@ static int run_airplay2(cli_config_t *cfg, int infile)
             ap2_send_result_t send_result =
                 ap2cl_send_chunk(g_ap2cl, send, af);
             if (send_result == AP2_SEND_FATAL) {
+                pthread_mutex_unlock(&g_playback_lock);
                 status_error("AirPlay audio send failed");
                 failed = true;
                 break;
             }
             frames += af;
+            pthread_mutex_unlock(&g_playback_lock);
         } else {
             usleep(1000);
         }
@@ -1360,8 +1387,8 @@ int main(int argc, char *argv[])
         if (g_cmdpipe_fd >= 0) close(g_cmdpipe_fd);
         unlink(cfg.cmdpipe);
     }
-    /* The command thread owns metadata/feedback/event-channel calls. Destroy
-     * protocol clients only after it is fully quiesced. */
+    /* The command thread owns metadata mutations. The protocol client's
+     * destroy path stops and joins its dedicated feedback/event worker. */
     if (g_ap2cl) {
         ap2cl_destroy(g_ap2cl);
         g_ap2cl = NULL;

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <time.h>
 #include <poll.h>
 #include <errno.h>
 
@@ -233,6 +234,8 @@ static int truncate_32to24(const uint8_t *in, int in_bytes, uint8_t *out)
  * backpressures the pipe as before.
  */
 #define INPUT_RING_BYTES (4u * 1024 * 1024)  /* allocation; admission is capped by playtime */
+#define INPUT_RING_WAIT (-2)
+#define INPUT_RING_WAIT_MS 250
 
 static struct {
     uint8_t *data;
@@ -302,8 +305,26 @@ static void input_ring_start(int fd, unsigned byte_rate, int cap_ms)
 static int input_ring_read(uint8_t *buf, size_t want)
 {
     pthread_mutex_lock(&g_inring.lock);
-    while (g_inring.fill == 0 && !g_inring.eof && g_running)
-        pthread_cond_wait(&g_inring.can_read, &g_inring.lock);
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_nsec += INPUT_RING_WAIT_MS * 1000000L;
+    if (deadline.tv_nsec >= 1000000000L) {
+        deadline.tv_sec++;
+        deadline.tv_nsec -= 1000000000L;
+    }
+    while (g_inring.fill == 0 && !g_inring.eof && g_running) {
+        int status = pthread_cond_timedwait(&g_inring.can_read,
+                                            &g_inring.lock, &deadline);
+        if (status == ETIMEDOUT) {
+            pthread_mutex_unlock(&g_inring.lock);
+            return INPUT_RING_WAIT;
+        }
+        if (status != 0) {
+            pthread_mutex_unlock(&g_inring.lock);
+            errno = status;
+            return -1;
+        }
+    }
     size_t n = g_inring.fill < want ? g_inring.fill : want;
     size_t got = 0;
     while (got < n) {
@@ -320,6 +341,15 @@ static int input_ring_read(uint8_t *buf, size_t want)
     return (int)n;
 }
 
+static void input_ring_stats(size_t *fill, size_t *capacity, bool *eof)
+{
+    pthread_mutex_lock(&g_inring.lock);
+    if (fill) *fill = g_inring.fill;
+    if (capacity) *capacity = g_inring.max_fill;
+    if (eof) *eof = g_inring.eof;
+    pthread_mutex_unlock(&g_inring.lock);
+}
+
 /* ---- Command pipe handler ---- */
 
 static struct {
@@ -329,6 +359,11 @@ static struct {
     int duration;
     int progress;
 } g_metadata = {"", "", "", 0, 0};
+
+static void artwork_pump_events(void *arg)
+{
+    ap2cl_tick((struct ap2cl_s *)arg);
+}
 
 static void handle_command(const char *key, const char *value, cli_config_t *cfg)
 {
@@ -356,8 +391,10 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
             ap2cl_is_connected(g_ap2cl))
             ap2cl_feedback(g_ap2cl);
+        artwork_pump_cb pump =
+            cfg->protocol == PROTO_AIRPLAY2 ? artwork_pump_events : NULL;
         bool loaded = artwork_load(value, &image, &image_size, content_type,
-                                   error, sizeof(error));
+                                   pump, g_ap2cl, error, sizeof(error));
         if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
             ap2cl_is_connected(g_ap2cl))
             ap2cl_feedback(g_ap2cl);
@@ -471,6 +508,9 @@ static void *cmdpipe_reader_thread(void *arg)
             raopcl_keepalive(g_raopcl);
             last_keepalive = now;
         }
+        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
+            ap2cl_is_connected(g_ap2cl))
+            ap2cl_tick(g_ap2cl);
         /* Native AP2 keepalive: real senders POST /feedback about every 2 s
          * and long sessions can hit receiver-side idle timeouts without it
          * (no-op for the RAOP-compat flow, which libraop keeps alive). */
@@ -632,7 +672,9 @@ static int run_raop(cli_config_t *cfg, int infile)
         /* Send audio chunk */
         if (g_status == STATUS_PLAYING && raopcl_accept_frames(g_raopcl)) {
             int n = input_ring_read(buf, DEFAULT_FRAMES_PER_CHUNK * input_bpf);
-            if (n < 0) {
+            if (n == INPUT_RING_WAIT) {
+                continue;
+            } else if (n < 0) {
                 status_error("Error reading from audio source");
                 break;
             } else if (n == 0) {
@@ -768,12 +810,21 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     uint8_t *buf = malloc(AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
     uint8_t *ap2_alac_buf = (cfg->bit_depth > 16) ? malloc(AP2_FRAMES_PER_CHUNK * ap2_alac_bpf) : NULL;
     bool got_eof = false;
+    bool failed = false;
 
     uint64_t eof_time = 0;
+    uint64_t last_diag = 0;
+    uint64_t input_wait_since = 0;
+    uint64_t last_input_warn = 0;
 
     /* Main audio loop */
     while (g_status != STATUS_STOPPED && (!got_eof || ap2cl_is_playing(g_ap2cl))) {
         uint64_t now = raopcl_get_ntp(NULL);
+        if (!ap2cl_control_healthy(g_ap2cl)) {
+            status_error("AirPlay control channel lost");
+            failed = true;
+            break;
+        }
 
         /* After EOF, drain for at most latency + 2 seconds then stop */
         if (got_eof && eof_time && now - eof_time > MS2NTP(cfg->latency_ms + 2000)) {
@@ -791,12 +842,40 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                 status_playing(elapsed);
             }
         }
+        if (now - last_diag >= MS2NTP(5000)) {
+            size_t ring_fill, ring_capacity;
+            bool ring_eof;
+            last_diag = now;
+            input_ring_stats(&ring_fill, &ring_capacity, &ring_eof);
+            LOG_SDEBUG("[CLIDIAG] frames=%" PRIu64
+                       " ring_fill=%zu ring_capacity=%zu ring_eof=%d "
+                       "status=%d got_eof=%d",
+                       frames, ring_fill, ring_capacity, ring_eof,
+                       g_status, got_eof);
+            ap2cl_log_diagnostics(g_ap2cl);
+        }
 
         /* Send audio chunk */
         if (g_status == STATUS_PLAYING && ap2cl_accept_frames(g_ap2cl)) {
             int n = input_ring_read(buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
-            if (n < 0) {
+            if (n == INPUT_RING_WAIT) {
+                uint64_t wait_now = raopcl_get_ntp(NULL);
+                if (!input_wait_since) input_wait_since = wait_now;
+                uint64_t wait_ms = NTP2MS(wait_now - input_wait_since);
+                if (wait_ms >= 2000 &&
+                    wait_now - last_input_warn >= MS2NTP(5000)) {
+                    size_t ring_fill, ring_capacity;
+                    bool ring_eof;
+                    last_input_warn = wait_now;
+                    input_ring_stats(&ring_fill, &ring_capacity, &ring_eof);
+                    LOG_WARN("[AP2DIAG] PCM input starved for %" PRIu64
+                             "ms (fill=%zu/%zu eof=%d)",
+                             wait_ms, ring_fill, ring_capacity, ring_eof);
+                }
+                continue;
+            } else if (n < 0) {
                 status_error("Error reading from audio source");
+                failed = true;
                 break;
             } else if (n == 0) {
                 if (!got_eof) {
@@ -805,6 +884,15 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                     eof_time = raopcl_get_ntp(NULL);
                 }
                 continue;
+            }
+            if (input_wait_since) {
+                uint64_t waited_ms = NTP2MS(raopcl_get_ntp(NULL) -
+                                            input_wait_since);
+                ap2cl_recover_input_gap(g_ap2cl);
+                if (waited_ms >= 2000)
+                    LOG_INFO("[AP2DIAG] PCM input recovered after %" PRIu64
+                             "ms", waited_ms);
+                input_wait_since = 0;
             }
 
             int af = n / ap2_input_bpf;
@@ -820,11 +908,11 @@ static int run_airplay2(cli_config_t *cfg, int infile)
         }
     }
 
-    status_eof();
+    if (!failed) status_eof();
     g_running = false;
     free(buf);
     free(ap2_alac_buf);
-    return 0;
+    return failed ? 1 : 0;
 }
 
 

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -360,11 +360,6 @@ static struct {
     int progress;
 } g_metadata = {"", "", "", 0, 0};
 
-static void artwork_pump_events(void *arg)
-{
-    ap2cl_tick((struct ap2cl_s *)arg);
-}
-
 static void handle_command(const char *key, const char *value, cli_config_t *cfg)
 {
     if (strcmp(key, "TITLE") == 0) {
@@ -388,16 +383,8 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         size_t image_size = 0;
         char content_type[32];
         char error[160];
-        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
-            ap2cl_is_connected(g_ap2cl))
-            ap2cl_feedback(g_ap2cl);
-        artwork_pump_cb pump =
-            cfg->protocol == PROTO_AIRPLAY2 ? artwork_pump_events : NULL;
         bool loaded = artwork_load(value, &image, &image_size, content_type,
-                                   pump, g_ap2cl, error, sizeof(error));
-        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
-            ap2cl_is_connected(g_ap2cl))
-            ap2cl_feedback(g_ap2cl);
+                                   error, sizeof(error));
         if (!loaded) {
             LOG_WARN("Cannot load artwork: %s", error);
         } else {
@@ -489,7 +476,6 @@ static void *cmdpipe_reader_thread(void *arg)
 {
     cli_config_t *cfg = (cli_config_t *)arg;
     uint64_t last_keepalive = raopcl_get_ntp(NULL);
-    uint64_t last_feedback = last_keepalive;
 
     g_cmdpipe_fd = open(cfg->cmdpipe, O_RDWR | O_NONBLOCK);
     if (g_cmdpipe_fd == -1) {
@@ -508,18 +494,6 @@ static void *cmdpipe_reader_thread(void *arg)
             raopcl_keepalive(g_raopcl);
             last_keepalive = now;
         }
-        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
-            ap2cl_is_connected(g_ap2cl))
-            ap2cl_tick(g_ap2cl);
-        /* Native AP2 keepalive: real senders POST /feedback about every 2 s
-         * and long sessions can hit receiver-side idle timeouts without it
-         * (no-op for the RAOP-compat flow, which libraop keeps alive). */
-        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl && ap2cl_is_connected(g_ap2cl) &&
-            now - last_feedback >= MS2NTP(2000)) {
-            ap2cl_feedback(g_ap2cl);
-            last_feedback = now;
-        }
-
         if (n <= 0 || !(pfds.revents & POLLIN)) continue;
 
         ssize_t bytes_read = read(g_cmdpipe_fd, g_cmdpipe_buf, sizeof(g_cmdpipe_buf) - 1);
@@ -790,11 +764,17 @@ static int run_airplay2(cli_config_t *cfg, int infile)
 
     /* Schedule start time */
     if (cfg->ntp_start) {
-        ap2cl_start_at(g_ap2cl, cfg->ntp_start);
+        if (!ap2cl_start_at(g_ap2cl, cfg->ntp_start)) {
+            status_error("Cannot start AirPlay 2 stream");
+            return 1;
+        }
     } else {
         uint64_t now = raopcl_get_ntp(NULL);
         uint64_t start_at = now + MS2NTP(cfg->latency_ms);
-        ap2cl_start_at(g_ap2cl, start_at);
+        if (!ap2cl_start_at(g_ap2cl, start_at)) {
+            status_error("Cannot start AirPlay 2 stream");
+            return 1;
+        }
     }
 
     /* Placeholder metadata must follow ap2cl_start_at: that call sets the RTP
@@ -901,7 +881,13 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                 truncate_32to24(buf, n, ap2_alac_buf);
                 send = ap2_alac_buf;
             }
-            ap2cl_send_chunk(g_ap2cl, send, af);
+            ap2_send_result_t send_result =
+                ap2cl_send_chunk(g_ap2cl, send, af);
+            if (send_result == AP2_SEND_FATAL) {
+                status_error("AirPlay audio send failed");
+                failed = true;
+                break;
+            }
             frames += af;
         } else {
             usleep(1000);

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -36,6 +36,7 @@
 #include "ap2_client.h"
 #include "ap2_ptp.h"
 #include "ap2_hap.h"
+#include "artwork.h"
 
 #define VERSION "0.1.0"
 #define AP2_FRAMES_PER_CHUNK 352
@@ -348,26 +349,31 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
             mrp_status_report(ap2cl_mrp_push(g_ap2cl));
         }
     } else if (strcmp(key, "ARTWORK") == 0) {
-        if (access(value, F_OK) == 0) {
-            /* Local file artwork */
-            FILE *artfile = fopen(value, "r");
-            if (artfile) {
-                fseek(artfile, 0L, SEEK_END);
-                long numbytes = ftell(artfile);
-                fseek(artfile, 0L, SEEK_SET);
-                char *buffer = (char *)calloc(numbytes, sizeof(char));
-                fread(buffer, sizeof(char), numbytes, artfile);
-                fclose(artfile);
-                if (cfg->protocol == PROTO_RAOP && g_raopcl) {
-                    raopcl_set_artwork(g_raopcl, "image/jpg", numbytes, buffer);
-                } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
-                    ap2cl_set_artwork(g_ap2cl, "image/jpeg", numbytes, buffer);
-                    mrp_status_report(ap2cl_mrp_push(g_ap2cl));
-                }
-                free(buffer);
-            }
+        uint8_t *image = NULL;
+        size_t image_size = 0;
+        char content_type[32];
+        char error[160];
+        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
+            ap2cl_is_connected(g_ap2cl))
+            ap2cl_feedback(g_ap2cl);
+        bool loaded = artwork_load(value, &image, &image_size, content_type,
+                                   error, sizeof(error));
+        if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl &&
+            ap2cl_is_connected(g_ap2cl))
+            ap2cl_feedback(g_ap2cl);
+        if (!loaded) {
+            LOG_WARN("Cannot load artwork: %s", error);
         } else {
-            LOG_DEBUG("Artwork URL not supported in binary, skipping: %s", value);
+            LOG_INFO("Loaded artwork (%zu bytes, %s)", image_size, content_type);
+            if (cfg->protocol == PROTO_RAOP && g_raopcl) {
+                raopcl_set_artwork(g_raopcl, content_type,
+                                   (int)image_size, (char *)image);
+            } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
+                ap2cl_set_artwork(g_ap2cl, content_type,
+                                  (int)image_size, (const char *)image);
+                mrp_status_report(ap2cl_mrp_push(g_ap2cl));
+            }
+            free(image);
         }
     } else if (strcmp(key, "VOLUME") == 0) {
         int vol = atoi(value);
@@ -581,8 +587,6 @@ static int run_raop(cli_config_t *cfg, int infile)
     LOG_INFO("Connecting to %s:%d via RAOP", inet_ntoa(player_addr), cfg->port);
     if (!raopcl_connect(g_raopcl, player_addr, cfg->port, cfg->volume > 0)) {
         status_error("Cannot connect to AirPlay device");
-        raopcl_destroy(g_raopcl);
-        g_raopcl = NULL;
         return 1;
     }
 
@@ -658,9 +662,6 @@ static int run_raop(cli_config_t *cfg, int infile)
     g_running = false;
     free(buf);
     free(alac_buf);
-    raopcl_disconnect(g_raopcl);
-    raopcl_destroy(g_raopcl);
-    g_raopcl = NULL;
     return 0;
 }
 
@@ -707,8 +708,6 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     LOG_INFO("Connecting to %s:%d via AirPlay 2", cfg->host, cfg->port);
     if (!ap2cl_connect(g_ap2cl)) {
         status_error("Cannot connect to AirPlay 2 device");
-        ap2cl_destroy(g_ap2cl);
-        g_ap2cl = NULL;
         return 1;
     }
 
@@ -825,8 +824,6 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     g_running = false;
     free(buf);
     free(ap2_alac_buf);
-    ap2cl_destroy(g_ap2cl);
-    g_ap2cl = NULL;
     return 0;
 }
 
@@ -1288,6 +1285,16 @@ int main(int argc, char *argv[])
         pthread_join(g_cmdpipe_thread, NULL);
         if (g_cmdpipe_fd >= 0) close(g_cmdpipe_fd);
         unlink(cfg.cmdpipe);
+    }
+    /* The command thread owns metadata/feedback/event-channel calls. Destroy
+     * protocol clients only after it is fully quiesced. */
+    if (g_ap2cl) {
+        ap2cl_destroy(g_ap2cl);
+        g_ap2cl = NULL;
+    }
+    if (g_raopcl) {
+        raopcl_destroy(g_raopcl);
+        g_raopcl = NULL;
     }
     if (infile >= 0 && infile != fileno(stdin)) close(infile);
     netsock_close();

--- a/tests/test_ap2_event.c
+++ b/tests/test_ap2_event.c
@@ -1,0 +1,159 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
+
+#include "ap2_mrp.h"
+#include "cross_log.h"
+
+#define KEY_SIZE 32
+#define TAG_SIZE 16
+
+static log_level test_log_level = lSILENCE;
+log_level *loglevel = &test_log_level;
+
+static void derive_key(const uint8_t secret[KEY_SIZE], const char *info,
+                       uint8_t key[KEY_SIZE])
+{
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
+    size_t len = KEY_SIZE;
+    assert(ctx);
+    assert(EVP_PKEY_derive_init(ctx) > 0);
+    assert(EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_sha512()) > 0);
+    assert(EVP_PKEY_CTX_set1_hkdf_salt(
+               ctx, (const unsigned char *)"Events-Salt", 11) > 0);
+    assert(EVP_PKEY_CTX_set1_hkdf_key(ctx, secret, KEY_SIZE) > 0);
+    assert(EVP_PKEY_CTX_add1_hkdf_info(
+               ctx, (const unsigned char *)info, strlen(info)) > 0);
+    assert(EVP_PKEY_derive(ctx, key, &len) > 0);
+    EVP_PKEY_CTX_free(ctx);
+}
+
+static void make_nonce(uint64_t counter, uint8_t nonce[12])
+{
+    memset(nonce, 0, 12);
+    for (int i = 0; i < 8; i++)
+        nonce[4 + i] = (uint8_t)(counter >> (i * 8));
+}
+
+static int encrypt_frame(const uint8_t key[KEY_SIZE], const uint8_t *plain,
+                         int plain_len, uint8_t *frame)
+{
+    uint8_t aad[2] = {plain_len & 0xff, (plain_len >> 8) & 0xff};
+    uint8_t nonce[12];
+    make_nonce(0, nonce);
+    memcpy(frame, aad, 2);
+
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    int len = 0, total = 0;
+    assert(ctx);
+    assert(EVP_EncryptInit_ex(
+               ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) > 0);
+    assert(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) > 0);
+    assert(EVP_EncryptInit_ex(ctx, NULL, NULL, key, nonce) > 0);
+    assert(EVP_EncryptUpdate(ctx, NULL, &len, aad, 2) > 0);
+    assert(EVP_EncryptUpdate(
+               ctx, frame + 2, &len, plain, plain_len) > 0);
+    total = len;
+    assert(EVP_EncryptFinal_ex(ctx, frame + 2 + total, &len) > 0);
+    total += len;
+    assert(EVP_CIPHER_CTX_ctrl(
+               ctx, EVP_CTRL_AEAD_GET_TAG, TAG_SIZE,
+               frame + 2 + total) > 0);
+    EVP_CIPHER_CTX_free(ctx);
+    return total + 2 + TAG_SIZE;
+}
+
+static int decrypt_frame(const uint8_t key[KEY_SIZE], const uint8_t *frame,
+                         int frame_len, uint8_t *plain)
+{
+    assert(frame_len >= 2 + TAG_SIZE);
+    int cipher_len = frame[0] | (frame[1] << 8);
+    assert(frame_len == cipher_len + 2 + TAG_SIZE);
+    uint8_t nonce[12];
+    make_nonce(0, nonce);
+
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    int len = 0, total = 0;
+    assert(ctx);
+    assert(EVP_DecryptInit_ex(
+               ctx, EVP_chacha20_poly1305(), NULL, NULL, NULL) > 0);
+    assert(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, 12, NULL) > 0);
+    assert(EVP_DecryptInit_ex(ctx, NULL, NULL, key, nonce) > 0);
+    assert(EVP_DecryptUpdate(ctx, NULL, &len, frame, 2) > 0);
+    assert(EVP_DecryptUpdate(
+               ctx, plain, &len, frame + 2, cipher_len) > 0);
+    total = len;
+    assert(EVP_CIPHER_CTX_ctrl(
+               ctx, EVP_CTRL_AEAD_SET_TAG, TAG_SIZE,
+               (void *)(frame + 2 + cipher_len)) > 0);
+    assert(EVP_DecryptFinal_ex(ctx, plain + total, &len) > 0);
+    total += len;
+    EVP_CIPHER_CTX_free(ctx);
+    return total;
+}
+
+int main(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    struct timeval timeout = {.tv_sec = 2};
+    assert(setsockopt(sockets[1], SOL_SOCKET, SO_RCVTIMEO,
+                      &timeout, sizeof(timeout)) == 0);
+
+    uint8_t secret[KEY_SIZE];
+    for (int i = 0; i < KEY_SIZE; i++) secret[i] = (uint8_t)i;
+    struct ap2_mrp_ctx *mrp = ap2_mrp_create(
+        "127.0.0.1", 7000, NULL, "1A2B3D4EA1B2C3D4",
+        "Music Assistant", "11111111-2222-4333-8444-555555555555",
+        "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE", secret);
+    assert(mrp);
+    assert(ap2_mrp_attach_events(mrp, sockets[0]));
+    assert(ap2_mrp_event_status(mrp) == 1);
+
+    uint8_t receiver_key[KEY_SIZE], sender_key[KEY_SIZE];
+    derive_key(secret, "Events-Write-Encryption-Key", receiver_key);
+    derive_key(secret, "Events-Read-Encryption-Key", sender_key);
+
+    static const char request[] =
+        "POST /command RTSP/1.0\r\n"
+        "CSeq: 42\r\n"
+        "Server: AirTunes/1.0\r\n"
+        "Content-Length: 4\r\n\r\n"
+        "test";
+    uint8_t encrypted[2048];
+    int encrypted_len = encrypt_frame(
+        receiver_key, (const uint8_t *)request,
+        (int)strlen(request), encrypted);
+
+    /* Exercise TCP fragmentation across the HAP length prefix. */
+    assert(write(sockets[1], encrypted, 1) == 1);
+    ap2_mrp_tick(mrp);
+    assert(write(sockets[1], encrypted + 1,
+                 (size_t)(encrypted_len - 1)) == encrypted_len - 1);
+    ap2_mrp_tick(mrp);
+
+    uint8_t response_frame[2048], response[2048];
+    ssize_t response_frame_len = read(
+        sockets[1], response_frame, sizeof(response_frame));
+    assert(response_frame_len > 0);
+    int response_len = decrypt_frame(
+        sender_key, response_frame, (int)response_frame_len, response);
+    response[response_len] = '\0';
+    assert(strstr((char *)response, "RTSP/1.0 200 OK\r\n"));
+    assert(strstr((char *)response, "Content-Length: 0\r\n"));
+    assert(strstr((char *)response, "Audio-Latency: 0\r\n"));
+    assert(strstr((char *)response, "Server: AirTunes/1.0\r\n"));
+    assert(strstr((char *)response, "CSeq: 42\r\n"));
+
+    ap2_mrp_destroy(mrp);
+    close(sockets[0]);
+    close(sockets[1]);
+    return 0;
+}

--- a/tests/test_ap2_event.c
+++ b/tests/test_ap2_event.c
@@ -42,12 +42,12 @@ static void make_nonce(uint64_t counter, uint8_t nonce[12])
         nonce[4 + i] = (uint8_t)(counter >> (i * 8));
 }
 
-static int encrypt_frame(const uint8_t key[KEY_SIZE], const uint8_t *plain,
-                         int plain_len, uint8_t *frame)
+static int encrypt_frame(const uint8_t key[KEY_SIZE], uint64_t counter,
+                         const uint8_t *plain, int plain_len, uint8_t *frame)
 {
     uint8_t aad[2] = {plain_len & 0xff, (plain_len >> 8) & 0xff};
     uint8_t nonce[12];
-    make_nonce(0, nonce);
+    make_nonce(counter, nonce);
     memcpy(frame, aad, 2);
 
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
@@ -70,14 +70,14 @@ static int encrypt_frame(const uint8_t key[KEY_SIZE], const uint8_t *plain,
     return total + 2 + TAG_SIZE;
 }
 
-static int decrypt_frame(const uint8_t key[KEY_SIZE], const uint8_t *frame,
-                         int frame_len, uint8_t *plain)
+static int decrypt_frame(const uint8_t key[KEY_SIZE], uint64_t counter,
+                         const uint8_t *frame, int frame_len, uint8_t *plain)
 {
     assert(frame_len >= 2 + TAG_SIZE);
     int cipher_len = frame[0] | (frame[1] << 8);
     assert(frame_len == cipher_len + 2 + TAG_SIZE);
     uint8_t nonce[12];
-    make_nonce(0, nonce);
+    make_nonce(counter, nonce);
 
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     int len = 0, total = 0;
@@ -99,61 +99,122 @@ static int decrypt_frame(const uint8_t key[KEY_SIZE], const uint8_t *frame,
     return total;
 }
 
-int main(void)
+static struct ap2_mrp_ctx *create_mrp(const uint8_t secret[KEY_SIZE],
+                                      int event_sock)
 {
-    int sockets[2];
-    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
-    struct timeval timeout = {.tv_sec = 2};
-    assert(setsockopt(sockets[1], SOL_SOCKET, SO_RCVTIMEO,
-                      &timeout, sizeof(timeout)) == 0);
-
-    uint8_t secret[KEY_SIZE];
-    for (int i = 0; i < KEY_SIZE; i++) secret[i] = (uint8_t)i;
     struct ap2_mrp_ctx *mrp = ap2_mrp_create(
         "127.0.0.1", 7000, NULL, "1A2B3D4EA1B2C3D4",
         "Music Assistant", "11111111-2222-4333-8444-555555555555",
         "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE", secret);
     assert(mrp);
-    assert(ap2_mrp_attach_events(mrp, sockets[0]));
+    assert(ap2_mrp_attach_events(mrp, event_sock));
     assert(ap2_mrp_event_status(mrp) == 1);
+    return mrp;
+}
 
+static void send_request(int fd, const uint8_t key[KEY_SIZE],
+                         uint64_t counter, int cseq)
+{
+    char request[256];
+    int request_len = snprintf(
+        request, sizeof(request),
+        "POST /command RTSP/1.0\r\n"
+        "CSeq: %d\r\n"
+        "Server: AirTunes/1.0\r\n"
+        "Content-Length: 4\r\n\r\n"
+        "test",
+        cseq);
+    assert(request_len > 0 && request_len < (int)sizeof(request));
+    uint8_t encrypted[512];
+    int encrypted_len = encrypt_frame(
+        key, counter, (const uint8_t *)request, request_len, encrypted);
+    assert(write(fd, encrypted, (size_t)encrypted_len) == encrypted_len);
+}
+
+static void read_response(int fd, const uint8_t key[KEY_SIZE],
+                          uint64_t counter, int cseq)
+{
+    uint8_t response_frame[2048], response[2048];
+    assert(recv(fd, response_frame, 2, MSG_WAITALL) == 2);
+    int cipher_len = response_frame[0] | (response_frame[1] << 8);
+    int remaining = cipher_len + TAG_SIZE;
+    assert(recv(fd, response_frame + 2, (size_t)remaining, MSG_WAITALL) ==
+           remaining);
+    int response_len = decrypt_frame(
+        key, counter, response_frame, remaining + 2, response);
+    response[response_len] = '\0';
+    char expected_cseq[32];
+    snprintf(expected_cseq, sizeof(expected_cseq), "CSeq: %d\r\n", cseq);
+    assert(strstr((char *)response, "RTSP/1.0 200 OK\r\n"));
+    assert(strstr((char *)response, "Content-Length: 0\r\n"));
+    assert(strstr((char *)response, "Audio-Latency: 0\r\n"));
+    assert(strstr((char *)response, "Server: AirTunes/1.0\r\n"));
+    assert(strstr((char *)response, expected_cseq));
+}
+
+int main(void)
+{
+    uint8_t secret[KEY_SIZE];
+    for (int i = 0; i < KEY_SIZE; i++) secret[i] = (uint8_t)i;
     uint8_t receiver_key[KEY_SIZE], sender_key[KEY_SIZE];
     derive_key(secret, "Events-Write-Encryption-Key", receiver_key);
     derive_key(secret, "Events-Read-Encryption-Key", sender_key);
 
-    static const char request[] =
-        "POST /command RTSP/1.0\r\n"
-        "CSeq: 42\r\n"
-        "Server: AirTunes/1.0\r\n"
-        "Content-Length: 4\r\n\r\n"
-        "test";
-    uint8_t encrypted[2048];
-    int encrypted_len = encrypt_frame(
-        receiver_key, (const uint8_t *)request,
-        (int)strlen(request), encrypted);
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    struct timeval timeout = {.tv_sec = 2};
+    assert(setsockopt(sockets[1], SOL_SOCKET, SO_RCVTIMEO,
+                      &timeout, sizeof(timeout)) == 0);
+    struct ap2_mrp_ctx *mrp = create_mrp(secret, sockets[0]);
 
+    char request[256];
+    int request_len = snprintf(
+        request, sizeof(request),
+        "POST /command RTSP/1.0\r\nCSeq: 42\r\n"
+        "Server: AirTunes/1.0\r\nContent-Length: 4\r\n\r\ntest");
+    uint8_t encrypted[512];
+    int encrypted_len = encrypt_frame(
+        receiver_key, 0, (const uint8_t *)request, request_len, encrypted);
     /* Exercise TCP fragmentation across the HAP length prefix. */
     assert(write(sockets[1], encrypted, 1) == 1);
     ap2_mrp_tick(mrp);
     assert(write(sockets[1], encrypted + 1,
                  (size_t)(encrypted_len - 1)) == encrypted_len - 1);
+    send_request(sockets[1], receiver_key, 1, 43);
     ap2_mrp_tick(mrp);
-
-    uint8_t response_frame[2048], response[2048];
-    ssize_t response_frame_len = read(
-        sockets[1], response_frame, sizeof(response_frame));
-    assert(response_frame_len > 0);
-    int response_len = decrypt_frame(
-        sender_key, response_frame, (int)response_frame_len, response);
-    response[response_len] = '\0';
-    assert(strstr((char *)response, "RTSP/1.0 200 OK\r\n"));
-    assert(strstr((char *)response, "Content-Length: 0\r\n"));
-    assert(strstr((char *)response, "Audio-Latency: 0\r\n"));
-    assert(strstr((char *)response, "Server: AirTunes/1.0\r\n"));
-    assert(strstr((char *)response, "CSeq: 42\r\n"));
-
+    read_response(sockets[1], sender_key, 0, 42);
+    read_response(sockets[1], sender_key, 1, 43);
     ap2_mrp_destroy(mrp);
-    close(sockets[0]);
+    close(sockets[1]);
+
+    /* A peer close is observable and permanently fails the encrypted channel. */
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    mrp = create_mrp(secret, sockets[0]);
+    close(sockets[1]);
+    ap2_mrp_tick(mrp);
+    assert(ap2_mrp_event_status(mrp) == 0);
+    ap2_mrp_destroy(mrp);
+
+    /* If the receiver stops draining responses, the bounded write closes the
+     * channel rather than reusing already-advanced encryption counters. */
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    int small_buffer = 1024;
+    assert(setsockopt(sockets[0], SOL_SOCKET, SO_SNDBUF,
+                     &small_buffer, sizeof(small_buffer)) == 0);
+    assert(setsockopt(sockets[1], SOL_SOCKET, SO_RCVBUF,
+                     &small_buffer, sizeof(small_buffer)) == 0);
+    mrp = create_mrp(secret, sockets[0]);
+    uint64_t counter = 0;
+    for (int batch = 0;
+         batch < 20 && ap2_mrp_event_status(mrp) == 1;
+         batch++) {
+        for (int i = 0; i < 10; i++, counter++)
+            send_request(sockets[1], receiver_key, counter,
+                        100 + (int)counter);
+        ap2_mrp_tick(mrp);
+    }
+    assert(ap2_mrp_event_status(mrp) == 0);
+    ap2_mrp_destroy(mrp);
     close(sockets[1]);
     return 0;
 }

--- a/tests/test_ap2_event.c
+++ b/tests/test_ap2_event.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -10,6 +11,7 @@
 #include <openssl/kdf.h>
 
 #include "ap2_mrp.h"
+#include "ap2_io.h"
 #include "cross_log.h"
 
 #define KEY_SIZE 32
@@ -216,5 +218,47 @@ int main(void)
     assert(ap2_mrp_event_status(mrp) == 0);
     ap2_mrp_destroy(mrp);
     close(sockets[1]);
+
+    /* A receiver that stops reading responses must fail within the event
+     * channel's deadline and become visible to the session health check. */
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    int sendbuf = 4096;
+    assert(setsockopt(sockets[0], SOL_SOCKET, SO_SNDBUF,
+                      &sendbuf, sizeof(sendbuf)) == 0);
+    assert(ap2_io_set_nonblocking(sockets[0]));
+    mrp = ap2_mrp_create(
+        "127.0.0.1", 7000, NULL, "1A2B3D4EA1B2C3D4",
+        "Music Assistant", "11111111-2222-4333-8444-555555555555",
+        "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE", secret);
+    assert(mrp);
+    assert(ap2_mrp_attach_events(mrp, sockets[0]));
+
+    uint8_t filler[4096] = {0};
+    while (send(sockets[0], filler, sizeof(filler), MSG_DONTWAIT) > 0) {}
+    assert(errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS);
+    assert(write(sockets[1], encrypted, (size_t)encrypted_len) == encrypted_len);
+    uint64_t started = ap2_io_monotonic_ms();
+    ap2_mrp_tick(mrp);
+    uint64_t elapsed = ap2_io_monotonic_ms() - started;
+    assert(elapsed < 2000);
+    assert(ap2_mrp_event_status(mrp) == 0);
+    ap2_mrp_destroy(mrp);
+    close(sockets[0]);
+    close(sockets[1]);
+
+    /* Peer closure is terminal too; the failed channel must never be reused
+     * with already-advanced encryption counters. */
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    mrp = ap2_mrp_create(
+        "127.0.0.1", 7000, NULL, "1A2B3D4EA1B2C3D4",
+        "Music Assistant", "11111111-2222-4333-8444-555555555555",
+        "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE", secret);
+    assert(mrp);
+    assert(ap2_mrp_attach_events(mrp, sockets[0]));
+    close(sockets[1]);
+    ap2_mrp_tick(mrp);
+    assert(ap2_mrp_event_status(mrp) == 0);
+    ap2_mrp_destroy(mrp);
+    close(sockets[0]);
     return 0;
 }

--- a/tests/test_ap2_event.c
+++ b/tests/test_ap2_event.c
@@ -243,22 +243,7 @@ int main(void)
     assert(elapsed < 2000);
     assert(ap2_mrp_event_status(mrp) == 0);
     ap2_mrp_destroy(mrp);
-    close(sockets[0]);
     close(sockets[1]);
 
-    /* Peer closure is terminal too; the failed channel must never be reused
-     * with already-advanced encryption counters. */
-    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
-    mrp = ap2_mrp_create(
-        "127.0.0.1", 7000, NULL, "1A2B3D4EA1B2C3D4",
-        "Music Assistant", "11111111-2222-4333-8444-555555555555",
-        "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE", secret);
-    assert(mrp);
-    assert(ap2_mrp_attach_events(mrp, sockets[0]));
-    close(sockets[1]);
-    ap2_mrp_tick(mrp);
-    assert(ap2_mrp_event_status(mrp) == 0);
-    ap2_mrp_destroy(mrp);
-    close(sockets[0]);
     return 0;
 }

--- a/tests/test_ap2_feedback.c
+++ b/tests/test_ap2_feedback.c
@@ -111,15 +111,6 @@ static void *fake_peer_thread(void *arg)
 
 int main(void)
 {
-    uint8_t oversized_response[128];
-    int oversized_len = snprintf(
-        (char *)oversized_response, sizeof(oversized_response),
-        "RTSP/1.0 200 OK\r\nCSeq: 7\r\n"
-        "Content-Length: 2147483647\r\n\r\n");
-    CHECK(oversized_len > 0);
-    CHECK(ap2cl_test_parse_response(
-              oversized_response, oversized_len, 7) == 0);
-
     int sockets[2];
     int event_sockets[2];
     CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
@@ -160,6 +151,14 @@ int main(void)
     uint64_t play_started = ap2_io_monotonic_ms();
     ap2cl_play(client);
     CHECK(ap2_io_monotonic_ms() - play_started < 100);
+    uint64_t pause_started = ap2_io_monotonic_ms();
+    ap2cl_pause(client);
+    CHECK(ap2_io_monotonic_ms() - pause_started < 100);
+    uint8_t sample[4] = {0};
+    errno = 0;
+    CHECK(ap2cl_send_chunk(client, sample, 1) == AP2_SEND_FATAL);
+    CHECK(errno == EAGAIN);
+    ap2cl_play(client);
     usleep(90000);
     CHECK(ap2cl_test_post_command(client) == 200);
     for (int i = 0; i < 100 && atomic_load(&peer.feedback_count) < 3; i++)
@@ -175,7 +174,6 @@ int main(void)
     CHECK(atomic_load(&peer.request_count) >= 4);
     close(sockets[0]);
     close(sockets[1]);
-    close(event_sockets[0]);
     close(event_sockets[1]);
     CHECK(ap2cl_destroy(client));
     puts("ap2 feedback worker test passed");

--- a/tests/test_ap2_feedback.c
+++ b/tests/test_ap2_feedback.c
@@ -1,0 +1,183 @@
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "ap2_client.h"
+#include "ap2_io.h"
+#include "cross_log.h"
+
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        return 1; \
+    } \
+} while (0)
+
+static log_level test_log_level = lSILENCE;
+log_level *loglevel = &test_log_level;
+log_level util_loglevel = lSILENCE;
+log_level raop_loglevel = lSILENCE;
+
+typedef struct {
+    int fd;
+    atomic_bool stop;
+    atomic_bool failed;
+    atomic_bool command_seen;
+    atomic_int request_count;
+    atomic_int feedback_count;
+    int cseq[16];
+} fake_peer_t;
+
+static int read_request(int fd, char request[2048])
+{
+    size_t used = 0;
+    uint64_t deadline = ap2_io_monotonic_ms() + 200;
+    while (used < 2047) {
+        ssize_t n = ap2_io_read_deadline(
+            fd, (uint8_t *)request + used, 2047 - used, deadline);
+        if (n <= 0) return errno == ETIMEDOUT ? 0 : -1;
+        used += (size_t)n;
+        request[used] = '\0';
+        char *header_end = strstr(request, "\r\n\r\n");
+        if (header_end) {
+            size_t header_len = (size_t)(header_end - request) + 4;
+            int content_len = 0;
+            char *content_length = strstr(request, "\r\nContent-Length: ");
+            if (content_length &&
+                sscanf(content_length + 18, "%d", &content_len) != 1)
+                return -1;
+            if (content_len < 0 ||
+                header_len + (size_t)content_len >= 2048)
+                return -1;
+            if (used >= header_len + (size_t)content_len) return 1;
+        }
+    }
+    return -1;
+}
+
+static bool answer_request(fake_peer_t *peer)
+{
+    char request[2048] = {0};
+    int read_status = read_request(peer->fd, request);
+    if (read_status <= 0) return read_status == 0;
+    char *cseq_header = strstr(request, "\r\nCSeq: ");
+    int cseq = -1;
+    if (!cseq_header || sscanf(cseq_header + 8, "%d", &cseq) != 1)
+        return false;
+
+    int index = atomic_load(&peer->request_count);
+    if (index >= (int)(sizeof(peer->cseq) / sizeof(peer->cseq[0])) ||
+        (index > 0 && cseq != peer->cseq[index - 1] + 1))
+        return false;
+    peer->cseq[index] = cseq;
+    bool feedback = strstr(request, "POST /feedback RTSP/1.0\r\n") != NULL;
+    bool command = strstr(request, "POST /command RTSP/1.0\r\n") != NULL;
+    if (!feedback && !command) return false;
+
+    char response[128];
+    int response_len = snprintf(
+        response, sizeof(response),
+        "RTSP/1.0 200 OK\r\nCSeq: %d\r\nContent-Length: 0\r\n\r\n",
+        cseq);
+    if (response_len <= 0 ||
+        !ap2_io_write_all_deadline(
+            peer->fd, (const uint8_t *)response, response_len,
+            ap2_io_monotonic_ms() + 1000))
+        return false;
+
+    if (feedback) atomic_fetch_add(&peer->feedback_count, 1);
+    if (command) atomic_store(&peer->command_seen, true);
+    atomic_fetch_add(&peer->request_count, 1);
+    return true;
+}
+
+static void *fake_peer_thread(void *arg)
+{
+    fake_peer_t *peer = arg;
+    while (!atomic_load(&peer->stop)) {
+        if (!answer_request(peer)) {
+            atomic_store(&peer->failed, true);
+            break;
+        }
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    uint8_t oversized_response[128];
+    int oversized_len = snprintf(
+        (char *)oversized_response, sizeof(oversized_response),
+        "RTSP/1.0 200 OK\r\nCSeq: 7\r\n"
+        "Content-Length: 2147483647\r\n\r\n");
+    CHECK(oversized_len > 0);
+    CHECK(ap2cl_test_parse_response(
+              oversized_response, oversized_len, 7) == 0);
+
+    int sockets[2];
+    int event_sockets[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, event_sockets) == 0);
+
+    ap2_device_info_t device = {
+        .name = "fake receiver",
+        .hostname = "fake.local",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    char credentials[193];
+    memset(credentials, 'A', sizeof(credentials) - 1);
+    credentials[sizeof(credentials) - 1] = '\0';
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, credentials, NULL, "1A2B3D4EA1B2C3D4",
+        "123456789", 2000, 50);
+    CHECK(client != NULL);
+    uint8_t shared_secret[32];
+    for (int i = 0; i < 32; i++) shared_secret[i] = (uint8_t)i;
+    CHECK(ap2cl_test_attach_mrp(
+        client, event_sockets[0], shared_secret));
+
+    fake_peer_t peer = {.fd = sockets[1]};
+    pthread_t peer_thread;
+    CHECK(pthread_create(&peer_thread, NULL, fake_peer_thread, &peer) == 0);
+
+    /* No command pipe exists in this test. Native session maintenance must
+     * still issue feedback, while a concurrent metadata transaction receives
+     * the next CSeq instead of interleaving with the keepalive. */
+    CHECK(ap2cl_test_start_feedback_worker(client, sockets[0], 25));
+    uint64_t play_started = ap2_io_monotonic_ms();
+    ap2cl_play(client);
+    CHECK(ap2_io_monotonic_ms() - play_started < 100);
+    usleep(90000);
+    CHECK(ap2cl_test_post_command(client) == 200);
+    for (int i = 0; i < 100 && atomic_load(&peer.feedback_count) < 3; i++)
+        usleep(20000);
+    CHECK(atomic_load(&peer.feedback_count) >= 3);
+    CHECK(atomic_load(&peer.command_seen));
+    CHECK(ap2cl_control_healthy(client));
+
+    ap2cl_test_stop_feedback_worker(client);
+    atomic_store(&peer.stop, true);
+    CHECK(pthread_join(peer_thread, NULL) == 0);
+    CHECK(!atomic_load(&peer.failed));
+    CHECK(atomic_load(&peer.request_count) >= 4);
+    close(sockets[0]);
+    close(sockets[1]);
+    close(event_sockets[0]);
+    close(event_sockets[1]);
+    CHECK(ap2cl_destroy(client));
+    puts("ap2 feedback worker test passed");
+    return 0;
+}

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -1,145 +1,138 @@
-#include <assert.h>
 #include <errno.h>
-#include <fcntl.h>
-#include <stdatomic.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include "ap2_feedback.h"
 #include "ap2_io.h"
 
-static void test_rtsp_parser(void)
-{
-    static const uint8_t response[] =
-        "RTSP/1.0 200 OK\r\n"
-        "CSeq: 17\r\n"
-        "Content-Length: 4\r\n\r\n"
-        "test";
-    ap2_rtsp_response_t parsed;
-    assert(ap2_io_parse_rtsp_response(
-               response, sizeof(response) - 2, &parsed) == 0);
-    assert(ap2_io_parse_rtsp_response(
-               response, sizeof(response) - 1, &parsed) == 1);
-    assert(parsed.status == 200);
-    assert(parsed.cseq == 17);
-    assert(parsed.body_len == 4);
-    assert(parsed.message_len == sizeof(response) - 1);
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        return false; \
+    } \
+} while (0)
 
-    static const uint8_t malformed[] =
-        "RTSP/1.0 200 OK\r\nCSeq: nope\r\nContent-Length: 0\r\n\r\n";
-    assert(ap2_io_parse_rtsp_response(
-               malformed, sizeof(malformed) - 1, &parsed) == -1);
-}
-
-static void test_deadline_io(void)
+static bool test_fake_peer_response(void)
 {
     int pair[2];
-    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
-    uint8_t byte;
-    uint64_t started = ap2_io_monotonic_ms();
-    errno = 0;
-    assert(ap2_io_read_deadline(pair[0], &byte, 1, started + 40) < 0);
-    assert(errno == ETIMEDOUT);
-    assert(ap2_io_monotonic_ms() - started < 500);
-    puts("  read timeout");
-    fflush(stdout);
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
+    const char response[] =
+        "RTSP/1.0 200 OK\r\nCSeq: 7\r\nContent-Length: 0\r\n\r\n";
+    CHECK(write(pair[1], response, sizeof(response) - 1) ==
+          (ssize_t)(sizeof(response) - 1));
 
-    int sendbuf = 4096;
-    assert(setsockopt(pair[0], SOL_SOCKET, SO_SNDBUF,
-                      &sendbuf, sizeof(sendbuf)) == 0);
-    uint8_t payload[65536];
-    memset(payload, 0x5a, sizeof(payload));
-    started = ap2_io_monotonic_ms();
-    errno = 0;
-    assert(!ap2_io_write_all_deadline(
-        pair[0], payload, sizeof(payload), started + 40));
-    assert(errno == ETIMEDOUT);
-    assert(ap2_io_monotonic_ms() - started < 500);
-    puts("  write timeout");
-    fflush(stdout);
+    uint8_t buf[128] = {0};
+    ssize_t n = ap2_io_read_deadline(
+        pair[0], buf, sizeof(buf), ap2_io_monotonic_ms() + 100);
+    CHECK(n == (ssize_t)(sizeof(response) - 1));
+    CHECK(memcmp(buf, response, sizeof(response) - 1) == 0);
     close(pair[0]);
     close(pair[1]);
-
-    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
-    close(pair[1]);
-    errno = 0;
-    assert(ap2_io_read_deadline(
-               pair[0], &byte, 1, ap2_io_monotonic_ms() + 40) == 0);
-    assert(errno == ECONNRESET);
-    puts("  peer close");
-    fflush(stdout);
-    close(pair[0]);
-}
-
-static void test_datagram_outcomes(void)
-{
-    int pair[2];
-    assert(socketpair(AF_UNIX, SOCK_DGRAM, 0, pair) == 0);
-    uint8_t payload[1024] = {0};
-    assert(ap2_io_send_datagram_deadline(
-               pair[0], payload, sizeof(payload), NULL, 0,
-               ap2_io_monotonic_ms() + 40) == AP2_SEND_SENT);
-
-    int sendbuf = 2048;
-    assert(setsockopt(pair[0], SOL_SOCKET, SO_SNDBUF,
-                      &sendbuf, sizeof(sendbuf)) == 0);
-    while (send(pair[0], payload, sizeof(payload), MSG_DONTWAIT) >= 0) {}
-    assert(errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS);
-    assert(ap2_io_send_datagram_deadline(
-               pair[0], payload, sizeof(payload), NULL, 0,
-               ap2_io_monotonic_ms() + 40) == AP2_SEND_DROPPED);
-
-    close(pair[0]);
-    assert(ap2_io_send_datagram_deadline(
-               pair[0], payload, sizeof(payload), NULL, 0,
-               ap2_io_monotonic_ms() + 40) == AP2_SEND_FATAL);
-    close(pair[1]);
-}
-
-static atomic_uint worker_ticks;
-
-static bool worker_tick(void *arg)
-{
-    (void)arg;
-    atomic_fetch_add(&worker_ticks, 1);
     return true;
 }
 
-static void test_worker_without_cmdpipe(void)
+static bool test_read_timeout_is_bounded(void)
 {
-    ap2_periodic_worker_t worker;
-    atomic_init(&worker_ticks, 0);
-    assert(ap2_periodic_worker_init(&worker, 20, worker_tick, NULL));
-    assert(ap2_periodic_worker_start(&worker));
-    uint64_t deadline_ms = ap2_io_monotonic_ms() + 1000;
-    while (atomic_load(&worker_ticks) < 3 &&
-           ap2_io_monotonic_ms() < deadline_ms)
-        usleep(5000);
-    ap2_periodic_worker_stop(&worker);
-    unsigned stopped_at = atomic_load(&worker_ticks);
-    assert(stopped_at >= 3);
-    usleep(30000);
-    assert(atomic_load(&worker_ticks) == stopped_at);
-    ap2_periodic_worker_destroy(&worker);
+    int pair[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
+    uint8_t byte;
+    uint64_t started = ap2_io_monotonic_ms();
+    errno = 0;
+    ssize_t n = ap2_io_read_deadline(pair[0], &byte, 1, started + 80);
+    uint64_t elapsed = ap2_io_monotonic_ms() - started;
+    CHECK(n < 0);
+    CHECK(errno == ETIMEDOUT);
+    CHECK(elapsed >= 50 && elapsed < 500);
+    close(pair[0]);
+    close(pair[1]);
+    return true;
+}
+
+static bool test_stalled_write_is_bounded(void)
+{
+    int pair[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
+    int sendbuf = 4096;
+    CHECK(setsockopt(pair[0], SOL_SOCKET, SO_SNDBUF,
+                     &sendbuf, sizeof(sendbuf)) == 0);
+
+    int len = 4 * 1024 * 1024;
+    uint8_t *payload = malloc((size_t)len);
+    CHECK(payload != NULL);
+    memset(payload, 0x5a, (size_t)len);
+    uint64_t started = ap2_io_monotonic_ms();
+    errno = 0;
+    bool ok = ap2_io_write_all_deadline(
+        pair[0], payload, len, started + 100);
+    uint64_t elapsed = ap2_io_monotonic_ms() - started;
+    CHECK(!ok);
+    CHECK(errno == ETIMEDOUT);
+    CHECK(elapsed >= 50 && elapsed < 1000);
+    free(payload);
+    close(pair[0]);
+    close(pair[1]);
+    return true;
+}
+
+static bool test_closed_peer_is_visible(void)
+{
+    int pair[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
+    close(pair[1]);
+    uint8_t byte;
+    errno = 0;
+    ssize_t n = ap2_io_read_deadline(
+        pair[0], &byte, 1, ap2_io_monotonic_ms() + 100);
+    CHECK(n == 0);
+    CHECK(errno == ECONNRESET);
+    close(pair[0]);
+    return true;
+}
+
+static bool test_datagram_outcomes(void)
+{
+    int pair[2];
+    CHECK(socketpair(AF_UNIX, SOCK_DGRAM, 0, pair) == 0);
+    int sendbuf = 4096;
+    CHECK(setsockopt(pair[0], SOL_SOCKET, SO_SNDBUF,
+                     &sendbuf, sizeof(sendbuf)) == 0);
+    CHECK(ap2_io_set_nonblocking(pair[0]));
+
+    uint8_t payload[1024] = {0};
+    CHECK(ap2_io_send_datagram_deadline(
+              pair[0], payload, sizeof(payload), NULL, 0,
+              ap2_io_monotonic_ms() + 100) == AP2_IO_DATAGRAM_SENT);
+    uint8_t received[1024];
+    CHECK(read(pair[1], received, sizeof(received)) ==
+          (ssize_t)sizeof(received));
+
+    while (send(pair[0], payload, sizeof(payload), MSG_DONTWAIT) > 0) {}
+    CHECK(errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS);
+    CHECK(ap2_io_send_datagram_deadline(
+              pair[0], payload, sizeof(payload), NULL, 0,
+              ap2_io_monotonic_ms() + 80) == AP2_IO_DATAGRAM_DROPPED);
+
+    errno = 0;
+    CHECK(ap2_io_send_datagram_deadline(
+              -1, payload, sizeof(payload), NULL, 0,
+              ap2_io_monotonic_ms() + 80) == AP2_IO_DATAGRAM_FATAL);
+    CHECK(errno == EBADF);
+    close(pair[0]);
+    close(pair[1]);
+    return true;
 }
 
 int main(void)
 {
-    puts("rtsp parser");
-    fflush(stdout);
-    test_rtsp_parser();
-    puts("deadline io");
-    fflush(stdout);
-    test_deadline_io();
-    puts("datagram outcomes");
-    fflush(stdout);
-    test_datagram_outcomes();
-    puts("worker");
-    fflush(stdout);
-    test_worker_without_cmdpipe();
+    if (!test_fake_peer_response()) return 1;
+    if (!test_read_timeout_is_bounded()) return 1;
+    if (!test_stalled_write_is_bounded()) return 1;
+    if (!test_closed_peer_is_visible()) return 1;
+    if (!test_datagram_outcomes()) return 1;
     puts("ap2_io tests passed");
     return 0;
 }

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -114,7 +114,10 @@ static void test_worker_without_cmdpipe(void)
     atomic_init(&worker_ticks, 0);
     assert(ap2_periodic_worker_init(&worker, 20, worker_tick, NULL));
     assert(ap2_periodic_worker_start(&worker));
-    usleep(85000);
+    uint64_t deadline_ms = ap2_io_monotonic_ms() + 1000;
+    while (atomic_load(&worker_ticks) < 3 &&
+           ap2_io_monotonic_ms() < deadline_ms)
+        usleep(5000);
     ap2_periodic_worker_stop(&worker);
     unsigned stopped_at = atomic_load(&worker_ticks);
     assert(stopped_at >= 3);

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -1,0 +1,142 @@
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "ap2_feedback.h"
+#include "ap2_io.h"
+
+static void test_rtsp_parser(void)
+{
+    static const uint8_t response[] =
+        "RTSP/1.0 200 OK\r\n"
+        "CSeq: 17\r\n"
+        "Content-Length: 4\r\n\r\n"
+        "test";
+    ap2_rtsp_response_t parsed;
+    assert(ap2_io_parse_rtsp_response(
+               response, sizeof(response) - 2, &parsed) == 0);
+    assert(ap2_io_parse_rtsp_response(
+               response, sizeof(response) - 1, &parsed) == 1);
+    assert(parsed.status == 200);
+    assert(parsed.cseq == 17);
+    assert(parsed.body_len == 4);
+    assert(parsed.message_len == sizeof(response) - 1);
+
+    static const uint8_t malformed[] =
+        "RTSP/1.0 200 OK\r\nCSeq: nope\r\nContent-Length: 0\r\n\r\n";
+    assert(ap2_io_parse_rtsp_response(
+               malformed, sizeof(malformed) - 1, &parsed) == -1);
+}
+
+static void test_deadline_io(void)
+{
+    int pair[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
+    uint8_t byte;
+    uint64_t started = ap2_io_monotonic_ms();
+    errno = 0;
+    assert(ap2_io_read_deadline(pair[0], &byte, 1, started + 40) < 0);
+    assert(errno == ETIMEDOUT);
+    assert(ap2_io_monotonic_ms() - started < 500);
+    puts("  read timeout");
+    fflush(stdout);
+
+    int sendbuf = 4096;
+    assert(setsockopt(pair[0], SOL_SOCKET, SO_SNDBUF,
+                      &sendbuf, sizeof(sendbuf)) == 0);
+    uint8_t payload[65536];
+    memset(payload, 0x5a, sizeof(payload));
+    started = ap2_io_monotonic_ms();
+    errno = 0;
+    assert(!ap2_io_write_all_deadline(
+        pair[0], payload, sizeof(payload), started + 40));
+    assert(errno == ETIMEDOUT);
+    assert(ap2_io_monotonic_ms() - started < 500);
+    puts("  write timeout");
+    fflush(stdout);
+    close(pair[0]);
+    close(pair[1]);
+
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == 0);
+    close(pair[1]);
+    errno = 0;
+    assert(ap2_io_read_deadline(
+               pair[0], &byte, 1, ap2_io_monotonic_ms() + 40) == 0);
+    assert(errno == ECONNRESET);
+    puts("  peer close");
+    fflush(stdout);
+    close(pair[0]);
+}
+
+static void test_datagram_outcomes(void)
+{
+    int pair[2];
+    assert(socketpair(AF_UNIX, SOCK_DGRAM, 0, pair) == 0);
+    uint8_t payload[1024] = {0};
+    assert(ap2_io_send_datagram_deadline(
+               pair[0], payload, sizeof(payload), NULL, 0,
+               ap2_io_monotonic_ms() + 40) == AP2_SEND_SENT);
+
+    int sendbuf = 2048;
+    assert(setsockopt(pair[0], SOL_SOCKET, SO_SNDBUF,
+                      &sendbuf, sizeof(sendbuf)) == 0);
+    while (send(pair[0], payload, sizeof(payload), MSG_DONTWAIT) >= 0) {}
+    assert(errno == EAGAIN || errno == EWOULDBLOCK || errno == ENOBUFS);
+    assert(ap2_io_send_datagram_deadline(
+               pair[0], payload, sizeof(payload), NULL, 0,
+               ap2_io_monotonic_ms() + 40) == AP2_SEND_DROPPED);
+
+    close(pair[0]);
+    assert(ap2_io_send_datagram_deadline(
+               pair[0], payload, sizeof(payload), NULL, 0,
+               ap2_io_monotonic_ms() + 40) == AP2_SEND_FATAL);
+    close(pair[1]);
+}
+
+static atomic_uint worker_ticks;
+
+static bool worker_tick(void *arg)
+{
+    (void)arg;
+    atomic_fetch_add(&worker_ticks, 1);
+    return true;
+}
+
+static void test_worker_without_cmdpipe(void)
+{
+    ap2_periodic_worker_t worker;
+    atomic_init(&worker_ticks, 0);
+    assert(ap2_periodic_worker_init(&worker, 20, worker_tick, NULL));
+    assert(ap2_periodic_worker_start(&worker));
+    usleep(85000);
+    ap2_periodic_worker_stop(&worker);
+    unsigned stopped_at = atomic_load(&worker_ticks);
+    assert(stopped_at >= 3);
+    usleep(30000);
+    assert(atomic_load(&worker_ticks) == stopped_at);
+    ap2_periodic_worker_destroy(&worker);
+}
+
+int main(void)
+{
+    puts("rtsp parser");
+    fflush(stdout);
+    test_rtsp_parser();
+    puts("deadline io");
+    fflush(stdout);
+    test_deadline_io();
+    puts("datagram outcomes");
+    fflush(stdout);
+    test_datagram_outcomes();
+    puts("worker");
+    fflush(stdout);
+    test_worker_without_cmdpipe();
+    puts("ap2_io tests passed");
+    return 0;
+}

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -35,6 +35,35 @@ static bool test_fake_peer_response(void)
     return true;
 }
 
+static bool test_rtsp_parser(void)
+{
+    static const uint8_t response[] =
+        "RTSP/1.0 200 OK\r\n"
+        "CSeq: 17\r\n"
+        "Content-Length: 4\r\n\r\n"
+        "test";
+    ap2_rtsp_response_t parsed;
+    CHECK(ap2_io_parse_rtsp_response(
+              response, sizeof(response) - 2, &parsed) == 0);
+    CHECK(ap2_io_parse_rtsp_response(
+              response, sizeof(response) - 1, &parsed) == 1);
+    CHECK(parsed.status == 200);
+    CHECK(parsed.cseq == 17);
+    CHECK(parsed.body_len == 4);
+    CHECK(parsed.message_len == sizeof(response) - 1);
+
+    static const uint8_t malformed[] =
+        "RTSP/1.0 200 OK\r\nCSeq: nope\r\nContent-Length: 0\r\n\r\n";
+    CHECK(ap2_io_parse_rtsp_response(
+              malformed, sizeof(malformed) - 1, &parsed) == -1);
+    static const uint8_t oversized[] =
+        "RTSP/1.0 200 OK\r\nCSeq: 18\r\n"
+        "Content-Length: 2147483647\r\n\r\n";
+    CHECK(ap2_io_parse_rtsp_response(
+              oversized, sizeof(oversized) - 1, &parsed) == 0);
+    return true;
+}
+
 static bool test_read_timeout_is_bounded(void)
 {
     int pair[2];
@@ -129,6 +158,7 @@ static bool test_datagram_outcomes(void)
 int main(void)
 {
     if (!test_fake_peer_response()) return 1;
+    if (!test_rtsp_parser()) return 1;
     if (!test_read_timeout_is_bounded()) return 1;
     if (!test_stalled_write_is_bounded()) return 1;
     if (!test_closed_peer_is_visible()) return 1;

--- a/tests/test_ap2_timeline.c
+++ b/tests/test_ap2_timeline.c
@@ -28,6 +28,57 @@ int main(void)
         wrapped_head + 20000, 11025, 77175, &plan));
     assert((uint32_t)plan.head + plan.offset == wrapped_rtp);
 
+    /* Repeated recoveries preserve contiguous RTP while shifting the PTP
+     * anchor line by the same number of frames each time. */
+    uint64_t head = 100000;
+    uint32_t rtp = 105000;
+    uint32_t offset = 5000;
+    uint64_t anchor_wall = 10000000000ULL;
+    uint32_t anchor_position = rtp;
+    uint64_t wall = 15000000000ULL;
+    ap2_timeline_ptp_anchor_t before, after;
+    assert(ap2_timeline_ptp_anchor(
+        wall, anchor_wall, anchor_position, 44100, 2000, &before));
+
+    assert(ap2_timeline_plan_recovery(
+        head, rtp, offset, 120000, 11025, 77175, &plan));
+    head = plan.head;
+    offset = plan.offset;
+    anchor_wall += ap2_timeline_frames_to_ns(plan.shifted_frames, 44100);
+    assert((uint32_t)head + offset == rtp);
+    assert(ap2_timeline_ptp_anchor(
+        wall, anchor_wall, anchor_position, 44100, 2000, &after));
+    assert(before.frame_1 - after.frame_1 == plan.shifted_frames);
+    assert(after.frame_2 - after.frame_1 == 77175);
+
+    head += 352;
+    rtp += 352;
+    assert((uint32_t)head + offset == rtp);
+    wall = 25000000000ULL;
+    assert(ap2_timeline_ptp_anchor(
+        wall, anchor_wall, anchor_position, 44100, 2000, &before));
+    assert(ap2_timeline_plan_recovery(
+        head, rtp, offset, 300000, 11025, 77175, &plan));
+    head = plan.head;
+    offset = plan.offset;
+    anchor_wall += ap2_timeline_frames_to_ns(plan.shifted_frames, 44100);
+    assert((uint32_t)head + offset == rtp);
+    assert(ap2_timeline_ptp_anchor(
+        wall, anchor_wall, anchor_position, 44100, 2000, &after));
+    assert(before.frame_1 - after.frame_1 == plan.shifted_frames);
+    assert(after.frame_2 - after.frame_1 == 77175);
+
+    /* Periodic PTP anchors remain valid beyond the old signed-multiply
+     * overflow point (about 53 hours at 48 kHz). */
+    ap2_timeline_ptp_anchor_t long_stream;
+    uint64_t seventy_two_hours_ns = 72ULL * 60 * 60 * 1000000000ULL;
+    assert(ap2_timeline_ptp_anchor(
+        10000000000ULL + 2000000000ULL + seventy_two_hours_ns,
+        10000000000ULL, 1234, 48000, 2000, &long_stream));
+    assert(long_stream.frame_1 ==
+           1234U + (uint32_t)(72ULL * 60 * 60 * 48000) + 11035U);
+    assert(long_stream.frame_2 - long_stream.frame_1 == 77175);
+
     /* Refuse recovery when the caller's existing invariant is already broken. */
     assert(!ap2_timeline_plan_recovery(
         100000, 999, 5000, 120000, 11025, 77175, &plan));

--- a/tests/test_ap2_timeline.c
+++ b/tests/test_ap2_timeline.c
@@ -85,18 +85,19 @@ int main(void)
 
     /* Repeated starvation recovery preserves the RTP/head invariant and moves
      * the PTP anchor by exactly the same media duration on every re-anchor. */
-    uint64_t head = 100000;
-    uint32_t offset = 5000;
-    uint32_t rtp = 105000;
+    uint64_t repeat_head = 100000;
+    uint32_t repeat_offset = 5000;
+    uint32_t repeat_rtp = 105000;
     uint64_t anchor_ns = 7000000000ULL;
     for (int i = 0; i < 5; i++) {
         assert(ap2_timeline_plan_recovery(
-            head, rtp, offset, head + 20000, 11025, 77175, &plan));
+            repeat_head, repeat_rtp, repeat_offset,
+            repeat_head + 20000, 11025, 77175, &plan));
         anchor_ns += ap2_timeline_frames_to_ns(
             plan.shifted_frames, 44100);
-        head = plan.head;
-        offset = plan.offset;
-        assert((uint32_t)head + offset == rtp);
+        repeat_head = plan.head;
+        repeat_offset = plan.offset;
+        assert((uint32_t)repeat_head + repeat_offset == repeat_rtp);
     }
     assert(anchor_ns > 7000000000ULL);
     return 0;

--- a/tests/test_ap2_timeline.c
+++ b/tests/test_ap2_timeline.c
@@ -1,0 +1,35 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "ap2_timeline.h"
+
+int main(void)
+{
+    ap2_timeline_recovery_t plan;
+
+    /* A healthy lead must not be disturbed. */
+    assert(!ap2_timeline_plan_recovery(
+        200000, 205000, 5000, 100000, 11025, 77175, &plan));
+
+    /* A late contiguous RTP sample is moved into the future without changing
+     * its RTP timestamp; the offset absorbs the wall-time shift. */
+    assert(ap2_timeline_plan_recovery(
+        100000, 105000, 5000, 120000, 11025, 77175, &plan));
+    assert(plan.head == 197175);
+    assert(plan.shifted_frames == 97175);
+    assert((uint32_t)plan.head + plan.offset == 105000);
+
+    /* The same invariant holds across uint32 wraparound. */
+    uint64_t wrapped_head = 0xFFFFFF00ULL;
+    uint32_t wrapped_offset = 0x00000200U;
+    uint32_t wrapped_rtp = (uint32_t)wrapped_head + wrapped_offset;
+    assert(ap2_timeline_plan_recovery(
+        wrapped_head, wrapped_rtp, wrapped_offset,
+        wrapped_head + 20000, 11025, 77175, &plan));
+    assert((uint32_t)plan.head + plan.offset == wrapped_rtp);
+
+    /* Refuse recovery when the caller's existing invariant is already broken. */
+    assert(!ap2_timeline_plan_recovery(
+        100000, 999, 5000, 120000, 11025, 77175, &plan));
+    return 0;
+}

--- a/tests/test_ap2_timeline.c
+++ b/tests/test_ap2_timeline.c
@@ -31,5 +31,22 @@ int main(void)
     /* Refuse recovery when the caller's existing invariant is already broken. */
     assert(!ap2_timeline_plan_recovery(
         100000, 999, 5000, 120000, 11025, 77175, &plan));
+
+    /* Repeated starvation recovery preserves the RTP/head invariant and moves
+     * the PTP anchor by exactly the same media duration on every re-anchor. */
+    uint64_t head = 100000;
+    uint32_t offset = 5000;
+    uint32_t rtp = 105000;
+    uint64_t anchor_ns = 7000000000ULL;
+    for (int i = 0; i < 5; i++) {
+        assert(ap2_timeline_plan_recovery(
+            head, rtp, offset, head + 20000, 11025, 77175, &plan));
+        anchor_ns += ap2_timeline_frames_to_ns(
+            plan.shifted_frames, 44100);
+        head = plan.head;
+        offset = plan.offset;
+        assert((uint32_t)head + offset == rtp);
+    }
+    assert(anchor_ns > 7000000000ULL);
     return 0;
 }


### PR DESCRIPTION
## Summary

- keep every native AirPlay 2 session alive with dedicated feedback/reverse-event maintenance, even without `--cmdpipe`
- queue MediaRemote updates separately and bound RTSP, event, DataStream, buffered, and RTP I/O so optional metadata cannot freeze audio
- distinguish transient RTP drops from fatal failures and recover the RTP/PTP timeline after long PCM starvation
- add deterministic worker, CSeq/parser, event-channel, datagram, and repeated timeline recovery tests

All four CI builds pass. Real Apple TV soak validation is still required before merge.