### PR TITLE
Report each device's supported audio formats

### DIFF
--- a/src/ap2_bplist.cpp
+++ b/src/ap2_bplist.cpp
@@ -129,6 +129,114 @@ static uint64_t bp_read_be(const uint8_t *p, size_t n)
     return v;
 }
 
+/* Bounds-checked view over a raw bplist for keyed traversal into nested
+ * containers (dict -> child value, dict -> array of ints). */
+struct bp_raw_view {
+    const uint8_t *data;
+    size_t table_ofs;
+    uint64_t num_objects;
+    uint8_t ofs_size;
+    uint8_t ref_size;
+};
+
+static bool bp_view_init(const uint8_t *data, size_t len, bp_raw_view *view)
+{
+    if (!data || !view || len < 40 || memcmp(data, "bplist00", 8) != 0) return false;
+
+    const uint8_t *tr = data + len - 32;
+    view->data = data;
+    view->ofs_size = tr[6];
+    view->ref_size = tr[7];
+    view->num_objects = bp_read_be(tr + 8, 8);
+    view->table_ofs = (size_t)bp_read_be(tr + 24, 8);
+    if (!view->ofs_size || view->ofs_size > 8 ||
+        !view->ref_size || view->ref_size > 8)
+        return false;
+    if (view->table_ofs > len - 32 ||
+        view->num_objects > (len - 32 - view->table_ofs) / view->ofs_size)
+        return false;
+    return true;
+}
+
+static size_t bp_view_obj_ofs(const bp_raw_view *view, uint64_t ref)
+{
+    if (!view || ref >= view->num_objects) return 0;
+    return (size_t)bp_read_be(view->data + view->table_ofs +
+                             ref * view->ofs_size, view->ofs_size);
+}
+
+static bool bp_ascii_key_equals(const bp_raw_view *view, uint64_t ref,
+                                const char *key)
+{
+    size_t pos = bp_view_obj_ofs(view, ref);
+    if (!pos || pos >= view->table_ofs ||
+        (view->data[pos] & 0xF0) != 0x50)
+        return false;
+
+    size_t count;
+    if (!bp_read_count(view->data, view->table_ofs, &pos, &count)) return false;
+    size_t keylen = strlen(key);
+    return count == keylen && pos + count <= view->table_ofs &&
+           memcmp(view->data + pos, key, keylen) == 0;
+}
+
+static bool bp_dict_find_value_ref(const bp_raw_view *view, uint64_t dict_ref,
+                                   const char *key, uint64_t *value_ref)
+{
+    size_t pos = bp_view_obj_ofs(view, dict_ref);
+    if (!pos || pos >= view->table_ofs ||
+        (view->data[pos] & 0xF0) != 0xD0)
+        return false;
+
+    size_t count;
+    if (!bp_read_count(view->data, view->table_ofs, &pos, &count)) return false;
+    if (count > (view->table_ofs - pos) / (2 * view->ref_size)) return false;
+
+    for (size_t i = 0; i < count; i++) {
+        uint64_t key_ref = bp_read_be(view->data + pos + i * view->ref_size,
+                                      view->ref_size);
+        if (!bp_ascii_key_equals(view, key_ref, key)) continue;
+        *value_ref = bp_read_be(view->data + pos +
+                                (count + i) * view->ref_size,
+                                view->ref_size);
+        return true;
+    }
+    return false;
+}
+
+static bool bp_find_value_ref(const bp_raw_view *view, const char *key,
+                              uint64_t *value_ref)
+{
+    for (uint64_t ref = 0; ref < view->num_objects; ref++) {
+        if (bp_dict_find_value_ref(view, ref, key, value_ref)) return true;
+    }
+    return false;
+}
+
+static bool bp_read_uint_ref(const bp_raw_view *view, uint64_t ref, uint64_t *out)
+{
+    size_t pos = bp_view_obj_ofs(view, ref);
+    if (!pos || pos >= view->table_ofs ||
+        (view->data[pos] & 0xF0) != 0x10)
+        return false;
+
+    size_t bytes;
+    if (!bp_read_count(view->data, view->table_ofs, &pos, &bytes) ||
+        bytes > 8 || pos + bytes > view->table_ofs)
+        return false;
+    *out = bp_read_be(view->data + pos, bytes);
+    return true;
+}
+
+static bool bp_find_dict_child_ref(const bp_raw_view *view,
+                                   const char *dict_key, const char *key,
+                                   uint64_t *value_ref)
+{
+    uint64_t dict_ref;
+    return bp_find_value_ref(view, dict_key, &dict_ref) &&
+           bp_dict_find_value_ref(view, dict_ref, key, value_ref);
+}
+
 int ap2_bplist_get_root_string(const uint8_t *data, size_t len, const char *key,
                                char *out, size_t out_size)
 {
@@ -254,6 +362,49 @@ int ap2_bplist_find_uint(const uint8_t *data, size_t len, const char *key, uint6
         }
     }
     return 0;
+}
+
+int ap2_bplist_find_dict_uint(const uint8_t *data, size_t len,
+                              const char *dict_key, const char *key,
+                              uint64_t *out)
+{
+    bp_raw_view view;
+    uint64_t value_ref;
+    return bp_view_init(data, len, &view) &&
+           bp_find_dict_child_ref(&view, dict_key, key, &value_ref) &&
+           bp_read_uint_ref(&view, value_ref, out);
+}
+
+int ap2_bplist_find_dict_uint_array_mask(const uint8_t *data, size_t len,
+                                         const char *dict_key, const char *key,
+                                         uint64_t *out)
+{
+    bp_raw_view view;
+    uint64_t array_ref;
+    if (!out || !bp_view_init(data, len, &view) ||
+        !bp_find_dict_child_ref(&view, dict_key, key, &array_ref))
+        return 0;
+
+    size_t pos = bp_view_obj_ofs(&view, array_ref);
+    if (!pos || pos >= view.table_ofs ||
+        (view.data[pos] & 0xF0) != 0xA0)
+        return 0;
+
+    size_t count;
+    if (!bp_read_count(view.data, view.table_ofs, &pos, &count) ||
+        count > (view.table_ofs - pos) / view.ref_size)
+        return 0;
+
+    uint64_t mask = 0;
+    for (size_t i = 0; i < count; i++) {
+        uint64_t value_ref = bp_read_be(view.data + pos + i * view.ref_size,
+                                        view.ref_size);
+        uint64_t bit;
+        if (!bp_read_uint_ref(&view, value_ref, &bit)) return 0;
+        if (bit < 64) mask |= 1ULL << bit;
+    }
+    *out = mask;
+    return 1;
 }
 
 } /* extern "C" */

--- a/src/ap2_bplist.h
+++ b/src/ap2_bplist.h
@@ -61,6 +61,23 @@ const uint8_t *ap2_bplist_get_data(struct ap2_bplist *bp, const char *key, size_
  */
 int ap2_bplist_find_uint(const uint8_t *data, size_t len, const char *key, uint64_t *out);
 
+/*
+ * Find an integer child inside a named dictionary, e.g.
+ * supportedFormats.bufferStream.
+ */
+int ap2_bplist_find_dict_uint(const uint8_t *data, size_t len,
+                              const char *dict_key, const char *key,
+                              uint64_t *out);
+
+/*
+ * Read an array of integer bit indices inside a named dictionary into a
+ * 64-bit mask, e.g. supportedAudioFormatsExtended.bufferStream.
+ * Indices above 63 are ignored.
+ */
+int ap2_bplist_find_dict_uint_array_mask(const uint8_t *data, size_t len,
+                                         const char *dict_key, const char *key,
+                                         uint64_t *out);
+
 /* Find a string value by key in the root dictionary only. */
 int ap2_bplist_get_root_string(const uint8_t *data, size_t len, const char *key,
                                char *out, size_t out_size);

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -55,6 +55,12 @@ extern log_level *loglevel;
 
 #define AP2_FRAMES_PER_CHUNK 352
 #define AP2_CHACHA_TAG_SIZE  16
+
+/* audioFormat codes (bit positions shared with the /info format tables). */
+#define AP2_FMT_ALAC_44100_16_2 (1ULL << 18)
+#define AP2_FMT_ALAC_44100_24_2 (1ULL << 19)
+#define AP2_FMT_ALAC_48000_16_2 (1ULL << 20)
+#define AP2_FMT_ALAC_48000_24_2 (1ULL << 21)
 #define AP2_RTSP_SETUP_TIMEOUT_MS    8000
 #define AP2_RTSP_CONTROL_TIMEOUT_MS  2000
 #define AP2_RTSP_FEEDBACK_TIMEOUT_MS 1500
@@ -158,6 +164,16 @@ struct ap2cl_s {
     uint64_t start_ntp;            /* shared group start (NTP fixed-point), 0 = none */
     _Atomic uint32_t rtp_offset;   /* per-process timeline offset (see start_at) */
     uint64_t audio_nonce_counter;
+    /* Requested audioFormat and the /info-advertised per-stream format tables
+     * (bit masks in the audioFormat bit space; "known" = the table was present,
+     * "extended" = from supportedAudioFormatsExtended vs the legacy mask). */
+    uint64_t audio_format;
+    uint64_t realtime_formats;
+    uint64_t buffered_formats;
+    bool realtime_formats_known;
+    bool buffered_formats_known;
+    bool realtime_formats_extended;
+    bool buffered_formats_extended;
     char session_url[128];
     char session_uuid[40];
     char group_uuid[40];
@@ -716,6 +732,42 @@ ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char
     return r;
 }
 
+static uint64_t ap2_audio_format_code(const ap2_audio_format_t *format)
+{
+    if (format->bit_depth > 16 && format->sample_rate >= 48000)
+        return AP2_FMT_ALAC_48000_24_2;
+    if (format->bit_depth > 16)
+        return AP2_FMT_ALAC_44100_24_2;
+    if (format->sample_rate >= 48000)
+        return AP2_FMT_ALAC_48000_16_2;
+    return AP2_FMT_ALAC_44100_16_2;
+}
+
+/* Read one stream type's advertised format table from the GET /info reply:
+ * supportedAudioFormatsExtended.<stream> (array of bit indices) when present,
+ * else the legacy supportedFormats.<stream> mask. The tables are advisory —
+ * hardware both understates (Apple TV renders unadvertised 24-bit) and
+ * overstates (a SETUP 200 can still render silence); see DESIGN.md §11. */
+static void ap2_parse_format_capability(const uint8_t *data, size_t len,
+                                        const char *stream_key,
+                                        uint64_t *formats, bool *known,
+                                        bool *extended)
+{
+    *formats = 0;
+    *known = false;
+    *extended = false;
+    if (ap2_bplist_find_dict_uint_array_mask(data, len,
+                                              "supportedAudioFormatsExtended",
+                                              stream_key, formats)) {
+        *known = true;
+        *extended = true;
+        return;
+    }
+    if (ap2_bplist_find_dict_uint(data, len, "supportedFormats",
+                                  stream_key, formats))
+        *known = true;
+}
+
 /* Build one timing-peer dict {ID, DeviceType, ClockID, SupportsClockPort..., Addresses:[addr]}. */
 static ap2_pl_node *ap2_make_timing_peer(const char *id, uint64_t clock_id, const char *addr)
 {
@@ -889,8 +941,34 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     /* 1. GET /info */
     uint8_t *resp = NULL; int resp_len = 0;
     int status = ap2_rtsp_send(p, "GET", "/info", NULL, 0, NULL, &resp, &resp_len);
+    if (status != 200) {
+        LOG_ERROR("[AP2] /info failed: %d", status);
+        free(resp);
+        return false;
+    }
+    p->audio_format = ap2_audio_format_code(&p->format);
+    if (resp && resp_len > 0) {
+        ap2_parse_format_capability(resp, (size_t)resp_len, "audioStream",
+                                    &p->realtime_formats,
+                                    &p->realtime_formats_known,
+                                    &p->realtime_formats_extended);
+        ap2_parse_format_capability(resp, (size_t)resp_len, "bufferStream",
+                                    &p->buffered_formats,
+                                    &p->buffered_formats_known,
+                                    &p->buffered_formats_extended);
+    }
+    LOG_INFO("[AP2] Formats requested=0x%" PRIx64
+             " realtime=%s0x%" PRIx64 " buffered=%s0x%" PRIx64,
+             p->audio_format,
+             p->realtime_formats_known
+                 ? (p->realtime_formats_extended ? "extended:" : "mask:")
+                 : "unknown:",
+             p->realtime_formats,
+             p->buffered_formats_known
+                 ? (p->buffered_formats_extended ? "extended:" : "mask:")
+                 : "unknown:",
+             p->buffered_formats);
     free(resp);
-    if (status != 200) { LOG_ERROR("[AP2] /info failed: %d", status); return false; }
 
     /* 2. HAP pairing: pair-verify with stored credentials (Apple TV/HomePod),
      * transient pair-setup otherwise (Sonos and most third-party receivers) */
@@ -1127,15 +1205,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     int local_ctrl_port = ntohs(cs_local.sin_port);
 
     /* Determine audio format */
-    uint64_t audio_format;
-    if (p->format.bit_depth > 16 && p->format.sample_rate >= 48000)
-        audio_format = 0x200000;  /* ALAC 48000/24/2 */
-    else if (p->format.bit_depth > 16)
-        audio_format = 0x80000;   /* ALAC 44100/24/2 */
-    else if (p->format.sample_rate >= 48000)
-        audio_format = 0x100000;  /* ALAC 48000/16/2 */
-    else
-        audio_format = 0x40000;   /* ALAC 44100/16/2 */
+    uint64_t audio_format = ap2_audio_format_code(&p->format);
 
     /* Realtime (type 96) streams the audio over UDP and carries our data port in
      * the SETUP; buffered (type 103) pushes RTP over a TCP connection to the
@@ -2878,6 +2948,19 @@ bool ap2cl_set_progress(struct ap2cl_s *p, int elapsed_s, int duration_s)
     }
     if (!p->raopcl) return false;
     return raopcl_set_progress_ms(p->raopcl, elapsed_s * 1000, duration_s * 1000);
+}
+
+void ap2cl_format_capabilities(struct ap2cl_s *p,
+                               ap2_format_capabilities_t *caps)
+{
+    if (!caps) return;
+    memset(caps, 0, sizeof(*caps));
+    if (!p) return;
+    caps->requested = p->audio_format;
+    caps->realtime_formats = p->realtime_formats;
+    caps->buffered_formats = p->buffered_formats;
+    caps->realtime_known = p->realtime_formats_known;
+    caps->buffered_known = p->buffered_formats_known;
 }
 
 void ap2cl_latency_info(struct ap2cl_s *p, int *lead_ms, uint32_t *dev_min, uint32_t *dev_max)

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -53,6 +53,18 @@ typedef struct {
     int channels;       /* 2 (stereo) */
 } ap2_audio_format_t;
 
+/* The requested audioFormat and the /info-advertised per-stream format tables
+ * (bit masks in the audioFormat bit space). The tables are advisory: hardware
+ * both understates and overstates them (DESIGN.md §11), so callers must treat
+ * them as evidence, not proof. */
+typedef struct {
+    uint64_t requested;          /* audioFormat selected for this session */
+    uint64_t realtime_formats;   /* advertised audioStream mask */
+    uint64_t buffered_formats;   /* advertised bufferStream mask */
+    bool realtime_known;
+    bool buffered_known;
+} ap2_format_capabilities_t;
+
 /* AP2 device info (from mDNS TXT records) */
 typedef struct {
     char *name;         /* Device display name */
@@ -256,6 +268,11 @@ void ap2cl_set_publish_ip(struct ap2cl_s *p, const char *ip);
  * the client falls back to the realtime (type 96) stream. Must be called before
  * ap2cl_connect(). */
 void ap2cl_set_buffered(struct ap2cl_s *p, bool enable);
+
+/* Return the requested format and the /info-advertised format capabilities
+ * (populated by the native flow's GET /info; zeroed otherwise). */
+void ap2cl_format_capabilities(struct ap2cl_s *p,
+                               ap2_format_capabilities_t *caps);
 
 /* Set the callback for validated receiver MediaRemote commands. Must be called
  * before ap2cl_connect(); the callback remains fixed for that session. */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -875,6 +875,21 @@ static int run_airplay2(cli_config_t *cfg, int infile)
         fflush(stdout);
     }
 
+    /* Surface the /info-advertised format tables so the caller can pick the
+     * best format per device (e.g. auto-selecting 24-bit) instead of relying
+     * on a static configuration. Masks use the audioFormat bit space; known=0
+     * means the device did not publish that table. */
+    {
+        ap2_format_capabilities_t caps;
+        ap2cl_format_capabilities(g_ap2cl, &caps);
+        printf("[STATUS] capabilities requested=0x%llx realtime_formats=0x%llx "
+               "realtime_known=%d buffered_formats=0x%llx buffered_known=%d\n",
+               (unsigned long long)caps.requested,
+               (unsigned long long)caps.realtime_formats, caps.realtime_known ? 1 : 0,
+               (unsigned long long)caps.buffered_formats, caps.buffered_known ? 1 : 0);
+        fflush(stdout);
+    }
+
     /* Set volume */
     if (cfg->volume > 0) {
         ap2cl_set_volume(g_ap2cl, cfg->volume);

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include "ap2_bplist.h"
 #include "ap2_client.h"
 #include "cross_log.h"
 
@@ -30,8 +31,78 @@ static void *run_health_check(void *arg)
     return NULL;
 }
 
+/* Minimal /info-shaped bplists for the format-table readers.
+ * { supportedAudioFormatsExtended: { audioStream: [18, 21] } } */
+static const uint8_t INFO_EXTENDED[] = {
+    'b','p','l','i','s','t','0','0',
+    0xD1, 0x01, 0x02,                       /* root dict */
+    0x5F, 0x10, 0x1D,                       /* 29-char key */
+    's','u','p','p','o','r','t','e','d','A','u','d','i','o','F','o','r',
+    'm','a','t','s','E','x','t','e','n','d','e','d',
+    0xD1, 0x03, 0x04,                       /* nested dict */
+    0x5B, 'a','u','d','i','o','S','t','r','e','a','m',
+    0xA2, 0x05, 0x06,                       /* array of two ints */
+    0x10, 18,
+    0x10, 21,
+    0x08, 0x0B, 0x2B, 0x2E, 0x3A, 0x3D, 0x3F,   /* offset table */
+    0, 0, 0, 0, 0, 0, 1, 1,                 /* trailer: ofs/ref sizes */
+    0, 0, 0, 0, 0, 0, 0, 7,                 /* num objects */
+    0, 0, 0, 0, 0, 0, 0, 0,                 /* top object */
+    0, 0, 0, 0, 0, 0, 0, 65,                /* offset-table offset */
+};
+
+/* { supportedFormats: { bufferStream: 0x60000 } } */
+static const uint8_t INFO_LEGACY[] = {
+    'b','p','l','i','s','t','0','0',
+    0xD1, 0x01, 0x02,
+    0x5F, 0x10, 0x10,
+    's','u','p','p','o','r','t','e','d','F','o','r','m','a','t','s',
+    0xD1, 0x03, 0x04,
+    0x5C, 'b','u','f','f','e','r','S','t','r','e','a','m',
+    0x12, 0x00, 0x06, 0x00, 0x00,           /* 4-byte int 0x60000 */
+    0x08, 0x0B, 0x1E, 0x21, 0x2E,
+    0, 0, 0, 0, 0, 0, 1, 1,
+    0, 0, 0, 0, 0, 0, 0, 5,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 51,
+};
+
+static void test_info_format_tables(void)
+{
+    uint64_t mask = 0;
+    assert(ap2_bplist_find_dict_uint_array_mask(
+               INFO_EXTENDED, sizeof(INFO_EXTENDED),
+               "supportedAudioFormatsExtended", "audioStream", &mask) == 1);
+    assert(mask == ((1ULL << 18) | (1ULL << 21)));
+    assert(ap2_bplist_find_dict_uint_array_mask(
+               INFO_EXTENDED, sizeof(INFO_EXTENDED),
+               "supportedAudioFormatsExtended", "bufferStream", &mask) == 0);
+
+    assert(ap2_bplist_find_dict_uint(
+               INFO_LEGACY, sizeof(INFO_LEGACY),
+               "supportedFormats", "bufferStream", &mask) == 1);
+    assert(mask == 0x60000);
+    assert(ap2_bplist_find_dict_uint(
+               INFO_LEGACY, sizeof(INFO_LEGACY),
+               "supportedFormats", "audioStream", &mask) == 0);
+    /* The value is an int, not an array. */
+    assert(ap2_bplist_find_dict_uint_array_mask(
+               INFO_LEGACY, sizeof(INFO_LEGACY),
+               "supportedFormats", "bufferStream", &mask) == 0);
+
+    /* Truncated input must fail cleanly at every length, never crash. */
+    for (size_t len = 0; len < sizeof(INFO_EXTENDED); len++) {
+        assert(ap2_bplist_find_dict_uint_array_mask(
+                   INFO_EXTENDED, len,
+                   "supportedAudioFormatsExtended", "audioStream", &mask) == 0);
+    }
+    puts("ap2_bplist /info format-table tests passed");
+}
+
 int main(void)
 {
+    test_info_format_tables();
+
     ap2_device_info_t device = {
         .name = "test",
         .address = "127.0.0.1",


### PR DESCRIPTION
AirPlay receivers publish which audio formats (sample rates / bit depths) they support in their /info reply, split per stream type — but we never read it, so the caller has no way to know whether a device can do 24-bit without a manual setting.

- Read the advertised format tables during connect (modern extended table, with fallback to the legacy masks)
- Report them on a machine-parseable `[STATUS] capabilities` line alongside the existing latency report
- Unit tests with synthetic /info fixtures, including truncated-input safety

This is groundwork for Music Assistant picking the best format per device automatically instead of the hidden hi-res toggle. The tables are treated as evidence, not proof — some devices understate or overstate them, so the selection policy lives with the caller.