### PR TITLE
Handle Siri Remote playback controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ CLIENT_TEST_OBJECTS = $(filter-out $(BUILDDIR)/ap2_client.o \
 TEST_EXECUTABLE = $(BUILDDIR)/test-mrp-artwork
 TEST_OBJECTS = $(BUILDDIR)/test_mrp_artwork.o \
 	$(BUILDDIR)/ap2_mrp.o $(BUILDDIR)/ap2_io.o $(BUILDDIR)/ap2_plist.o \
+	$(BUILDDIR)/ap2_bplist.o $(BUILDDIR)/bplist.o \
 	$(BUILDDIR)/artwork.o $(BUILDDIR)/cross_log.o
 RAOP_LIFECYCLE_TEST_EXECUTABLE = $(BUILDDIR)/test-ap2-raop-lifecycle
 RAOP_LIFECYCLE_TEST_OBJECTS = $(BUILDDIR)/test_ap2_raop_lifecycle.o \
@@ -155,7 +156,7 @@ $(EXECUTABLE): $(OBJECTS_ALL) $(LIBCODECS_PATCHED)
 	$(CXX) $(OBJECTS_ALL) $(LIBRARY) $(LDFLAGS) -o $@
 
 $(TEST_EXECUTABLE): $(TEST_OBJECTS) $(OPENSSL)/libopenssl.a
-	$(CC) $(TEST_OBJECTS) $(OPENSSL)/libopenssl.a $(LDFLAGS) -o $@
+	$(CXX) $(TEST_OBJECTS) $(OPENSSL)/libopenssl.a $(LDFLAGS) -o $@
 
 $(RAOP_LIFECYCLE_TEST_EXECUTABLE): $(RAOP_LIFECYCLE_TEST_OBJECTS) $(LIBCODECS_PATCHED) $(OPENSSL)/libopenssl.a
 	$(CXX) $(RAOP_LIFECYCLE_TEST_OBJECTS) \
@@ -196,11 +197,13 @@ $(TIMELINE_TEST): tests/test_ap2_timeline.c src/ap2_timeline.h Makefile
 
 $(EVENT_TEST): tests/test_ap2_event.c $(BUILDDIR)/ap2_mrp.o \
 		$(BUILDDIR)/ap2_io.o $(BUILDDIR)/ap2_plist.o \
+		$(BUILDDIR)/ap2_bplist.o $(BUILDDIR)/bplist.o \
 		$(BUILDDIR)/cross_log.o Makefile
 	@mkdir -p $(dir $@)
 	$(CC) $(TEST_CFLAGS) $(INCLUDE) \
 		$< $(BUILDDIR)/ap2_mrp.o $(BUILDDIR)/ap2_io.o \
-		$(BUILDDIR)/ap2_plist.o $(BUILDDIR)/cross_log.o \
+		$(BUILDDIR)/ap2_plist.o $(BUILDDIR)/ap2_bplist.o \
+		$(BUILDDIR)/bplist.o $(BUILDDIR)/cross_log.o \
 		$(OPENSSL)/libopenssl.a $(LDFLAGS) -o $@
 
 $(IO_TEST): tests/test_ap2_io.c src/ap2_io.c src/ap2_io.h Makefile

--- a/src/ap2_bplist.cpp
+++ b/src/ap2_bplist.cpp
@@ -129,8 +129,11 @@ static uint64_t bp_read_be(const uint8_t *p, size_t n)
     return v;
 }
 
-int ap2_bplist_find_uint(const uint8_t *data, size_t len, const char *key, uint64_t *out)
+int ap2_bplist_get_root_string(const uint8_t *data, size_t len, const char *key,
+                               char *out, size_t out_size)
 {
+    if (!key || !out || !out_size) return 0;
+    out[0] = '\0';
     if (!data || len < 40 || memcmp(data, "bplist00", 8) != 0) return 0;
 
     const uint8_t *tr = data + len - 32;
@@ -138,38 +141,114 @@ int ap2_bplist_find_uint(const uint8_t *data, size_t len, const char *key, uint6
     uint64_t num_objects = bp_read_be(tr + 8, 8);
     uint64_t table_ofs = bp_read_be(tr + 24, 8);
     if (!ofs_size || ofs_size > 8 || !ref_size || ref_size > 8) return 0;
-    if (table_ofs + num_objects * ofs_size > len - 32) return 0;
+    size_t object_end = len - 32;
+    if (!num_objects || table_ofs < 8 || table_ofs > object_end) return 0;
+    if (num_objects > (object_end - table_ofs) / ofs_size) return 0;
+    size_t keylen = strlen(key);
+
+    auto obj_ofs = [&](uint64_t ref, size_t *pos) -> bool {
+        if (ref >= num_objects) return false;
+        uint64_t ofs = bp_read_be(
+            data + table_ofs + ref * ofs_size, ofs_size);
+        if (ofs < 8 || ofs >= table_ofs) return false;
+        *pos = (size_t)ofs;
+        return true;
+    };
+
+    uint64_t root_ref = bp_read_be(tr + 16, 8);
+    size_t pos;
+    if (!obj_ofs(root_ref, &pos) || (data[pos] & 0xf0) != 0xd0) return 0;
+    size_t count;
+    if (!bp_read_count(data, (size_t)table_ofs, &pos, &count) ||
+        count > (table_ofs - pos) / (2 * ref_size))
+        return 0;
+
+    for (size_t i = 0; i < count; i++) {
+        uint64_t kref = bp_read_be(data + pos + i * ref_size, ref_size);
+        size_t kpos;
+        if (!obj_ofs(kref, &kpos) || (data[kpos] & 0xf0) != 0x50)
+            continue;
+        size_t kcount;
+        if (!bp_read_count(data, (size_t)table_ofs, &kpos, &kcount) ||
+            kcount != keylen || kcount > table_ofs - kpos ||
+            memcmp(data + kpos, key, keylen) != 0)
+            continue;
+
+        uint64_t vref = bp_read_be(
+            data + pos + (count + i) * ref_size, ref_size);
+        size_t vpos;
+        if (!obj_ofs(vref, &vpos) || (data[vpos] & 0xf0) != 0x50)
+            return 0;
+        size_t chars;
+        if (!bp_read_count(data, (size_t)table_ofs, &vpos, &chars) ||
+            chars > table_ofs - vpos || chars >= out_size ||
+            memchr(data + vpos, '\0', chars))
+            return 0;
+        memcpy(out, data + vpos, chars);
+        out[chars] = '\0';
+        return 1;
+    }
+    return 0;
+}
+
+int ap2_bplist_find_uint(const uint8_t *data, size_t len, const char *key, uint64_t *out)
+{
+    if (!data || !key || !out || len < 40 ||
+        memcmp(data, "bplist00", 8) != 0)
+        return 0;
+
+    const uint8_t *tr = data + len - 32;
+    uint8_t ofs_size = tr[6], ref_size = tr[7];
+    uint64_t num_objects = bp_read_be(tr + 8, 8);
+    uint64_t table_ofs = bp_read_be(tr + 24, 8);
+    if (!ofs_size || ofs_size > 8 || !ref_size || ref_size > 8) return 0;
+    size_t object_end = len - 32;
+    if (!num_objects || table_ofs < 8 || table_ofs > object_end) return 0;
+    if (num_objects > (object_end - table_ofs) / ofs_size) return 0;
     size_t keylen = strlen(key);
 
     /* Object offset lookup */
-    auto obj_ofs = [&](uint64_t ref) -> size_t {
-        if (ref >= num_objects) return 0;
-        return (size_t)bp_read_be(data + table_ofs + ref * ofs_size, ofs_size);
+    auto obj_ofs = [&](uint64_t ref, size_t *pos) -> bool {
+        if (ref >= num_objects) return false;
+        uint64_t ofs = bp_read_be(
+            data + table_ofs + ref * ofs_size, ofs_size);
+        if (ofs < 8 || ofs >= table_ofs) return false;
+        *pos = (size_t)ofs;
+        return true;
     };
 
     for (uint64_t o = 0; o < num_objects; o++) {
-        size_t pos = obj_ofs(o);
-        if (!pos || pos >= table_ofs || (data[pos] & 0xF0) != 0xD0) continue;
+        size_t pos;
+        if (!obj_ofs(o, &pos) || (data[pos] & 0xF0) != 0xD0) continue;
 
         size_t count;
-        if (!bp_read_count(data, table_ofs, &pos, &count)) continue;
-        if (pos + 2 * count * ref_size > table_ofs) continue;
+        if (!bp_read_count(data, (size_t)table_ofs, &pos, &count)) continue;
+        if (count > (table_ofs - pos) / (2 * ref_size)) continue;
 
         for (size_t i = 0; i < count; i++) {
             uint64_t kref = bp_read_be(data + pos + i * ref_size, ref_size);
-            size_t kpos = obj_ofs(kref);
-            if (!kpos || (data[kpos] & 0xF0) != 0x50) continue;   /* ASCII string key */
+            size_t kpos;
+            if (!obj_ofs(kref, &kpos) ||
+                (data[kpos] & 0xF0) != 0x50)
+                continue;   /* ASCII string key */
             size_t kcount;
-            if (!bp_read_count(data, table_ofs, &kpos, &kcount)) continue;
-            if (kcount != keylen || kpos + kcount > table_ofs) continue;
+            if (!bp_read_count(
+                    data, (size_t)table_ofs, &kpos, &kcount))
+                continue;
+            if (kcount != keylen || kcount > table_ofs - kpos) continue;
             if (memcmp(data + kpos, key, keylen) != 0) continue;
 
             uint64_t vref = bp_read_be(data + pos + (count + i) * ref_size, ref_size);
-            size_t vpos = obj_ofs(vref);
-            if (!vpos || (data[vpos] & 0xF0) != 0x10) return 0;   /* not an integer */
+            size_t vpos;
+            if (!obj_ofs(vref, &vpos) ||
+                (data[vpos] & 0xF0) != 0x10)
+                return 0;   /* not an integer */
             size_t vbytes;
-            if (!bp_read_count(data, table_ofs, &vpos, &vbytes)) return 0;
-            if (vpos + vbytes > table_ofs) return 0;
+            if (!bp_read_count(
+                    data, (size_t)table_ofs, &vpos, &vbytes))
+                return 0;
+            if (!vbytes || vbytes > 8 || vbytes > table_ofs - vpos)
+                return 0;
             *out = bp_read_be(data + vpos, vbytes);
             return 1;
         }

--- a/src/ap2_bplist.h
+++ b/src/ap2_bplist.h
@@ -61,6 +61,10 @@ const uint8_t *ap2_bplist_get_data(struct ap2_bplist *bp, const char *key, size_
  */
 int ap2_bplist_find_uint(const uint8_t *data, size_t len, const char *key, uint64_t *out);
 
+/* Find a string value by key in the root dictionary only. */
+int ap2_bplist_get_root_string(const uint8_t *data, size_t len, const char *key,
+                               char *out, size_t out_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -61,6 +61,7 @@ extern log_level *loglevel;
 #define AP2_RTSP_METADATA_TIMEOUT_MS 5000
 #define AP2_RTSP_ARTWORK_TIMEOUT_MS  15000
 #define AP2_FEEDBACK_INTERVAL_MS     2000
+#define AP2_EVENT_POLL_INTERVAL_MS   100
 #define AP2_UDP_SEND_TIMEOUT_MS      20
 #define AP2_BUFFERED_WRITE_TIMEOUT_MS 8000
 
@@ -124,6 +125,8 @@ struct ap2cl_s {
     bool mrp_device_registered;
     bool mrp_extended_registered;
     int mrp_last_playback_state;
+    ap2_remote_command_cb_t remote_command_cb;
+    void *remote_command_userdata;
     int data_sock;                /* UDP audio */
     int ctrl_sock;                /* UDP control */
     int events_sock;              /* reverse TCP events connection (kept open) */
@@ -183,6 +186,14 @@ static void ap2_mrp_publish_playback(struct ap2cl_s *p,
                                      bool force);
 static bool ap2_set_nonblocking(int fd, const char *name);
 static void ap2_raop_session_cleanup(struct ap2cl_s *p);
+
+static void ap2_remote_command_received(
+    ap2_remote_command_t command, void *userdata)
+{
+    struct ap2cl_s *p = userdata;
+    if (p && p->remote_command_cb)
+        p->remote_command_cb(command, p->remote_command_userdata);
+}
 
 /* ---- Native AP2 RTSP I/O ---- */
 
@@ -468,6 +479,21 @@ static int ap2_rtsp_send_tracked(
         resp_body, resp_len, request_started);
 }
 
+static void ap2_service_mrp_input(struct ap2cl_s *p)
+{
+    if (!p || atomic_load(&p->rtsp_dead)) return;
+    pthread_mutex_lock(&p->mrp_lock);
+    struct ap2_mrp_ctx *mrp = p->mrp;
+    pthread_mutex_unlock(&p->mrp_lock);
+    if (!mrp) return;
+
+    ap2_mrp_tick(mrp);
+    pthread_mutex_lock(&p->mrp_lock);
+    if (p->mrp == mrp)
+        atomic_store(&p->mrp_event_health, ap2_mrp_event_status(mrp));
+    pthread_mutex_unlock(&p->mrp_lock);
+}
+
 static void *ap2_feedback_thread_main(void *arg)
 {
     struct ap2cl_s *p = arg;
@@ -478,10 +504,12 @@ static void *ap2_feedback_thread_main(void *arg)
               AP2_FEEDBACK_INTERVAL_MS);
     while (!atomic_load(&p->feedback_stop) &&
            !atomic_load(&p->rtsp_dead)) {
+        ap2_service_mrp_input(p);
         uint64_t now_ms = ap2_io_monotonic_ms();
         if (now_ms < next_tick_ms) {
             uint64_t sleep_ms = next_tick_ms - now_ms;
-            if (sleep_ms > 100) sleep_ms = 100;
+            if (sleep_ms > AP2_EVENT_POLL_INTERVAL_MS)
+                sleep_ms = AP2_EVENT_POLL_INTERVAL_MS;
             usleep((useconds_t)sleep_ms * 1000);
             continue;
         }
@@ -774,6 +802,8 @@ static void ap2_native_setup_mrp(struct ap2cl_s *p)
                                 p->session_uuid, p->group_uuid,
                                 ap2_hap_get_shared_secret(p->hap));
     if (!p->mrp) return;
+    ap2_mrp_set_remote_command_callback(
+        p->mrp, ap2_remote_command_received, p);
     if (!ap2_mrp_attach_events(p->mrp, p->events_sock)) {
         LOG_WARN("[MRP] event-channel attach failed; degrading to no-MRP");
         ap2_mrp_destroy(p->mrp);
@@ -2013,6 +2043,14 @@ void ap2cl_set_buffered(struct ap2cl_s *p, bool enable)
     LOG_INFO("[AP2] Buffered audio (type 103) %s", enable ? "requested" : "disabled");
 }
 
+void ap2cl_set_remote_command_callback(
+    struct ap2cl_s *p, ap2_remote_command_cb_t callback, void *userdata)
+{
+    if (!p) return;
+    p->remote_command_cb = callback;
+    p->remote_command_userdata = userdata;
+}
+
 bool ap2cl_connect(struct ap2cl_s *p)
 {
     if (!p) return false;
@@ -2483,6 +2521,8 @@ static void ap2_mrp_ready(struct ap2cl_s *p)
                             p->session_uuid, p->group_uuid,
                             ap2_hap_get_shared_secret(p->hap));
     if (!p->mrp) return;
+    ap2_mrp_set_remote_command_callback(
+        p->mrp, ap2_remote_command_received, p);
     if (!ap2_mrp_attach_events(p->mrp, p->events_sock)) {
         LOG_WARN("[MRP] event-channel attach failed; MediaRemote disabled");
         ap2_mrp_destroy(p->mrp);

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -257,6 +257,11 @@ void ap2cl_set_publish_ip(struct ap2cl_s *p, const char *ip);
  * ap2cl_connect(). */
 void ap2cl_set_buffered(struct ap2cl_s *p, bool enable);
 
+/* Set the callback for validated receiver MediaRemote commands. Must be called
+ * before ap2cl_connect(); the callback remains fixed for that session. */
+void ap2cl_set_remote_command_callback(
+    struct ap2cl_s *p, ap2_remote_command_cb_t callback, void *userdata);
+
 /*
  * Get the effective playback lead and the receiver-reported buffering window.
  *

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -21,6 +21,7 @@
 #include <strings.h>
 #include <stdbool.h>
 #include <stdatomic.h>
+#include <ctype.h>
 #include <unistd.h>
 #include <errno.h>
 #include <time.h>
@@ -38,6 +39,7 @@
 #include <openssl/crypto.h>
 
 #include "cross_log.h"
+#include "ap2_bplist.h"
 #include "ap2_io.h"
 #include "ap2_plist.h"
 #include "ap2_mrp.h"
@@ -140,6 +142,8 @@ enum mrp_ext_field {
 /* Cadence of the defensive state re-push from ap2_mrp_tick (seconds). */
 #define MRP_STATE_REPUSH_S 15
 #define MRP_WRITE_TIMEOUT_MS 1000
+#define MRP_EVENT_LOG_TEXT_MAX 96
+#define MRP_EVENT_LOG_HEX_MAX  32
 
 struct ap2_mrp_ctx {
     /* Target + identity */
@@ -151,6 +155,8 @@ struct ap2_mrp_ctx {
     char *session_uuid;       /* active AirPlay session */
     char *group_uuid;         /* active AirPlay group */
     char device_uuid[37];     /* stable UUID derived from dacp_id */
+    ap2_remote_command_cb_t remote_command_cb;
+    void *remote_command_userdata;
 
     /* Channel crypto. The DataStream keys derive from the pairing shared
      * secret of the RTSP session that performed the type-130 SETUP. */
@@ -1091,6 +1097,107 @@ static bool mrp_http_header_value(const char *header, const char *name,
     return false;
 }
 
+static void mrp_event_log_text(char out[MRP_EVENT_LOG_TEXT_MAX + 1],
+                               const char *in)
+{
+    size_t i = 0;
+    if (in) {
+        for (; i < MRP_EVENT_LOG_TEXT_MAX && in[i]; i++) {
+            unsigned char c = (unsigned char)in[i];
+            out[i] = isprint(c) ? (char)c : '.';
+        }
+    }
+    out[i] = '\0';
+}
+
+void ap2_mrp_set_remote_command_callback(
+    struct ap2_mrp_ctx *m, ap2_remote_command_cb_t callback, void *userdata)
+{
+    if (!m) return;
+    m->remote_command_cb = callback;
+    m->remote_command_userdata = userdata;
+}
+
+static void mrp_emit_remote_command(
+    struct ap2_mrp_ctx *m, ap2_remote_command_t command)
+{
+    if (m->remote_command_cb)
+        m->remote_command_cb(command, m->remote_command_userdata);
+}
+
+static bool mrp_parse_remote_command(const uint8_t *body, int body_len,
+                                     ap2_remote_command_t *command)
+{
+    if (!body || body_len < 8 || !command ||
+        memcmp(body, "bplist00", 8) != 0)
+        return false;
+
+    char type[64];
+    char value[64];
+    if (!ap2_bplist_get_root_string(
+            body, (size_t)body_len, "type", type, sizeof(type)) ||
+        strcmp(type, "sendMediaRemoteCommand") != 0 ||
+        !ap2_bplist_get_root_string(
+            body, (size_t)body_len, "value", value, sizeof(value)))
+        return false;
+
+    if (strcmp(value, "play") == 0)
+        *command = AP2_REMOTE_COMMAND_PLAY;
+    else if (strcmp(value, "paus") == 0)
+        *command = AP2_REMOTE_COMMAND_PAUSE;
+    else if (strcmp(value, "plps") == 0)
+        *command = AP2_REMOTE_COMMAND_PLAY_PAUSE;
+    else if (strcmp(value, "nitm") == 0)
+        *command = AP2_REMOTE_COMMAND_NEXT;
+    else if (strcmp(value, "pitm") == 0)
+        *command = AP2_REMOTE_COMMAND_PREVIOUS;
+    else
+        return false;
+    return true;
+}
+
+static void mrp_log_event_command_body(const char *header,
+                                      const uint8_t *body, int body_len)
+{
+    char content_type[256] = "<missing>";
+    char safe_content_type[MRP_EVENT_LOG_TEXT_MAX + 1];
+    if (!mrp_http_header_value(header, "Content-Type",
+                               content_type, sizeof(content_type)))
+        snprintf(content_type, sizeof(content_type), "%s", "<missing>");
+    mrp_event_log_text(safe_content_type, content_type);
+
+    if (body_len >= 8 && memcmp(body, "bplist00", 8) == 0) {
+        char type[256];
+        char value[256];
+        char safe_type[MRP_EVENT_LOG_TEXT_MAX + 1] = "";
+        char safe_value[MRP_EVENT_LOG_TEXT_MAX + 1] = "";
+        if (ap2_bplist_get_root_string(
+                body, (size_t)body_len, "type", type, sizeof(type)))
+            mrp_event_log_text(safe_type, type);
+        if (ap2_bplist_get_root_string(
+                body, (size_t)body_len, "value", value, sizeof(value)))
+            mrp_event_log_text(safe_value, value);
+        if (safe_type[0] && safe_value[0]) {
+            LOG_DEBUG("[MRP] event command content_type=%s content_length=%d "
+                      "type=%s value=%s",
+                      safe_content_type, body_len, safe_type, safe_value);
+            return;
+        }
+    }
+
+    int shown = body_len < MRP_EVENT_LOG_HEX_MAX
+                    ? body_len : MRP_EVENT_LOG_HEX_MAX;
+    char hex[MRP_EVENT_LOG_HEX_MAX * 2 + 1];
+    for (int i = 0; i < shown; i++)
+        snprintf(hex + i * 2, sizeof(hex) - (size_t)i * 2,
+                 "%02x", body[i]);
+    hex[shown * 2] = '\0';
+    LOG_DEBUG("[MRP] event command body parse failed content_type=%s "
+              "content_length=%d hex=%s%s",
+              safe_content_type, body_len, hex,
+              body_len > shown ? "..." : "");
+}
+
 static bool mrp_event_send_response(struct ap2_mrp_ctx *m,
                                     const uint8_t *response, int response_len)
 {
@@ -1152,6 +1259,18 @@ static bool mrp_process_event_requests(struct ap2_mrp_ctx *m)
             LOG_ERROR("[MRP] malformed event request line");
             return false;
         }
+        bool is_command = content_len > 0 &&
+                          strcasecmp(method, "POST") == 0 &&
+                          strcmp(path, "/command") == 0;
+        ap2_remote_command_t remote_command;
+        bool have_remote_command = false;
+        if (is_command) {
+            const uint8_t *body = m->event_plain + off + header_len;
+            have_remote_command =
+                mrp_parse_remote_command(body, content_len, &remote_command);
+            if (*loglevel >= lDEBUG)
+                mrp_log_event_command_body(header, body, content_len);
+        }
 
         char cseq[64] = "";
         char server[256] = "";
@@ -1173,9 +1292,13 @@ static bool mrp_process_event_requests(struct ap2_mrp_ctx *m)
             have_server ? "\r\n" : "",
             have_cseq ? "CSeq: " : "", have_cseq ? cseq : "",
             have_cseq ? "\r\n" : "");
-        if (response_len <= 0 || response_len >= (int)sizeof(response) ||
-            !mrp_event_send_response(m, (const uint8_t *)response,
-                                     response_len)) {
+        bool response_ok =
+            response_len > 0 && response_len < (int)sizeof(response) &&
+            mrp_event_send_response(
+                m, (const uint8_t *)response, response_len);
+        if (have_remote_command)
+            mrp_emit_remote_command(m, remote_command);
+        if (!response_ok) {
             LOG_ERROR("[MRP] event response send failed");
             return false;
         }

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -23,7 +23,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "ap2_remote.h"
+
 struct ap2_mrp_ctx;
+
+/* Receive validated event-channel MediaRemote commands. Set before attaching
+ * the event socket; the callback remains fixed for that session. */
+void ap2_mrp_set_remote_command_callback(
+    struct ap2_mrp_ctx *m, ap2_remote_command_cb_t callback, void *userdata);
 
 typedef enum {
     AP2_MRP_PLAYBACK_PLAYING = 1,

--- a/src/ap2_remote.h
+++ b/src/ap2_remote.h
@@ -1,0 +1,36 @@
+/*
+ * AirPlay remote-command types shared by the protocol layers and CLI.
+ *
+ * Copyright (C) 2024-2026 Music Assistant Contributors
+ * See LICENSE
+ */
+
+#ifndef __AP2_REMOTE_H_
+#define __AP2_REMOTE_H_
+
+#include <stddef.h>
+
+typedef enum {
+    AP2_REMOTE_COMMAND_PLAY = 0,
+    AP2_REMOTE_COMMAND_PAUSE,
+    AP2_REMOTE_COMMAND_PLAY_PAUSE,
+    AP2_REMOTE_COMMAND_NEXT,
+    AP2_REMOTE_COMMAND_PREVIOUS,
+} ap2_remote_command_t;
+
+typedef void (*ap2_remote_command_cb_t)(ap2_remote_command_t command,
+                                        void *userdata);
+
+static inline const char *ap2_remote_command_name(ap2_remote_command_t command)
+{
+    switch (command) {
+    case AP2_REMOTE_COMMAND_PLAY: return "play";
+    case AP2_REMOTE_COMMAND_PAUSE: return "pause";
+    case AP2_REMOTE_COMMAND_PLAY_PAUSE: return "play_pause";
+    case AP2_REMOTE_COMMAND_NEXT: return "next";
+    case AP2_REMOTE_COMMAND_PREVIOUS: return "previous";
+    default: return NULL;
+    }
+}
+
+#endif /* __AP2_REMOTE_H_ */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -179,6 +179,16 @@ static void status_error(const char *msg)
     status_print("[ERROR] %s", msg);
 }
 
+static void remote_command_event(
+    ap2_remote_command_t command, void *userdata)
+{
+    (void)userdata;
+    const char *name = ap2_remote_command_name(command);
+    if (!name) return;
+    printf("[EVENT] remote command=%s\n", name);
+    fflush(stdout);
+}
+
 /* Path-A MRP experiment: surface the POST /command response on stdout when it
  * changes, so the caller can log whether the device accepts the push. */
 static void mrp_status_report(int status)
@@ -820,6 +830,8 @@ static int run_airplay2(cli_config_t *cfg, int infile)
     ap2cl_set_ptp(client, cfg->route.ptp);
     ap2cl_set_ptp_shared(client, cfg->ptp_shared);
     ap2cl_set_buffered(client, cfg->route.buffered);
+    ap2cl_set_remote_command_callback(
+        client, remote_command_event, NULL);
 
     /* Connect: auth-setup + RAOP ANNOUNCE/SETUP/RECORD */
     LOG_INFO("Connecting to %s:%d via AirPlay 2", cfg->host, cfg->port);

--- a/tests/test_ap2_event.c
+++ b/tests/test_ap2_event.c
@@ -11,13 +11,27 @@
 #include <openssl/kdf.h>
 
 #include "ap2_mrp.h"
+#include "ap2_plist.h"
 #include "cross_log.h"
 
 #define KEY_SIZE 32
 #define TAG_SIZE 16
 
+struct command_capture {
+    ap2_remote_command_t commands[16];
+    int count;
+};
+
 static log_level test_log_level = lSILENCE;
 log_level *loglevel = &test_log_level;
+
+static void capture_remote_command(
+    ap2_remote_command_t command, void *userdata)
+{
+    struct command_capture *capture = userdata;
+    assert(capture && capture->count < 16);
+    capture->commands[capture->count++] = command;
+}
 
 static void derive_key(const uint8_t secret[KEY_SIZE], const char *info,
                        uint8_t key[KEY_SIZE])
@@ -100,35 +114,132 @@ static int decrypt_frame(const uint8_t key[KEY_SIZE], uint64_t counter,
     return total;
 }
 
-static struct ap2_mrp_ctx *create_mrp(const uint8_t secret[KEY_SIZE],
-                                      int event_sock)
+static struct ap2_mrp_ctx *create_mrp_with_callback(
+    const uint8_t secret[KEY_SIZE], int event_sock,
+    ap2_remote_command_cb_t callback, void *userdata)
 {
     struct ap2_mrp_ctx *mrp = ap2_mrp_create(
         "127.0.0.1", 7000, NULL, "1A2B3D4EA1B2C3D4",
         "Music Assistant", "11111111-2222-4333-8444-555555555555",
         "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE", secret);
     assert(mrp);
+    ap2_mrp_set_remote_command_callback(mrp, callback, userdata);
     assert(ap2_mrp_attach_events(mrp, event_sock));
     assert(ap2_mrp_event_status(mrp) == 1);
     return mrp;
 }
 
-static void send_request(int fd, const uint8_t key[KEY_SIZE],
-                         uint64_t counter, int cseq)
+static struct ap2_mrp_ctx *create_mrp(const uint8_t secret[KEY_SIZE],
+                                      int event_sock)
 {
-    char request[256];
-    int request_len = snprintf(
-        request, sizeof(request),
+    return create_mrp_with_callback(secret, event_sock, NULL, NULL);
+}
+
+static int build_event_request(uint8_t *encrypted, size_t encrypted_size,
+                               const uint8_t key[KEY_SIZE],
+                               uint64_t counter, int cseq,
+                               const uint8_t *body, int body_len)
+{
+    uint8_t request[1024];
+    int header_len = snprintf(
+        (char *)request, sizeof(request),
         "POST /command RTSP/1.0\r\n"
         "CSeq: %d\r\n"
         "Server: AirTunes/1.0\r\n"
-        "Content-Length: 4\r\n\r\n"
-        "test",
-        cseq);
-    assert(request_len > 0 && request_len < (int)sizeof(request));
-    uint8_t encrypted[512];
-    int encrypted_len = encrypt_frame(
-        key, counter, (const uint8_t *)request, request_len, encrypted);
+        "Content-Type: application/x-apple-binary-plist\r\n"
+        "Content-Length: %d\r\n\r\n",
+        cseq, body_len);
+    assert(header_len > 0 && header_len + body_len < (int)sizeof(request));
+    memcpy(request + header_len, body, (size_t)body_len);
+
+    int request_len = header_len + body_len;
+    assert((size_t)(request_len + 2 + TAG_SIZE) <= encrypted_size);
+    return encrypt_frame(
+        key, counter, request, request_len, encrypted);
+}
+
+static int build_typed_command_request(
+    uint8_t *encrypted, size_t encrypted_size,
+    const uint8_t key[KEY_SIZE], uint64_t counter, int cseq,
+    const char *type, const char *value)
+{
+    ap2_pl_node *root = ap2_pl_dict();
+    ap2_pl_dict_set(root, "type", ap2_pl_string(type));
+    ap2_pl_dict_set(root, "value", ap2_pl_string(value));
+    uint8_t *body = NULL;
+    int body_len = ap2_pl_serialize(root, &body);
+    ap2_pl_free(root);
+    assert(body_len > 0 && body);
+    int encrypted_len = build_event_request(
+        encrypted, encrypted_size, key, counter, cseq, body, body_len);
+    free(body);
+    return encrypted_len;
+}
+
+static int build_command_request(uint8_t *encrypted, size_t encrypted_size,
+                                 const uint8_t key[KEY_SIZE],
+                                 uint64_t counter, int cseq,
+                                 const char *value)
+{
+    return build_typed_command_request(
+        encrypted, encrypted_size, key, counter, cseq,
+        "sendMediaRemoteCommand", value);
+}
+
+static int build_embedded_nul_request(
+    uint8_t *encrypted, size_t encrypted_size,
+    const uint8_t key[KEY_SIZE], uint64_t counter, int cseq)
+{
+    ap2_pl_node *root = ap2_pl_dict();
+    ap2_pl_dict_set(root, "type",
+                    ap2_pl_string("sendMediaRemoteCommand"));
+    ap2_pl_dict_set(root, "value", ap2_pl_string("playXjunk"));
+    uint8_t *body = NULL;
+    int body_len = ap2_pl_serialize(root, &body);
+    ap2_pl_free(root);
+    assert(body_len > 0 && body);
+
+    bool replaced = false;
+    for (int i = 0; i + 9 <= body_len; i++) {
+        if (memcmp(body + i, "playXjunk", 9) == 0) {
+            body[i + 4] = '\0';
+            replaced = true;
+            break;
+        }
+    }
+    assert(replaced);
+    int encrypted_len = build_event_request(
+        encrypted, encrypted_size, key, counter, cseq, body, body_len);
+    free(body);
+    return encrypted_len;
+}
+
+static int build_nested_command_request(
+    uint8_t *encrypted, size_t encrypted_size,
+    const uint8_t key[KEY_SIZE], uint64_t counter, int cseq)
+{
+    ap2_pl_node *nested = ap2_pl_dict();
+    ap2_pl_dict_set(nested, "type",
+                    ap2_pl_string("sendMediaRemoteCommand"));
+    ap2_pl_dict_set(nested, "value", ap2_pl_string("play"));
+    ap2_pl_node *root = ap2_pl_dict();
+    ap2_pl_dict_set(root, "payload", nested);
+    uint8_t *body = NULL;
+    int body_len = ap2_pl_serialize(root, &body);
+    ap2_pl_free(root);
+    assert(body_len > 0 && body);
+    int encrypted_len = build_event_request(
+        encrypted, encrypted_size, key, counter, cseq, body, body_len);
+    free(body);
+    return encrypted_len;
+}
+
+static void send_request(int fd, const uint8_t key[KEY_SIZE],
+                         uint64_t counter, int cseq, const char *value)
+{
+    uint8_t encrypted[1200];
+    int encrypted_len = build_command_request(
+        encrypted, sizeof(encrypted), key, counter, cseq, value);
     assert(write(fd, encrypted, (size_t)encrypted_len) == encrypted_len);
 }
 
@@ -226,24 +337,116 @@ int main(void)
     struct timeval timeout = {.tv_sec = 2};
     assert(setsockopt(sockets[1], SOL_SOCKET, SO_RCVTIMEO,
                       &timeout, sizeof(timeout)) == 0);
-    struct ap2_mrp_ctx *mrp = create_mrp(secret, sockets[0]);
+    struct command_capture capture = {0};
+    struct ap2_mrp_ctx *mrp = create_mrp_with_callback(
+        secret, sockets[0], capture_remote_command, &capture);
 
-    char request[256];
-    int request_len = snprintf(
-        request, sizeof(request),
-        "POST /command RTSP/1.0\r\nCSeq: 42\r\n"
-        "Server: AirTunes/1.0\r\nContent-Length: 4\r\n\r\ntest");
-    uint8_t encrypted[512];
-    int encrypted_len = encrypt_frame(
-        receiver_key, 0, (const uint8_t *)request, request_len, encrypted);
+    int saved_stderr = dup(STDERR_FILENO);
+    FILE *log_capture = tmpfile();
+    assert(saved_stderr >= 0 && log_capture);
+    assert(dup2(fileno(log_capture), STDERR_FILENO) >= 0);
+    test_log_level = lDEBUG;
+
+    uint8_t encrypted[1200];
+    int encrypted_len = build_command_request(
+        encrypted, sizeof(encrypted), receiver_key, 0, 42, "play");
     assert(write(sockets[1], encrypted, 1) == 1);
     ap2_mrp_tick(mrp);
     assert(write(sockets[1], encrypted + 1,
                  (size_t)(encrypted_len - 1)) == encrypted_len - 1);
-    send_request(sockets[1], receiver_key, 1, 43);
+    send_request(sockets[1], receiver_key, 1, 43, "paus");
     ap2_mrp_tick(mrp);
     read_response(sockets[1], sender_key, 0, 42);
     read_response(sockets[1], sender_key, 1, 43);
+
+    static const char *values[] = {"plps", "nitm", "pitm"};
+    for (int i = 0; i < 3; i++) {
+        send_request(sockets[1], receiver_key, (uint64_t)i + 2,
+                     i + 44, values[i]);
+        ap2_mrp_tick(mrp);
+        read_response(sockets[1], sender_key, (uint64_t)i + 2, i + 44);
+    }
+
+    send_request(sockets[1], receiver_key, 5, 47, "unknown");
+    ap2_mrp_tick(mrp);
+    read_response(sockets[1], sender_key, 5, 47);
+
+    encrypted_len = build_typed_command_request(
+        encrypted, sizeof(encrypted), receiver_key, 6, 48,
+        "updateInfo", "play");
+    assert(write(sockets[1], encrypted, (size_t)encrypted_len) == encrypted_len);
+    ap2_mrp_tick(mrp);
+    read_response(sockets[1], sender_key, 6, 48);
+
+    encrypted_len = build_embedded_nul_request(
+        encrypted, sizeof(encrypted), receiver_key, 7, 49);
+    assert(write(sockets[1], encrypted, (size_t)encrypted_len) == encrypted_len);
+    ap2_mrp_tick(mrp);
+    read_response(sockets[1], sender_key, 7, 49);
+
+    encrypted_len = build_nested_command_request(
+        encrypted, sizeof(encrypted), receiver_key, 8, 50);
+    assert(write(sockets[1], encrypted, (size_t)encrypted_len) == encrypted_len);
+    ap2_mrp_tick(mrp);
+    read_response(sockets[1], sender_key, 8, 50);
+
+    uint8_t corrupt_bplist[40] = {0};
+    memcpy(corrupt_bplist, "bplist00", 8);
+    corrupt_bplist[14] = 1;  /* offset size */
+    corrupt_bplist[15] = 1;  /* object-reference size */
+    corrupt_bplist[23] = 1;  /* object count */
+    corrupt_bplist[39] = 8;  /* invalid offset-table location */
+    encrypted_len = build_event_request(
+        encrypted, sizeof(encrypted), receiver_key, 9, 51,
+        corrupt_bplist, (int)sizeof(corrupt_bplist));
+    assert(write(sockets[1], encrypted, (size_t)encrypted_len) == encrypted_len);
+    ap2_mrp_tick(mrp);
+    read_response(sockets[1], sender_key, 9, 51);
+
+    static const uint8_t invalid_body[] = {'t', 'e', 's', 't'};
+    encrypted_len = build_event_request(
+        encrypted, sizeof(encrypted), receiver_key, 10, 52,
+        invalid_body, (int)sizeof(invalid_body));
+    assert(write(sockets[1], encrypted, (size_t)encrypted_len) == encrypted_len);
+    ap2_mrp_tick(mrp);
+    read_response(sockets[1], sender_key, 10, 52);
+
+    static const ap2_remote_command_t expected_commands[] = {
+        AP2_REMOTE_COMMAND_PLAY,
+        AP2_REMOTE_COMMAND_PAUSE,
+        AP2_REMOTE_COMMAND_PLAY_PAUSE,
+        AP2_REMOTE_COMMAND_NEXT,
+        AP2_REMOTE_COMMAND_PREVIOUS,
+    };
+    static const char *expected_names[] = {
+        "play", "pause", "play_pause", "next", "previous",
+    };
+    assert(capture.count == 5);
+    for (int i = 0; i < capture.count; i++) {
+        assert(capture.commands[i] == expected_commands[i]);
+        assert(strcmp(
+                   ap2_remote_command_name(capture.commands[i]),
+                   expected_names[i]) == 0);
+    }
+
+    fflush(stderr);
+    test_log_level = lSILENCE;
+    assert(dup2(saved_stderr, STDERR_FILENO) >= 0);
+    close(saved_stderr);
+    assert(fseek(log_capture, 0, SEEK_SET) == 0);
+    char logs[8192];
+    size_t logs_len = fread(logs, 1, sizeof(logs) - 1, log_capture);
+    logs[logs_len] = '\0';
+    fclose(log_capture);
+    assert(strstr(logs, "content_type=application/x-apple-binary-plist"));
+    assert(strstr(logs, "type=sendMediaRemoteCommand value=play"));
+    assert(strstr(logs, "type=sendMediaRemoteCommand value=paus"));
+    assert(strstr(logs, "type=sendMediaRemoteCommand value=plps"));
+    assert(strstr(logs, "type=sendMediaRemoteCommand value=nitm"));
+    assert(strstr(logs, "type=sendMediaRemoteCommand value=pitm"));
+    assert(strstr(logs, "body parse failed"));
+    assert(strstr(logs, "content_length=4 hex=74657374"));
+
     ap2_mrp_destroy(mrp);
     close(sockets[1]);
 
@@ -267,7 +470,7 @@ int main(void)
          batch++) {
         for (int i = 0; i < 10; i++, counter++)
             send_request(sockets[1], receiver_key, counter,
-                         100 + (int)counter);
+                         100 + (int)counter, "play");
         ap2_mrp_tick(mrp);
     }
     assert(ap2_mrp_event_status(mrp) == 0);


### PR DESCRIPTION
Apple TV sends Siri Remote playback controls through encrypted event-channel `POST /command` requests. These requests were acknowledged but their binary-plist payloads were previously discarded.

- Safely parse classic `sendMediaRemoteCommand` callbacks and forward typed play, pause, play/pause, next, and previous commands through the AP2 client to normalized CLI events.
- Keep HTTP acknowledgements independent, ignore malformed or unsupported payloads, and service event input at a responsive cadence.
- Cover all mappings, exactly-once delivery, fragmented requests, malformed payloads, and acknowledgement behavior with focused tests.