### PR TITLE
Automate AirPlay CLI server bumps

### DIFF
--- a/.github/scripts/test_update_server_airplay_pins.py
+++ b/.github/scripts/test_update_server_airplay_pins.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import tempfile
+import unittest
+
+from update_server_airplay_pins import update_pins
+
+
+OLD_CHECKSUM = "1" * 64
+NEW_CHECKSUM = "a" * 64
+
+
+class UpdateServerAirplayPinsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.dockerfile = Path(self.temporary_directory.name) / "Dockerfile"
+
+    def write_dockerfile(self, content: str) -> None:
+        self.dockerfile.write_text(content, encoding="utf-8")
+
+    def test_updates_both_pins_and_preserves_mode(self) -> None:
+        self.write_dockerfile(
+            "FROM alpine\n"
+            "ARG CLIAIRPLAY_VERSION=v0.1.0\n"
+            f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_CHECKSUM}\n"
+            "RUN echo done\n"
+        )
+        os.chmod(self.dockerfile, 0o640)
+
+        changed, old_version, old_checksum = update_pins(
+            self.dockerfile, "v0.2.0", NEW_CHECKSUM
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(old_version, "v0.1.0")
+        self.assertEqual(old_checksum, OLD_CHECKSUM)
+        self.assertEqual(
+            self.dockerfile.read_text(encoding="utf-8"),
+            "FROM alpine\n"
+            "ARG CLIAIRPLAY_VERSION=v0.2.0\n"
+            f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={NEW_CHECKSUM}\n"
+            "RUN echo done\n",
+        )
+        self.assertEqual(stat.S_IMODE(self.dockerfile.stat().st_mode), 0o640)
+
+    def test_is_idempotent(self) -> None:
+        content = (
+            "ARG CLIAIRPLAY_VERSION=v0.2.0\n"
+            f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={NEW_CHECKSUM}\n"
+        )
+        self.write_dockerfile(content)
+
+        changed, _, _ = update_pins(self.dockerfile, "v0.2.0", NEW_CHECKSUM)
+
+        self.assertFalse(changed)
+        self.assertEqual(self.dockerfile.read_text(encoding="utf-8"), content)
+
+    def test_unexpected_shapes_do_not_partially_update(self) -> None:
+        fixtures = {
+            "missing checksum": "ARG CLIAIRPLAY_VERSION=v0.1.0\n",
+            "duplicate version": (
+                "ARG CLIAIRPLAY_VERSION=v0.1.0\n"
+                "ARG CLIAIRPLAY_VERSION=v0.1.1\n"
+                f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_CHECKSUM}\n"
+            ),
+            "mixed valid and malformed checksum declarations": (
+                "ARG CLIAIRPLAY_VERSION=v0.1.0\n"
+                f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_CHECKSUM}\n"
+                "ARG CLIAIRPLAY_CHECKSUMS_SHA256=not-a-digest\n"
+            ),
+            "indented duplicate version declaration": (
+                "ARG CLIAIRPLAY_VERSION=v0.1.0\n"
+                "  ARG CLIAIRPLAY_VERSION=v0.1.1\n"
+                f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_CHECKSUM}\n"
+            ),
+            "lowercase duplicate version instruction": (
+                "ARG CLIAIRPLAY_VERSION=v0.1.0\n"
+                "arg CLIAIRPLAY_VERSION=v0.1.1\n"
+                f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_CHECKSUM}\n"
+            ),
+            "lowercase duplicate checksum instruction": (
+                "ARG CLIAIRPLAY_VERSION=v0.1.0\n"
+                f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_CHECKSUM}\n"
+                f"arg CLIAIRPLAY_CHECKSUMS_SHA256={NEW_CHECKSUM}\n"
+            ),
+            "malformed checksum": (
+                "ARG CLIAIRPLAY_VERSION=v0.1.0\n"
+                "ARG CLIAIRPLAY_CHECKSUMS_SHA256=not-a-digest\n"
+            ),
+            "malformed version": (
+                "ARG CLIAIRPLAY_VERSION=latest\n"
+                f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_CHECKSUM}\n"
+            ),
+        }
+        for name, content in fixtures.items():
+            with self.subTest(name=name):
+                self.write_dockerfile(content)
+                with self.assertRaises(ValueError):
+                    update_pins(self.dockerfile, "v0.2.0", NEW_CHECKSUM)
+                self.assertEqual(
+                    self.dockerfile.read_text(encoding="utf-8"), content
+                )
+
+    def test_invalid_inputs_do_not_modify_file(self) -> None:
+        content = (
+            "ARG CLIAIRPLAY_VERSION=v0.1.0\n"
+            f"ARG CLIAIRPLAY_CHECKSUMS_SHA256={OLD_CHECKSUM}\n"
+        )
+        self.write_dockerfile(content)
+
+        for version, checksum in (
+            ("0.2.0", NEW_CHECKSUM),
+            ("v0.2.0", "A" * 64),
+            ("v0.2.0", "a" * 63),
+        ):
+            with self.subTest(version=version, checksum=checksum):
+                with self.assertRaises(ValueError):
+                    update_pins(self.dockerfile, version, checksum)
+                self.assertEqual(
+                    self.dockerfile.read_text(encoding="utf-8"), content
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/update_server_airplay_pins.py
+++ b/.github/scripts/update_server_airplay_pins.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Atomically update the airplay-cli release pins in the server Dockerfile."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import tempfile
+
+
+VERSION_PREFIX = "ARG CLIAIRPLAY_VERSION="
+CHECKSUM_PREFIX = "ARG CLIAIRPLAY_CHECKSUMS_SHA256="
+VERSION_DECLARATION = re.compile(
+    r"^\s*(?i:ARG)\s+CLIAIRPLAY_VERSION(?=$|[\s=])"
+)
+CHECKSUM_DECLARATION = re.compile(
+    r"^\s*(?i:ARG)\s+CLIAIRPLAY_CHECKSUMS_SHA256(?=$|[\s=])"
+)
+VERSION_LINE = re.compile(rf"{VERSION_PREFIX}(?P<value>\S+)")
+CHECKSUM_LINE = re.compile(rf"{CHECKSUM_PREFIX}(?P<value>[0-9a-f]{{64}})")
+RELEASE_TAG = re.compile(r"v[0-9A-Za-z][0-9A-Za-z._+-]*")
+SHA256 = re.compile(r"[0-9a-f]{64}")
+
+
+def _find_unique_line(
+    lines: list[str],
+    declaration: re.Pattern[str],
+    exact: re.Pattern[str],
+    label: str,
+    path: Path,
+) -> tuple[int, str]:
+    declarations = [
+        (index, line.rstrip("\r\n"))
+        for index, line in enumerate(lines)
+        if declaration.match(line.rstrip("\r\n"))
+    ]
+    if len(declarations) != 1:
+        raise ValueError(
+            f"{path}: expected exactly one {label} declaration, "
+            f"found {len(declarations)}"
+        )
+    index, content = declarations[0]
+    if not (match := exact.fullmatch(content)):
+        raise ValueError(f"{path}: {label} declaration has an unexpected format")
+    return index, match.group("value")
+
+
+def _replace_value(line: str, prefix: str, value: str) -> str:
+    content = line.rstrip("\r\n")
+    return f"{prefix}{value}{line[len(content):]}"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    mode = stat.S_IMODE(path.stat().st_mode)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}."
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as temporary:
+            os.fchmod(temporary.fileno(), mode)
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def update_pins(
+    dockerfile: Path, version: str, checksums_sha256: str
+) -> tuple[bool, str, str]:
+    """Validate and update both pins, returning changed and previous values."""
+    if not RELEASE_TAG.fullmatch(version):
+        raise ValueError(f"invalid release tag: {version!r}")
+    if not SHA256.fullmatch(checksums_sha256):
+        raise ValueError("SHA256SUMS digest must be 64 lowercase hexadecimal characters")
+
+    with dockerfile.open("r", encoding="utf-8", newline="") as source:
+        original = source.read()
+    lines = original.splitlines(keepends=True)
+    version_index, old_version = _find_unique_line(
+        lines,
+        VERSION_DECLARATION,
+        VERSION_LINE,
+        "CLIAIRPLAY_VERSION",
+        dockerfile,
+    )
+    checksum_index, old_checksum = _find_unique_line(
+        lines,
+        CHECKSUM_DECLARATION,
+        CHECKSUM_LINE,
+        "CLIAIRPLAY_CHECKSUMS_SHA256",
+        dockerfile,
+    )
+    if not RELEASE_TAG.fullmatch(old_version):
+        raise ValueError(f"{dockerfile}: invalid existing release tag: {old_version!r}")
+
+    updated_lines = lines.copy()
+    updated_lines[version_index] = _replace_value(
+        lines[version_index], VERSION_PREFIX, version
+    )
+    updated_lines[checksum_index] = _replace_value(
+        lines[checksum_index], CHECKSUM_PREFIX, checksums_sha256
+    )
+    updated = "".join(updated_lines)
+    if updated == original:
+        return False, old_version, old_checksum
+
+    _atomic_write(dockerfile, updated)
+    return True, old_version, old_checksum
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dockerfile", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--checksums-sha256", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        changed, old_version, _ = update_pins(
+            args.dockerfile, args.version, args.checksums_sha256
+        )
+    except (OSError, ValueError) as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    if changed:
+        print(f"Updated {args.dockerfile} release pins for {args.version}")
+    else:
+        print(f"{args.dockerfile} already pins {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,14 @@ permissions:
   contents: read
 
 jobs:
+  test-release-automation:
+    name: Test release automation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test server pin updater
+        run: python3 -m unittest discover -s .github/scripts -p "test_*.py"
+
   build-linux:
     # Keep release binaries on a stable libc baseline that runs on Debian 12+.
     runs-on: ubuntu-22.04
@@ -100,7 +108,7 @@ jobs:
   release:
     # Publish binaries as release assets when a version tag is pushed.
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build-linux, build-macos]
+    needs: [build-linux, build-macos, test-release-automation]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -136,6 +144,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: release
     runs-on: ubuntu-22.04
+    outputs:
+      checksums_sha256: ${{ steps.verify-assets.outputs.checksums_sha256 }}
     steps:
       - name: Download published assets
         env:
@@ -146,6 +156,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --dir release
       - name: Verify asset contract and checksums
+        id: verify-assets
         run: |
           assets=(
             SHA256SUMS
@@ -160,6 +171,10 @@ jobs:
           done
           cat release/SHA256SUMS
           (cd release && sha256sum --check SHA256SUMS)
+          checksums_sha256=$(sha256sum release/SHA256SUMS | cut -d " " -f 1)
+          [[ "$checksums_sha256" =~ ^[0-9a-f]{64}$ ]]
+          echo "SHA256SUMS asset digest: sha256:$checksums_sha256"
+          echo "checksums_sha256=$checksums_sha256" >> "$GITHUB_OUTPUT"
           chmod +x release/cliairplay-linux-x86_64
           release/cliairplay-linux-x86_64 --check
       - name: Verify privileged PTP binding
@@ -194,3 +209,62 @@ jobs:
           printf '%s\nCAPABILITY_TIMEOUT_EXIT_CODE=%s\n' "$output" "$rc"
           test "$rc" -eq 124
           grep -F "daemon up: engine on 319/320" <<<"$output"
+
+  bump-server:
+    name: Create server bump PR
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: verify-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate server PR token
+        env:
+          SERVER_PR_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+        run: |
+          if [ -z "$SERVER_PR_TOKEN" ]; then
+            echo "::error::PRIVILEGED_GITHUB_TOKEN is required to update music-assistant/server"
+            exit 1
+          fi
+
+      - name: Checkout release automation
+        uses: actions/checkout@v7
+        with:
+          path: airplay-cli
+          persist-credentials: false
+
+      - name: Checkout server repository
+        uses: actions/checkout@v7
+        with:
+          repository: music-assistant/server
+          ref: dev
+          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          path: server
+          persist-credentials: false
+
+      - name: Update server release pins
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+          CHECKSUMS_SHA256: ${{ needs.verify-release.outputs.checksums_sha256 }}
+        run: |
+          python3 airplay-cli/.github/scripts/update_server_airplay_pins.py \
+            --dockerfile server/Dockerfile \
+            --version "$RELEASE_TAG" \
+            --checksums-sha256 "$CHECKSUMS_SHA256"
+
+      - name: Create or update server pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          path: server
+          token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
+          add-paths: Dockerfile
+          commit-message: "Update AirPlay CLI to ${{ github.ref_name }}"
+          # Server auto-merges only its auto-update frontend/models branches.
+          branch: "bump-airplay-cli-${{ github.ref_name }}"
+          delete-branch: true
+          base: dev
+          title: "Update AirPlay CLI to ${{ github.ref_name }}"
+          body: |
+            Update the server's AirPlay CLI pin to [${{ github.ref_name }}](https://github.com/music-assistant/airplay-cli/releases/tag/${{ github.ref_name }}), including the verified `SHA256SUMS` digest.
+          labels: |
+            dependencies


### PR DESCRIPTION
After a tagged release is published and fully verified, create or update a manual-review PR against `music-assistant/server:dev` that atomically bumps the AirPlay CLI tag and verified `SHA256SUMS` digest. The generated `bump-airplay-cli-*` branch intentionally stays outside the server's auto-merge allowlist.

Uses the existing org-scoped `PRIVILEGED_GITHUB_TOKEN` inherited by this repository; it must retain write access to server contents, pull requests, and PR labels.