### PR TITLE
Automate server release bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,16 @@ permissions:
   contents: read
 
 jobs:
+  test-updater:
+    name: Test release updater
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Run updater unit tests
+        run: python3 -m unittest discover -s tests -v
+
   build-linux:
     # Keep release binaries on a stable libc baseline that runs on Debian 12+.
     runs-on: ubuntu-22.04
@@ -100,7 +110,7 @@ jobs:
   release:
     # Publish binaries as release assets when a version tag is pushed.
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build-linux, build-macos]
+    needs: [test-updater, build-linux, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -136,6 +146,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: release
     runs-on: ubuntu-22.04
+    outputs:
+      checksums_sha256: ${{ steps.checksums_digest.outputs.sha256 }}
     steps:
       - name: Download published assets
         env:
@@ -162,6 +174,16 @@ jobs:
           (cd release && sha256sum --check SHA256SUMS)
           chmod +x release/cliairplay-linux-x86_64
           release/cliairplay-linux-x86_64 --check
+      - name: Record checksum manifest digest
+        id: checksums_digest
+        run: |
+          set -euo pipefail
+          digest="$(sha256sum release/SHA256SUMS | awk '{print $1}')"
+          if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::Failed to compute a valid SHA256SUMS digest"
+            exit 1
+          fi
+          echo "sha256=$digest" >> "$GITHUB_OUTPUT"
       - name: Verify privileged PTP binding
         run: |
           image=ubuntu:22.04
@@ -194,3 +216,96 @@ jobs:
           printf '%s\nCAPABILITY_TIMEOUT_EXIT_CODE=%s\n' "$output" "$rc"
           test "$rc" -eq 124
           grep -F "daemon up: engine on 319/320" <<<"$output"
+
+  server-repo-pr:
+    name: Update server release pins
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: verify-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate server automation token
+        env:
+          GH_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::PRIVILEGED_GITHUB_TOKEN is required to update music-assistant/server"
+            exit 1
+          fi
+          if [[ "$(gh api repos/music-assistant/server --jq '.permissions.push // false')" != "true" ]]; then
+            echo "::error::PRIVILEGED_GITHUB_TOKEN needs write access to music-assistant/server"
+            exit 1
+          fi
+      - name: Checkout airplay-cli
+        uses: actions/checkout@v4
+        with:
+          path: airplay-cli
+          persist-credentials: false
+      - name: Checkout server
+        uses: actions/checkout@v4
+        with:
+          repository: music-assistant/server
+          ref: dev
+          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          path: server
+          persist-credentials: false
+      - name: Update server Dockerfile pins
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          CHECKSUMS_SHA256: ${{ needs.verify-release.outputs.checksums_sha256 }}
+        run: |
+          set -euo pipefail
+          python3 airplay-cli/scripts/update_server_dockerfile.py \
+            server/Dockerfile \
+            "$RELEASE_TAG" \
+            "$CHECKSUMS_SHA256"
+      - name: Create or update server pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          path: server
+          commit-message: Update airplay-cli to ${{ github.ref_name }}
+          # This branch deliberately avoids the server's auto-merge prefixes.
+          branch: bump-airplay-cli-${{ github.ref_name }}
+          base: dev
+          delete-branch: true
+          title: Update airplay-cli to ${{ github.ref_name }}
+          body: |
+            # What does this implement/fix?
+
+            Updates the server Dockerfile to use the verified
+            [airplay-cli ${{ github.ref_name }} release](https://github.com/music-assistant/airplay-cli/releases/tag/${{ github.ref_name }}).
+
+            - Pins `CLIAIRPLAY_VERSION` to `${{ github.ref_name }}`.
+            - Pins `CLIAIRPLAY_CHECKSUMS_SHA256` to `${{ needs.verify-release.outputs.checksums_sha256 }}`.
+            - The release workflow verified the four published binaries and `SHA256SUMS` before opening this PR.
+
+            **Related issue (if applicable):**
+
+            - N/A
+
+            ## Types of changes
+
+            - [ ] Bugfix (non-breaking change which fixes an issue) — `bugfix`
+            - [ ] New feature (non-breaking change which adds functionality) — `new-feature`
+            - [ ] Enhancement to an existing feature — `enhancement`
+            - [ ] New music/player/metadata/plugin provider — `new-provider`
+            - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — `breaking-change`
+            - [ ] Refactor (no behaviour change) — `refactor`
+            - [ ] Documentation only — `documentation`
+            - [ ] Maintenance / chore — `maintenance`
+            - [ ] CI / workflow change — `ci`
+            - [x] Dependencies bump — `dependencies`
+
+            ## Checklist
+
+            - [ ] The code change is tested and works locally. (Release assets and pin updates were verified in CI; no local server build is run.)
+            - [ ] `pre-commit run --all-files` passes. (Not run by this pin-only automation.)
+            - [ ] `pytest` passes, and tests have been added/updated under `tests/` where applicable. (Not applicable to a Dockerfile pin-only change.)
+            - [ ] For changes to shared models, the companion PR in `music-assistant/models` is linked. (Not applicable.)
+            - [ ] For changes affecting the UI, the companion PR in `music-assistant/frontend` is linked. (Not applicable.)
+            - [ ] I have read and complied with the project's [AI Policy](https://github.com/music-assistant/.github/blob/main/AI_POLICY.md) for any AI-assisted contributions. (Not applicable to this automated pin-only PR.)
+            - [ ] I have raised a PR against the documentation repository targeting the main or beta branch as appropriate. (Not applicable.)
+          labels: dependencies

--- a/README.md
+++ b/README.md
@@ -210,7 +210,10 @@ CI (`.github/workflows/build.yml`) cross-builds four targets on every push —
 `linux-x86_64`, `linux-aarch64`, `macos-arm64`, `macos-x86_64` — validates
 `--check` on the natively runnable ones, and uploads the binaries as
 artifacts. Pushing a `v*` tag additionally runs a release job (GitHub Release
-with the four binaries + `SHA256SUMS`).
+with the four binaries + `SHA256SUMS`). After verifying the published assets,
+CI hashes `SHA256SUMS` and opens or updates a non-auto-merge PR against the
+server `dev` branch with both Dockerfile pins. That step requires the
+`PRIVILEGED_GITHUB_TOKEN` Actions secret to have server write access.
 
 ## Architecture
 

--- a/scripts/update_server_dockerfile.py
+++ b/scripts/update_server_dockerfile.py
@@ -128,6 +128,12 @@ def update_dockerfile(
             os.fsync(temporary.fileno())
         os.replace(temporary_name, dockerfile)
         replaced = True
+        # Persist the renamed directory entry as well as the file contents.
+        directory_fd = os.open(dockerfile.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
     finally:
         if not replaced:
             Path(temporary_name).unlink(missing_ok=True)

--- a/scripts/update_server_dockerfile.py
+++ b/scripts/update_server_dockerfile.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Atomically update the airplay-cli pins in the server Dockerfile."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import tempfile
+
+VERSION_PIN = "CLIAIRPLAY_VERSION"
+CHECKSUM_PIN = "CLIAIRPLAY_CHECKSUMS_SHA256"
+PIN_NAMES = (VERSION_PIN, CHECKSUM_PIN)
+
+_SEMVER_NUMBER = r"(?:0|[1-9][0-9]*)"
+_SEMVER_IDENTIFIER = r"(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+TAG_PATTERN = re.compile(
+    rf"^v{_SEMVER_NUMBER}\.{_SEMVER_NUMBER}\.{_SEMVER_NUMBER}"
+    rf"(?:-{_SEMVER_IDENTIFIER}(?:\.{_SEMVER_IDENTIFIER})*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+TARGET_LINE_PATTERN = re.compile(
+    rf"^\s*ARG\s+(?P<name>{VERSION_PIN}|{CHECKSUM_PIN})\b.*$"
+)
+PIN_LINE_PATTERNS = {
+    VERSION_PIN: re.compile(rf"^ARG {VERSION_PIN}=(?P<value>\S+)$"),
+    CHECKSUM_PIN: re.compile(rf"^ARG {CHECKSUM_PIN}=(?P<value>\S+)$"),
+}
+
+
+class PinUpdateError(ValueError):
+    """Raised when release inputs or Dockerfile pins violate the contract."""
+
+
+def _validate_release_inputs(tag: str, checksums_sha256: str) -> None:
+    if TAG_PATTERN.fullmatch(tag) is None:
+        raise PinUpdateError(f"invalid release tag: {tag!r}")
+    if DIGEST_PATTERN.fullmatch(checksums_sha256) is None:
+        raise PinUpdateError(
+            "invalid SHA256SUMS digest: expected 64 lowercase hexadecimal characters"
+        )
+
+
+def _updated_contents(
+    original: bytes, tag: str, checksums_sha256: str
+) -> bytes:
+    try:
+        text = original.decode("utf-8")
+    except UnicodeDecodeError as err:
+        raise PinUpdateError("Dockerfile must be valid UTF-8") from err
+
+    lines = text.splitlines(keepends=True)
+    occurrences: dict[str, list[tuple[int, str, str]]] = {
+        name: [] for name in PIN_NAMES
+    }
+
+    for index, line in enumerate(lines):
+        content = line.rstrip("\r\n")
+        line_ending = line[len(content) :]
+        match = TARGET_LINE_PATTERN.fullmatch(content)
+        if match is not None:
+            occurrences[match.group("name")].append(
+                (index, content, line_ending)
+            )
+
+    for name in PIN_NAMES:
+        count = len(occurrences[name])
+        if count == 0:
+            raise PinUpdateError(f"missing Dockerfile pin: ARG {name}=...")
+        if count != 1:
+            raise PinUpdateError(
+                f"duplicate Dockerfile pin: ARG {name}=... appears {count} times"
+            )
+
+    replacements = {
+        VERSION_PIN: tag,
+        CHECKSUM_PIN: checksums_sha256,
+    }
+    validators = {
+        VERSION_PIN: TAG_PATTERN,
+        CHECKSUM_PIN: DIGEST_PATTERN,
+    }
+
+    for name in PIN_NAMES:
+        index, content, line_ending = occurrences[name][0]
+        match = PIN_LINE_PATTERNS[name].fullmatch(content)
+        if match is None or validators[name].fullmatch(match.group("value")) is None:
+            raise PinUpdateError(
+                f"malformed Dockerfile pin: expected exactly ARG {name}=<valid-value>"
+            )
+        lines[index] = f"ARG {name}={replacements[name]}{line_ending}"
+
+    return "".join(lines).encode("utf-8")
+
+
+def update_dockerfile(
+    dockerfile: Path, tag: str, checksums_sha256: str
+) -> bool:
+    """Update both pins in one atomic replacement, returning whether it changed."""
+
+    _validate_release_inputs(tag, checksums_sha256)
+
+    source_stat = dockerfile.lstat()
+    if stat.S_ISLNK(source_stat.st_mode) or not stat.S_ISREG(source_stat.st_mode):
+        raise PinUpdateError(f"Dockerfile path is not a regular file: {dockerfile}")
+
+    original = dockerfile.read_bytes()
+    updated = _updated_contents(original, tag, checksums_sha256)
+    if updated == original:
+        return False
+
+    fd, temporary_name = tempfile.mkstemp(
+        dir=dockerfile.parent,
+        prefix=f".{dockerfile.name}.",
+        suffix=".tmp",
+    )
+    replaced = False
+    try:
+        with os.fdopen(fd, "wb") as temporary:
+            temporary.write(updated)
+            os.fchmod(temporary.fileno(), stat.S_IMODE(source_stat.st_mode))
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_name, dockerfile)
+        replaced = True
+    finally:
+        if not replaced:
+            Path(temporary_name).unlink(missing_ok=True)
+
+    return True
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Update airplay-cli release pins in a server Dockerfile."
+    )
+    parser.add_argument("dockerfile", type=Path)
+    parser.add_argument("tag")
+    parser.add_argument("checksums_sha256")
+    args = parser.parse_args(argv)
+
+    try:
+        changed = update_dockerfile(
+            args.dockerfile, args.tag, args.checksums_sha256
+        )
+    except (OSError, PinUpdateError) as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    status = "updated" if changed else "already up to date"
+    print(f"{args.dockerfile}: {status}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_update_server_dockerfile.py
+++ b/tests/test_update_server_dockerfile.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import tempfile
+import unittest
+
+from scripts.update_server_dockerfile import PinUpdateError, update_dockerfile
+
+OLD_TAG = "v0.1.0"
+NEW_TAG = "v1.2.3"
+OLD_DIGEST = "1" * 64
+NEW_DIGEST = "2" * 64
+DOCKERFILE = (
+    "# syntax=docker/dockerfile:1\n"
+    "\n"
+    "FROM scratch\n"
+    f"ARG CLIAIRPLAY_VERSION={OLD_TAG}\n"
+    f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_DIGEST}\n"
+    "RUN echo ready\n"
+)
+
+
+class UpdateServerDockerfileTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.dockerfile = Path(self.temporary_directory.name) / "Dockerfile"
+        self.dockerfile.write_text(DOCKERFILE, encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def test_updates_both_pins(self) -> None:
+        self.assertTrue(
+            update_dockerfile(self.dockerfile, NEW_TAG, NEW_DIGEST)
+        )
+
+        updated = self.dockerfile.read_text(encoding="utf-8")
+        self.assertIn(f"ARG CLIAIRPLAY_VERSION={NEW_TAG}\n", updated)
+        self.assertIn(
+            f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={NEW_DIGEST}\n", updated
+        )
+        self.assertNotIn(OLD_TAG, updated)
+        self.assertNotIn(OLD_DIGEST, updated)
+
+    def test_idempotent_update_does_not_rewrite_file(self) -> None:
+        self.assertTrue(
+            update_dockerfile(self.dockerfile, NEW_TAG, NEW_DIGEST)
+        )
+        before = self.dockerfile.stat()
+
+        self.assertFalse(
+            update_dockerfile(self.dockerfile, NEW_TAG, NEW_DIGEST)
+        )
+
+        after = self.dockerfile.stat()
+        self.assertEqual(before.st_ino, after.st_ino)
+        self.assertEqual(before.st_mtime_ns, after.st_mtime_ns)
+
+    def test_rejects_malformed_pins_without_partial_update(self) -> None:
+        malformed_lines = (
+            (
+                f"ARG CLIAIRPLAY_VERSION={OLD_TAG}",
+                f"ARG CLIAIRPLAY_VERSION = {OLD_TAG}",
+            ),
+            (
+                f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_DIGEST}",
+                "ARG CLIAIRPLAY_CHECKSUMS_SHA256=not-a-digest",
+            ),
+        )
+        for valid_line, malformed_line in malformed_lines:
+            with self.subTest(pin=valid_line):
+                contents = DOCKERFILE.replace(valid_line, malformed_line)
+                self.dockerfile.write_text(contents, encoding="utf-8")
+                before = self.dockerfile.read_bytes()
+
+                with self.assertRaisesRegex(PinUpdateError, "malformed"):
+                    update_dockerfile(self.dockerfile, NEW_TAG, NEW_DIGEST)
+
+                self.assertEqual(before, self.dockerfile.read_bytes())
+
+    def test_rejects_duplicate_pins(self) -> None:
+        for line in (
+            f"ARG CLIAIRPLAY_VERSION={OLD_TAG}\n",
+            f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_DIGEST}\n",
+        ):
+            with self.subTest(pin=line):
+                contents = DOCKERFILE.replace(line, line + line)
+                self.dockerfile.write_text(contents, encoding="utf-8")
+                before = self.dockerfile.read_bytes()
+
+                with self.assertRaisesRegex(PinUpdateError, "duplicate"):
+                    update_dockerfile(self.dockerfile, NEW_TAG, NEW_DIGEST)
+
+                self.assertEqual(before, self.dockerfile.read_bytes())
+
+    def test_rejects_missing_pins(self) -> None:
+        for line in (
+            f"ARG CLIAIRPLAY_VERSION={OLD_TAG}\n",
+            f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_DIGEST}\n",
+        ):
+            with self.subTest(pin=line):
+                contents = DOCKERFILE.replace(line, "")
+                self.dockerfile.write_text(contents, encoding="utf-8")
+                before = self.dockerfile.read_bytes()
+
+                with self.assertRaisesRegex(PinUpdateError, "missing"):
+                    update_dockerfile(self.dockerfile, NEW_TAG, NEW_DIGEST)
+
+                self.assertEqual(before, self.dockerfile.read_bytes())
+
+    def test_rejects_invalid_release_tags(self) -> None:
+        for tag in ("1.2.3", "v1.2", "v01.2.3", "v1.2.3/other"):
+            with self.subTest(tag=tag):
+                before = self.dockerfile.read_bytes()
+
+                with self.assertRaisesRegex(
+                    PinUpdateError, "invalid release tag"
+                ):
+                    update_dockerfile(self.dockerfile, tag, NEW_DIGEST)
+
+                self.assertEqual(before, self.dockerfile.read_bytes())
+
+    def test_rejects_invalid_digests(self) -> None:
+        for digest in ("2" * 63, "g" * 64, "A" * 64):
+            with self.subTest(digest=digest):
+                before = self.dockerfile.read_bytes()
+
+                with self.assertRaisesRegex(
+                    PinUpdateError, "invalid SHA256SUMS digest"
+                ):
+                    update_dockerfile(self.dockerfile, NEW_TAG, digest)
+
+                self.assertEqual(before, self.dockerfile.read_bytes())
+
+    def test_preserves_file_mode(self) -> None:
+        os.chmod(self.dockerfile, 0o640)
+
+        update_dockerfile(self.dockerfile, NEW_TAG, NEW_DIGEST)
+
+        mode = stat.S_IMODE(self.dockerfile.stat().st_mode)
+        self.assertEqual(0o640, mode)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- expose the verified SHA256SUMS digest from tagged releases
- strictly and atomically update the two server Dockerfile pins
- create or update a stable, non-auto-merge PR against server `dev`
- run the updater unit suite in normal CI and gate releases on it

## Validation

- `python3 -m unittest discover -s tests -v`
- native `make STATIC=1` build and `--check`
- workflow YAML syntax validation
- updater exercised against server PR #4881 and the published v0.1.0 SHA256SUMS asset