### PR TITLE
Reuse the connection for instant seek and next-track

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ RAOP_SOURCES = raop_client.c rtsp_client.c \
 	alac.c
 
 # AirPlay 2 sources (new)
-AP2_SOURCES = ap2_client.c ap2_hap.c ap2_io.c ap2_ptp.c ap2_ptp_shm.c ap2_plist.c ap2_mrp.c
+AP2_SOURCES = ap2_client.c ap2_hap.c ap2_io.c ap2_ptp.c ap2_ptp_shm.c ap2_plist.c ap2_mrp.c ap2_session.c
 
 # Common/CLI sources
 CLI_SOURCES = cross_log.c cross_ssl.c cross_util.c cross_net.c platform.c \

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,13 @@
 
 Genuinely open work only. Completed work lives in git history.
 
-- [ ] **Persistent session mode.** Keep one connection per player across
-      seek/next/resume: numbered media generations over per-generation input
-      pipes, committed with RTSP `FLUSH` + a re-based frozen anchor line
+- [ ] **Persistent sessions (no mode flag).** Keep one connection per player
+      across seek/next/resume: numbered media generations over per-generation
+      input pipes, committed with RTSP `FLUSH` + a re-based frozen anchor line
       (measured working down to a 150 ms warm lead on Sonos and Apple TV).
-      Replaces today's teardown-and-reconnect per `play_media`.
+      The argv invocation is generation 0; an attached `--cmdpipe` means the
+      connection outlives it awaiting the next generation. Replaces today's
+      teardown-and-reconnect per `play_media`.
 - [ ] **Parse `audioLatencies` from GET /info.** The SETUP echo of
       `latencyMin`/`latencyMax` is receiver-optional (Sonos omits it); the
       /info table would populate the pacing window and the reported

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -69,6 +69,10 @@ extern log_level *loglevel;
 #define AP2_FEEDBACK_INTERVAL_MS     2000
 #define AP2_EVENT_POLL_INTERVAL_MS   100
 #define AP2_UDP_SEND_TIMEOUT_MS      20
+/* Minimum lead for a warm generation switch: receivers accepted re-anchors
+ * down to 150 ms in the flush-ladder measurements; 350 ms leaves margin for
+ * the commit round-trips and scheduling jitter. */
+#define AP2_MIN_WARM_LEAD_MS         350
 
 typedef enum {
     FLOW_RAOP_COMPAT = 0,
@@ -1980,6 +1984,71 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
     int latency = raopcl_latency(p->raopcl);
     raopcl_start_at(p->raopcl, ntp_start - TS2NTP(latency, p->format.sample_rate));
     p->state = AP2_STREAMING;
+    return true;
+}
+
+/* Warm-flush a LIVE session for a generation switch: discard receiver-buffered
+ * audio and re-base the timeline so the next written frame is audible at the
+ * requested instant. Native realtime sends the classic RTSP FLUSH with
+ * RTP-Info and freezes a fresh anchor line (measured accepted down to a
+ * 150 ms lead on Sonos and Apple TV); the RAOP paths use libraop's documented
+ * flush + start-at seek flow. Sequence numbers (and thus audio nonces) are
+ * never reset, so crypto state stays valid across the boundary. A start in
+ * the past (or 0) is clamped to now + the minimum warm lead so the first
+ * samples of the new generation can never be clipped. */
+bool ap2cl_warm_flush(struct ap2cl_s *p, uint64_t start_unix_ms)
+{
+    if (!p || p->state == AP2_DOWN) return false;
+
+    uint64_t now_ntp = raopcl_get_ntp(NULL);
+    uint64_t start_ntp = start_unix_ms
+        ? ((start_unix_ms / 1000) << 32) |
+              (((start_unix_ms % 1000) << 32) / 1000)
+        : 0;
+    uint64_t min_start = now_ntp + MS2NTP(AP2_MIN_WARM_LEAD_MS);
+    if (start_ntp < min_start) start_ntp = min_start;
+
+    if (p->flow != FLOW_NATIVE_AP2) {
+        if (!p->raopcl) return false;
+        raopcl_pause(p->raopcl);
+        raopcl_flush(p->raopcl);
+        int latency = raopcl_latency(p->raopcl);
+        raopcl_start_at(p->raopcl,
+                        start_ntp - TS2NTP(latency, p->format.sample_rate));
+        p->state = AP2_STREAMING;
+        return true;
+    }
+
+    if (atomic_load(&p->rtsp_dead)) return false;
+    char hdr[64];
+    snprintf(hdr, sizeof(hdr), "RTP-Info: seq=%u;rtptime=%u\r\n",
+             (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
+    uint8_t *resp = NULL;
+    int resp_len = 0;
+    int status = ap2_rtsp_send_ex(p, "FLUSH", p->session_url, NULL, 0, NULL,
+                                  hdr, &resp, &resp_len);
+    free(resp);
+    LOG_INFO("[AP2] warm FLUSH (seq=%u rtptime=%u) -> %d",
+             (unsigned)p->seq_number, (unsigned)p->rtp_timestamp, status);
+    if (status != 200)
+        LOG_WARN("[AP2] receiver did not accept FLUSH (%d); re-anchoring anyway",
+                 status);
+
+    /* Re-base the frozen line: head_ts moves in the scheduling domain, the
+     * wire timestamp follows it plus the per-process offset, and the next
+     * sync packet freezes the new line from start_ntp. */
+    p->start_ntp = start_ntp;
+    p->head_ts = NTP2TS(start_ntp, p->format.sample_rate);
+    p->rtp_timestamp = (uint32_t)p->head_ts + atomic_load(&p->rtp_offset);
+    p->rt_anchor_valid = false;
+    p->state = AP2_STREAMING;
+    atomic_store(&p->media_healthy, true);
+
+    if (p->use_ptp && p->ctrl_sock >= 0 &&
+        ap2_send_sync_packet_ptp(p, true) == AP2_SEND_FATAL) {
+        atomic_store(&p->media_healthy, false);
+        return false;
+    }
     return true;
 }
 

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -1987,15 +1987,6 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
     return true;
 }
 
-/* Warm-flush a LIVE session for a generation switch: discard receiver-buffered
- * audio and re-base the timeline so the next written frame is audible at the
- * requested instant. Native realtime sends the classic RTSP FLUSH with
- * RTP-Info and freezes a fresh anchor line (measured accepted down to a
- * 150 ms lead on Sonos and Apple TV); the RAOP paths use libraop's documented
- * flush + start-at seek flow. Sequence numbers (and thus audio nonces) are
- * never reset, so crypto state stays valid across the boundary. A start in
- * the past (or 0) is clamped to now + the minimum warm lead so the first
- * samples of the new generation can never be clipped. */
 /* Silence the receiver but keep the session warm (persistent standby):
  * discard buffered audio with an RTSP FLUSH, publish the stopped playback
  * state, and drop back to CONNECTED so a later warm flush can restart. */
@@ -2023,6 +2014,15 @@ void ap2cl_standby(struct ap2cl_s *p)
     p->state = AP2_CONNECTED;
 }
 
+/* Warm-flush a LIVE session for a generation switch: discard receiver-buffered
+ * audio and re-base the timeline so the next written frame is audible at the
+ * requested instant. Native realtime sends the classic RTSP FLUSH with
+ * RTP-Info and freezes a fresh anchor line (measured accepted down to a
+ * 150 ms lead on Sonos and Apple TV); the RAOP paths use libraop's documented
+ * flush + start-at seek flow. Sequence numbers (and thus audio nonces) are
+ * never reset, so crypto state stays valid across the boundary. A start in
+ * the past (or 0) is clamped to now + the minimum warm lead so the first
+ * samples of the new generation can never be clipped. */
 bool ap2cl_warm_flush(struct ap2cl_s *p, uint64_t start_unix_ms)
 {
     if (!p || p->state == AP2_DOWN) return false;

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -1996,6 +1996,33 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
  * never reset, so crypto state stays valid across the boundary. A start in
  * the past (or 0) is clamped to now + the minimum warm lead so the first
  * samples of the new generation can never be clipped. */
+/* Silence the receiver but keep the session warm (persistent standby):
+ * discard buffered audio with an RTSP FLUSH, publish the stopped playback
+ * state, and drop back to CONNECTED so a later warm flush can restart. */
+void ap2cl_standby(struct ap2cl_s *p)
+{
+    if (!p || p->state == AP2_DOWN) return;
+    if (p->flow != FLOW_NATIVE_AP2) {
+        if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
+        p->state = AP2_CONNECTED;
+        return;
+    }
+    if (!atomic_load(&p->rtsp_dead)) {
+        char hdr[64];
+        snprintf(hdr, sizeof(hdr), "RTP-Info: seq=%u;rtptime=%u\r\n",
+                 (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
+        uint8_t *resp = NULL;
+        int resp_len = 0;
+        int status = ap2_rtsp_send_ex(p, "FLUSH", p->session_url, NULL, 0,
+                                      NULL, hdr, &resp, &resp_len);
+        free(resp);
+        LOG_INFO("[AP2] standby FLUSH -> %d", status);
+    }
+    ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
+    p->rt_anchor_valid = false;
+    p->state = AP2_CONNECTED;
+}
+
 bool ap2cl_warm_flush(struct ap2cl_s *p, uint64_t start_unix_ms)
 {
     if (!p || p->state == AP2_DOWN) return false;

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -161,6 +161,10 @@ bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start);
  */
 bool ap2cl_warm_flush(struct ap2cl_s *p, uint64_t start_unix_ms);
 
+/* Silence the receiver but keep the session warm: discard buffered audio,
+ * publish the stopped state, drop to CONNECTED awaiting the next warm flush. */
+void ap2cl_standby(struct ap2cl_s *p);
+
 /* Send a chunk of PCM audio data.
  * A transient realtime UDP drop advances the media timeline and returns
  * AP2_SEND_DROPPED; hard encode/control/session failures return AP2_SEND_FATAL.

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -152,6 +152,15 @@ bool ap2cl_disconnect(struct ap2cl_s *p);
 /* Start playback at the given NTP timestamp. */
 bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start);
 
+/*
+ * Warm-flush a live session for a generation switch (persistent session
+ * mode): discard receiver-buffered audio and re-base the timeline so the next
+ * written frame is audible at start_unix_ms (unix epoch milliseconds). A
+ * start of 0 or one already in the past is clamped to now + the minimum warm
+ * lead, so a new generation's first samples can never be clipped.
+ */
+bool ap2cl_warm_flush(struct ap2cl_s *p, uint64_t start_unix_ms);
+
 /* Send a chunk of PCM audio data.
  * A transient realtime UDP drop advances the media timeline and returns
  * AP2_SEND_DROPPED; hard encode/control/session failures return AP2_SEND_FATAL.

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -1,0 +1,496 @@
+/*
+ * Persistent session - generation state machine (see ap2_session.h)
+ *
+ * Threading model: PREPARE spawns one reader thread per generation that
+ * drains the generation's input into its own ring. The command-pipe thread
+ * drives prepare/start/flush/standby; START performs the transport commit
+ * (RTSP work is serialized inside the transport) and swaps the staged slot
+ * in as active under the session lock. The audio loop only ever calls
+ * ap2_session_read()/poll(), so a generation switch is invisible to it
+ * beyond the data changing.
+ *
+ * Slots are heap objects with stable addresses for their reader threads;
+ * generation switches swap pointers, never slot contents. A retired slot is
+ * freed only after its reader has been joined.
+ *
+ * Copyright (C) 2024-2026 Music Assistant Contributors
+ * See LICENSE
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "ap2_io.h"
+#include "ap2_session.h"
+#include "cross_log.h"
+
+extern log_level *loglevel;
+
+#define SRING_MIN_BYTES   (1u << 20)   /* 1 MiB floor */
+#define SRING_SECONDS     4            /* ring depth in media time */
+
+/* One generation's input ring, filled by its reader thread. */
+typedef struct {
+    uint8_t *data;
+    size_t cap, rd, wr, fill;
+    bool eof;        /* writer closed (or read error) */
+    bool abort;      /* stop the reader and discard */
+} sring_t;
+
+typedef struct {
+    ap2_generation_t gen;
+    char *path_owned;         /* strdup'd audio_path (gen.audio_path aliases) */
+    sring_t ring;
+    pthread_t thread;
+    bool thread_started;
+    bool ready_sent;
+    bool primed_sent;
+} slot_t;
+
+struct ap2_session_s {
+    ap2_session_ops_t ops;
+    unsigned byte_rate;
+    size_t prefill_bytes;
+    int idle_timeout_ms;
+
+    pthread_mutex_t lock;
+    pthread_cond_t can_read;   /* active ring gained data / state changed */
+    pthread_cond_t can_write;  /* a ring gained space / abort requested */
+
+    ap2_session_state_t state;
+    slot_t *active;
+    slot_t *staged;
+    uint64_t played_bytes;     /* consumed from the ACTIVE generation */
+    uint64_t idle_since_ms;    /* monotonic ms when we last went idle */
+};
+
+/* ---- ring helpers (called with s->lock held) ---- */
+
+static bool sring_init(sring_t *r, unsigned byte_rate)
+{
+    size_t cap = (size_t)byte_rate * SRING_SECONDS;
+    if (cap < SRING_MIN_BYTES) cap = SRING_MIN_BYTES;
+    memset(r, 0, sizeof(*r));
+    r->data = malloc(cap);
+    if (!r->data) return false;
+    r->cap = cap;
+    return true;
+}
+
+static size_t sring_pop(sring_t *r, uint8_t *buf, size_t want)
+{
+    size_t n = want < r->fill ? want : r->fill;
+    size_t first = r->cap - r->rd;
+    if (first > n) first = n;
+    memcpy(buf, r->data + r->rd, first);
+    memcpy(buf + first, r->data, n - first);
+    r->rd = (r->rd + n) % r->cap;
+    r->fill -= n;
+    return n;
+}
+
+static size_t sring_push(sring_t *r, const uint8_t *buf, size_t len)
+{
+    size_t space = r->cap - r->fill;
+    size_t n = len < space ? len : space;
+    size_t first = r->cap - r->wr;
+    if (first > n) first = n;
+    memcpy(r->data + r->wr, buf, first);
+    memcpy(r->data, buf + first, n - first);
+    r->wr = (r->wr + n) % r->cap;
+    r->fill += n;
+    return n;
+}
+
+/* ---- status emission (short callback; safe under the session lock) ---- */
+
+static void emit(struct ap2_session_s *s, const char *fmt, ...)
+{
+    char line[192];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(line, sizeof(line), fmt, ap);
+    va_end(ap);
+    s->ops.status(line);
+}
+
+/* ---- generation reader thread ---- */
+
+typedef struct {
+    struct ap2_session_s *s;
+    slot_t *slot;
+} reader_arg_t;
+
+static void *reader_thread(void *arg)
+{
+    reader_arg_t a = *(reader_arg_t *)arg;
+    free(arg);
+    struct ap2_session_s *s = a.s;
+    slot_t *slot = a.slot;
+
+    int fd = slot->gen.audio_fd;
+    if (fd < 0) {
+        /* Blocking open pairs with the writer's open; an abort unblocks it by
+         * briefly opening the write side (abort_slot). */
+        fd = open(slot->path_owned, O_RDONLY);
+        if (fd < 0) {
+            pthread_mutex_lock(&s->lock);
+            slot->ring.eof = true;
+            pthread_cond_broadcast(&s->can_read);
+            pthread_mutex_unlock(&s->lock);
+            LOG_ERROR("[SESSION] cannot open %s: %s", slot->path_owned,
+                      strerror(errno));
+            return NULL;
+        }
+    }
+
+    pthread_mutex_lock(&s->lock);
+    if (!slot->ring.abort && !slot->ready_sent) {
+        slot->ready_sent = true;
+        emit(s, "[STATUS] ready generation=%llu",
+             (unsigned long long)slot->gen.number);
+    }
+    pthread_mutex_unlock(&s->lock);
+
+    /* The read below unblocks when the writer closes its end (MA kills the
+     * generation's ffmpeg on replace), which is the normal retirement path;
+     * abort covers the never-started cases. */
+    uint8_t buf[16384];
+    for (;;) {
+        ssize_t n = read(fd, buf, sizeof(buf));
+        pthread_mutex_lock(&s->lock);
+        if (slot->ring.abort) {
+            pthread_mutex_unlock(&s->lock);
+            break;
+        }
+        if (n <= 0) {
+            slot->ring.eof = true;
+            emit(s, "[STATUS] input_eof generation=%llu",
+                 (unsigned long long)slot->gen.number);
+            pthread_cond_broadcast(&s->can_read);
+            pthread_mutex_unlock(&s->lock);
+            break;
+        }
+        size_t off = 0;
+        while (off < (size_t)n && !slot->ring.abort) {
+            size_t pushed = sring_push(&slot->ring, buf + off, (size_t)n - off);
+            off += pushed;
+            if (pushed) pthread_cond_broadcast(&s->can_read);
+            if (!slot->primed_sent && slot->ring.fill >= s->prefill_bytes) {
+                slot->primed_sent = true;
+                emit(s, "[STATUS] primed generation=%llu prefill_ms=%llu",
+                     (unsigned long long)slot->gen.number,
+                     (unsigned long long)(slot->ring.fill * 1000ULL /
+                                          s->byte_rate));
+            }
+            if (off < (size_t)n)
+                pthread_cond_wait(&s->can_write, &s->lock);
+        }
+        pthread_mutex_unlock(&s->lock);
+    }
+    if (fd != slot->gen.audio_fd) close(fd);
+    return NULL;
+}
+
+/* Stop a detached slot's reader, join it and free the slot. The slot must
+ * already be unlinked from the session. Lock must NOT be held. */
+static void retire_slot(struct ap2_session_s *s, slot_t *slot)
+{
+    if (!slot) return;
+    pthread_mutex_lock(&s->lock);
+    slot->ring.abort = true;
+    pthread_cond_broadcast(&s->can_write);
+    bool started = slot->thread_started;
+    pthread_mutex_unlock(&s->lock);
+
+    if (started) {
+        /* Unblock a reader stuck in open(O_RDONLY) on a writerless FIFO. */
+        if (slot->gen.audio_fd < 0 && slot->path_owned) {
+            int wfd = open(slot->path_owned, O_WRONLY | O_NONBLOCK);
+            if (wfd >= 0) close(wfd);
+        }
+        pthread_join(slot->thread, NULL);
+    }
+    free(slot->ring.data);
+    free(slot->path_owned);
+    free(slot);
+}
+
+/* Detach a slot pointer from the session under the lock. */
+static slot_t *detach(struct ap2_session_s *s, slot_t **ref)
+{
+    pthread_mutex_lock(&s->lock);
+    slot_t *slot = *ref;
+    *ref = NULL;
+    pthread_mutex_unlock(&s->lock);
+    return slot;
+}
+
+/* ---- public API ---- */
+
+struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
+                                         unsigned byte_rate, int prefill_ms,
+                                         int idle_timeout_ms)
+{
+    if (!ops || !ops->commit || !ops->stop || !ops->status || !byte_rate)
+        return NULL;
+    struct ap2_session_s *s = calloc(1, sizeof(*s));
+    if (!s) return NULL;
+    s->ops = *ops;
+    s->byte_rate = byte_rate;
+    s->prefill_bytes = (size_t)byte_rate * (prefill_ms > 0 ? prefill_ms : 1)
+                       / 1000;
+    s->idle_timeout_ms = idle_timeout_ms;
+    pthread_mutex_init(&s->lock, NULL);
+    pthread_cond_init(&s->can_read, NULL);
+    pthread_cond_init(&s->can_write, NULL);
+    s->state = AP2_SESSION_IDLE;
+    s->idle_since_ms = ap2_io_monotonic_ms();
+    return s;
+}
+
+void ap2_session_destroy(struct ap2_session_s *s)
+{
+    if (!s) return;
+    ap2_session_end(s);
+    retire_slot(s, detach(s, &s->staged));
+    retire_slot(s, detach(s, &s->active));
+    pthread_cond_destroy(&s->can_read);
+    pthread_cond_destroy(&s->can_write);
+    pthread_mutex_destroy(&s->lock);
+    free(s);
+}
+
+bool ap2_session_prepare(struct ap2_session_s *s, const ap2_generation_t *gen)
+{
+    if (!s || !gen || (gen->audio_fd < 0 && !gen->audio_path)) return false;
+    /* A superseded staged generation is discarded: the caller only ever wants
+     * the newest one (rapid seek/seek/seek collapses naturally). */
+    retire_slot(s, detach(s, &s->staged));
+
+    slot_t *slot = calloc(1, sizeof(*slot));
+    if (!slot) return false;
+    slot->gen = *gen;
+    slot->path_owned = gen->audio_path ? strdup(gen->audio_path) : NULL;
+    slot->gen.audio_path = slot->path_owned;
+    if (!sring_init(&slot->ring, s->byte_rate)) {
+        free(slot->path_owned);
+        free(slot);
+        return false;
+    }
+
+    pthread_mutex_lock(&s->lock);
+    if (s->state == AP2_SESSION_ENDED) {
+        pthread_mutex_unlock(&s->lock);
+        free(slot->ring.data);
+        free(slot->path_owned);
+        free(slot);
+        return false;
+    }
+    s->staged = slot;
+    if (s->state == AP2_SESSION_IDLE || s->state == AP2_SESSION_STANDBY)
+        s->state = AP2_SESSION_PREPARING;
+    pthread_mutex_unlock(&s->lock);
+
+    reader_arg_t *arg = malloc(sizeof(*arg));
+    if (!arg) {
+        retire_slot(s, detach(s, &s->staged));
+        return false;
+    }
+    arg->s = s;
+    arg->slot = slot;
+    if (pthread_create(&slot->thread, NULL, reader_thread, arg) != 0) {
+        free(arg);
+        retire_slot(s, detach(s, &s->staged));
+        return false;
+    }
+    pthread_mutex_lock(&s->lock);
+    slot->thread_started = true;
+    pthread_mutex_unlock(&s->lock);
+    return true;
+}
+
+bool ap2_session_start(struct ap2_session_s *s, uint64_t generation,
+                       uint64_t start_unix_ms)
+{
+    if (!s) return false;
+    pthread_mutex_lock(&s->lock);
+    bool ok = s->staged && s->staged->gen.number == generation &&
+              s->state != AP2_SESSION_ENDED;
+    pthread_mutex_unlock(&s->lock);
+    if (!ok) {
+        LOG_ERROR("[SESSION] START for generation %llu does not match the "
+                  "staged generation",
+                  (unsigned long long)generation);
+        return false;
+    }
+
+    /* Transport commit outside the lock: it does RTSP round-trips. The staged
+     * reader keeps filling meanwhile; the audio loop still consumes the OLD
+     * ring until the swap below, and anything it sends between flush and swap
+     * lands behind the flush point. */
+    if (!s->ops.commit(s->ops.transport, start_unix_ms)) {
+        LOG_ERROR("[SESSION] transport commit failed for generation %llu",
+                  (unsigned long long)generation);
+        return false;
+    }
+
+    pthread_mutex_lock(&s->lock);
+    slot_t *old = s->active;
+    s->active = s->staged;
+    s->staged = NULL;
+    s->played_bytes = 0;
+    s->state = AP2_SESSION_PLAYING;
+    pthread_cond_broadcast(&s->can_read);
+    pthread_cond_broadcast(&s->can_write);
+    pthread_mutex_unlock(&s->lock);
+
+    retire_slot(s, old);
+    return true;
+}
+
+bool ap2_session_flush(struct ap2_session_s *s, uint64_t generation)
+{
+    if (!s) return false;
+    pthread_mutex_lock(&s->lock);
+    bool is_staged = s->staged && s->staged->gen.number == generation;
+    bool is_active = s->active && s->active->gen.number == generation;
+    pthread_mutex_unlock(&s->lock);
+
+    if (is_staged) {
+        retire_slot(s, detach(s, &s->staged));
+        return true;
+    }
+    if (is_active) {
+        s->ops.stop(s->ops.transport);
+        retire_slot(s, detach(s, &s->active));
+        pthread_mutex_lock(&s->lock);
+        if (s->state != AP2_SESSION_ENDED) {
+            s->state = s->staged ? AP2_SESSION_PREPARING : AP2_SESSION_IDLE;
+            s->idle_since_ms = ap2_io_monotonic_ms();
+        }
+        pthread_cond_broadcast(&s->can_read);
+        pthread_mutex_unlock(&s->lock);
+        return true;
+    }
+    return false;
+}
+
+bool ap2_session_standby(struct ap2_session_s *s)
+{
+    if (!s) return false;
+    s->ops.stop(s->ops.transport);
+    retire_slot(s, detach(s, &s->active));
+    pthread_mutex_lock(&s->lock);
+    if (s->state != AP2_SESSION_ENDED) {
+        s->state = s->staged ? AP2_SESSION_PREPARING : AP2_SESSION_STANDBY;
+        s->idle_since_ms = ap2_io_monotonic_ms();
+    }
+    pthread_cond_broadcast(&s->can_read);
+    pthread_mutex_unlock(&s->lock);
+    return true;
+}
+
+void ap2_session_end(struct ap2_session_s *s)
+{
+    if (!s) return;
+    pthread_mutex_lock(&s->lock);
+    s->state = AP2_SESSION_ENDED;
+    pthread_cond_broadcast(&s->can_read);
+    pthread_cond_broadcast(&s->can_write);
+    pthread_mutex_unlock(&s->lock);
+}
+
+int ap2_session_read(struct ap2_session_s *s, uint8_t *buf, int len,
+                     int timeout_ms)
+{
+    if (!s || !buf || len <= 0) return -2;
+    uint64_t deadline =
+        ap2_io_monotonic_ms() + (timeout_ms > 0 ? (uint64_t)timeout_ms : 0);
+
+    pthread_mutex_lock(&s->lock);
+    for (;;) {
+        if (s->state == AP2_SESSION_ENDED) {
+            pthread_mutex_unlock(&s->lock);
+            return -2;
+        }
+        if (s->active && s->active->ring.fill > 0) {
+            size_t n = sring_pop(&s->active->ring, buf, (size_t)len);
+            s->played_bytes += n;
+            pthread_cond_broadcast(&s->can_write);
+            pthread_mutex_unlock(&s->lock);
+            return (int)n;
+        }
+        if (s->active && s->active->ring.eof) {
+            pthread_mutex_unlock(&s->lock);
+            return -1;   /* generation fully consumed */
+        }
+        uint64_t now = ap2_io_monotonic_ms();
+        if (now >= deadline) {
+            pthread_mutex_unlock(&s->lock);
+            return 0;
+        }
+        uint64_t wait_ms = deadline - now;
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += (time_t)(wait_ms / 1000);
+        ts.tv_nsec += (long)(wait_ms % 1000) * 1000000L;
+        if (ts.tv_nsec >= 1000000000L) {
+            ts.tv_sec += 1;
+            ts.tv_nsec -= 1000000000L;
+        }
+        pthread_cond_timedwait(&s->can_read, &s->lock, &ts);
+    }
+}
+
+void ap2_session_poll(struct ap2_session_s *s)
+{
+    if (!s || s->idle_timeout_ms <= 0) return;
+    pthread_mutex_lock(&s->lock);
+    bool idle = s->state == AP2_SESSION_IDLE || s->state == AP2_SESSION_STANDBY;
+    if (idle && ap2_io_monotonic_ms() - s->idle_since_ms >=
+                    (uint64_t)s->idle_timeout_ms) {
+        s->state = AP2_SESSION_ENDED;
+        emit(s, "[STATUS] idle_timeout");
+        pthread_cond_broadcast(&s->can_read);
+        pthread_cond_broadcast(&s->can_write);
+    }
+    pthread_mutex_unlock(&s->lock);
+}
+
+ap2_session_state_t ap2_session_state(struct ap2_session_s *s)
+{
+    if (!s) return AP2_SESSION_ENDED;
+    pthread_mutex_lock(&s->lock);
+    ap2_session_state_t st = s->state;
+    pthread_mutex_unlock(&s->lock);
+    return st;
+}
+
+uint64_t ap2_session_active_generation(struct ap2_session_s *s)
+{
+    if (!s) return 0;
+    pthread_mutex_lock(&s->lock);
+    uint64_t g = s->active ? s->active->gen.number : 0;
+    pthread_mutex_unlock(&s->lock);
+    return g;
+}
+
+uint64_t ap2_session_position_ms(struct ap2_session_s *s)
+{
+    if (!s) return 0;
+    pthread_mutex_lock(&s->lock);
+    uint64_t pos = 0;
+    if (s->active)
+        pos = s->active->gen.position_ms +
+              s->played_bytes * 1000ULL / s->byte_rate;
+    pthread_mutex_unlock(&s->lock);
+    return pos;
+}

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -165,6 +165,9 @@ static void *reader_thread(void *arg)
     uint8_t buf[16384];
     for (;;) {
         ssize_t n = read(fd, buf, sizeof(buf));
+        if (n < 0 && errno == EINTR)
+            continue;  /* interrupted syscall, not an error — retry the read */
+        int read_errno = errno;
         pthread_mutex_lock(&s->lock);
         if (slot->ring.abort) {
             pthread_mutex_unlock(&s->lock);
@@ -172,8 +175,16 @@ static void *reader_thread(void *arg)
         }
         if (n <= 0) {
             slot->ring.eof = true;
-            emit(s, "[STATUS] input_eof generation=%llu",
-                 (unsigned long long)slot->gen.number);
+            /* A clean EOF (0) is the normal retirement path; a negative return
+             * is a real read error (e.g. a broken pipe) and is surfaced
+             * distinctly instead of being hidden as end-of-input. */
+            if (n < 0)
+                emit(s, "[STATUS] input_error generation=%llu errno=%d (%s)",
+                     (unsigned long long)slot->gen.number, read_errno,
+                     strerror(read_errno));
+            else
+                emit(s, "[STATUS] input_eof generation=%llu",
+                     (unsigned long long)slot->gen.number);
             pthread_cond_broadcast(&s->can_read);
             pthread_mutex_unlock(&s->lock);
             break;
@@ -343,6 +354,19 @@ bool ap2_session_start(struct ap2_session_s *s, uint64_t generation,
     }
 
     pthread_mutex_lock(&s->lock);
+    /* commit() ran without the lock held, so a concurrent PREPARE (e.g. an
+     * argv gen-0 START on the main thread racing a cmdpipe PREPARE) can have
+     * superseded and freed the generation we just committed. Re-validate the
+     * staged slot by generation number before the swap so we never activate a
+     * freed slot or the wrong generation; MA sends START for the newer
+     * generation next. */
+    if (!s->staged || s->staged->gen.number != generation ||
+        s->state == AP2_SESSION_ENDED) {
+        pthread_mutex_unlock(&s->lock);
+        LOG_WARN("[SESSION] generation %llu superseded before activation",
+                 (unsigned long long)generation);
+        return false;
+    }
     slot_t *old = s->active;
     s->active = s->staged;
     s->staged = NULL;

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -1,10 +1,14 @@
 /*
- * Persistent session mode - generation state machine
+ * Persistent session - generation state machine
  *
- * Separates connection lifetime from media lifetime. In --session mode the
- * binary connects once (HAP, RTSP, timing, MRP) and then plays a sequence of
- * numbered media GENERATIONS over one connection, so seek/next/resume never
- * pay the connect cost again:
+ * Separates connection lifetime from media lifetime: the binary connects once
+ * (HAP, RTSP, timing, MRP) and plays a sequence of numbered media GENERATIONS
+ * over that one connection, so seek/next/resume never pay the connect cost
+ * again. This is not a mode: the argv invocation defines generation 0, and
+ * whenever a command pipe is attached the connection simply outlives the
+ * generation (bounded by the idle timeout) awaiting the next PREPARE. Without
+ * a command pipe there is no way to receive further generations, so input EOF
+ * drains and exits - the classic one-shot behavior, by construction.
  *
  *   PREPARE(gen, audio pipe, position)  ->  ready  ->  primed
  *   START(gen, start time)              ->  flush old + swap + anchor -> playing

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -1,0 +1,117 @@
+/*
+ * Persistent session mode - generation state machine
+ *
+ * Separates connection lifetime from media lifetime. In --session mode the
+ * binary connects once (HAP, RTSP, timing, MRP) and then plays a sequence of
+ * numbered media GENERATIONS over one connection, so seek/next/resume never
+ * pay the connect cost again:
+ *
+ *   PREPARE(gen, audio pipe, position)  ->  ready  ->  primed
+ *   START(gen, start time)              ->  flush old + swap + anchor -> playing
+ *   STANDBY                             ->  stop playback, keep the connection warm
+ *   DISCONNECT                          ->  real teardown
+ *
+ * The next generation's audio arrives on its OWN pipe and is drained into a
+ * staging ring while the current generation keeps playing, so source and DSP
+ * preparation cost no audible time. The commit is the measured-fast warm
+ * flush: RTSP FLUSH (+/- 5 ms) plus a re-based frozen anchor line, working
+ * down to a 150 ms lead on tested receivers. Sequence numbers and audio
+ * nonces are never reset within the connection; the media timeline re-bases
+ * per generation.
+ *
+ * Command pipe verbs (newline-terminated KEY=VALUE, existing verbs unchanged):
+ *   GENERATION=<n>            select the generation the next ACTION applies to
+ *   AUDIO=<path>              FIFO carrying this generation's PCM (PREPARE)
+ *   POSITION_MS=<ms>          media position of the pipe's first byte
+ *   START_UNIX_MS=<ms|0>      audible start instant; 0 = ASAP at the minimum
+ *                             warm lead
+ *   ACTION=PREPARE|START|FLUSH|STANDBY|DISCONNECT
+ *
+ * Status lines (stderr, generation-tagged):
+ *   [STATUS] ready generation=<n>
+ *   [STATUS] primed generation=<n> prefill_ms=<ms>
+ *   [STATUS] playing generation=<n> elapsed_ms=<ms>
+ *   [STATUS] input_eof generation=<n>
+ *   [STATUS] eof generation=<n>
+ *   [STATUS] idle_timeout
+ *
+ * Copyright (C) 2024-2026 Music Assistant Contributors
+ * See LICENSE
+ */
+
+#ifndef __AP2_SESSION_H_
+#define __AP2_SESSION_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Overall session-mode state. */
+typedef enum {
+    AP2_SESSION_IDLE = 0,     /* connected; no generation playing or staged */
+    AP2_SESSION_PREPARING,    /* staging ring filling for the next generation */
+    AP2_SESSION_PLAYING,      /* a generation is streaming */
+    AP2_SESSION_STANDBY,      /* stopped on request; connection kept warm */
+    AP2_SESSION_ENDED,        /* DISCONNECT requested or idle timeout hit */
+} ap2_session_state_t;
+
+/* One staged/active generation. */
+typedef struct {
+    uint64_t number;          /* caller-assigned generation number */
+    char *audio_path;         /* FIFO delivering this generation's PCM */
+    uint64_t position_ms;     /* media position of byte zero (progress base) */
+    uint64_t start_unix_ms;   /* audible start instant; 0 = ASAP */
+} ap2_generation_t;
+
+struct ap2_session_s;
+
+/*
+ * Callbacks the session engine invokes from its own threads. All are
+ * required. `commit` performs the transport work of a generation switch on a
+ * LIVE connection: discard receiver-buffered audio and re-base the timeline
+ * so the next written frame is audible at `start_unix_ms` (or now + the
+ * minimum warm lead when 0). Returns false when the transport failed
+ * terminally (the caller then ends the session so MA can fall back cold).
+ */
+typedef struct {
+    bool (*commit)(void *transport, uint64_t start_unix_ms);
+    void (*status)(const char *line);   /* emit one [STATUS] line */
+    void *transport;
+} ap2_session_ops_t;
+
+/*
+ * Create the session engine.
+ *
+ * :param ops: transport commit + status emit callbacks.
+ * :param byte_rate: PCM byte rate of the input format (ring sizing/timing).
+ * :param prefill_ms: staging ring fill level that emits `primed`.
+ * :param idle_timeout_ms: end the session after this long without a playing
+ *                         or preparing generation (orphan safety net).
+ */
+struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
+                                         unsigned byte_rate, int prefill_ms,
+                                         int idle_timeout_ms);
+void ap2_session_destroy(struct ap2_session_s *s);
+
+/* Command-pipe entry points (called from the cmdpipe thread). Invalid
+ * transitions are rejected with a [STATUS]/log line and return false. */
+bool ap2_session_prepare(struct ap2_session_s *s, const ap2_generation_t *gen);
+bool ap2_session_start(struct ap2_session_s *s, uint64_t generation,
+                       uint64_t start_unix_ms);
+bool ap2_session_flush(struct ap2_session_s *s, uint64_t generation);
+bool ap2_session_standby(struct ap2_session_s *s);
+void ap2_session_end(struct ap2_session_s *s);
+
+/* Audio-loop entry points. `read` returns PCM from the ACTIVE generation's
+ * ring (blocking up to timeout_ms; 0 on generation boundary/underrun, -1 on
+ * end-of-generation, -2 when the session ended). The loop calls `poll` once
+ * per iteration so the engine can run timeouts and complete commits. */
+int ap2_session_read(struct ap2_session_s *s, uint8_t *buf, int len,
+                     int timeout_ms);
+void ap2_session_poll(struct ap2_session_s *s);
+
+ap2_session_state_t ap2_session_state(struct ap2_session_s *s);
+uint64_t ap2_session_active_generation(struct ap2_session_s *s);
+/* Media position of the active generation (position_ms + played ms). */
+uint64_t ap2_session_position_ms(struct ap2_session_s *s);
+
+#endif /* __AP2_SESSION_H_ */

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -10,6 +10,15 @@
  * a command pipe there is no way to receive further generations, so input EOF
  * drains and exits - the classic one-shot behavior, by construction.
  *
+ * Start times are COMMANDED, not configured: every generation (including
+ * generation 0) starts on an explicit START, which the caller sends after
+ * seeing `connected` and `primed`. The caller therefore never has to guess a
+ * safe setup lead in advance - it picks the start once the expensive work has
+ * already succeeded, and a group start is simply the same START_UNIX_MS sent
+ * to every primed member. An argv --start-unix-ms, when present, acts as an
+ * implicit START for generation 0 (manual one-shot use, and the transitional
+ * caller); starts of 0 or in the past clamp to now + the minimum warm lead.
+ *
  *   PREPARE(gen, audio pipe, position)  ->  ready  ->  primed
  *   START(gen, start time)              ->  flush old + swap + anchor -> playing
  *   STANDBY                             ->  stop playback, keep the connection warm
@@ -58,12 +67,14 @@ typedef enum {
     AP2_SESSION_ENDED,        /* DISCONNECT requested or idle timeout hit */
 } ap2_session_state_t;
 
-/* One staged/active generation. */
+/* One staged/active generation. Audio comes from `audio_fd` when >= 0 (an
+ * already-open descriptor - generation 0 adopts stdin/the argv file this
+ * way), else from opening `audio_path` (a FIFO created by the caller). */
 typedef struct {
     uint64_t number;          /* caller-assigned generation number */
-    char *audio_path;         /* FIFO delivering this generation's PCM */
+    const char *audio_path;   /* FIFO delivering this generation's PCM */
+    int audio_fd;             /* pre-opened input fd, or -1 to open the path */
     uint64_t position_ms;     /* media position of byte zero (progress base) */
-    uint64_t start_unix_ms;   /* audible start instant; 0 = ASAP */
 } ap2_generation_t;
 
 struct ap2_session_s;
@@ -78,6 +89,7 @@ struct ap2_session_s;
  */
 typedef struct {
     bool (*commit)(void *transport, uint64_t start_unix_ms);
+    void (*stop)(void *transport);      /* silence the receiver, keep session */
     void (*status)(const char *line);   /* emit one [STATUS] line */
     void *transport;
 } ap2_session_ops_t;

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -486,7 +486,15 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
     } else if (strcmp(key, "GENERATION") == 0) {
         g_pend_generation = strtoull(value, NULL, 10);
     } else if (strcmp(key, "AUDIO") == 0) {
-        snprintf(g_pend_audio, sizeof(g_pend_audio), "%s", value);
+        int written = snprintf(g_pend_audio, sizeof(g_pend_audio), "%s", value);
+        if (written < 0 || (size_t)written >= sizeof(g_pend_audio)) {
+            /* A truncated path would fail to open later at PREPARE with an
+             * opaque error; reject it here where the cause is clear. */
+            LOG_ERROR("AUDIO path too long (%zu bytes, max %zu)",
+                      strlen(value), sizeof(g_pend_audio) - 1);
+            g_pend_audio[0] = '\0';
+            status_error("AUDIO path too long");
+        }
     } else if (strcmp(key, "POSITION_MS") == 0) {
         g_pend_position_ms = strtoull(value, NULL, 10);
     } else if (strcmp(key, "START_UNIX_MS") == 0) {

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -35,6 +35,7 @@
 #include "cross_util.h"
 #include "cross_log.h"
 #include "ap2_client.h"
+#include "ap2_session.h"
 #include "ap2_ptp.h"
 #include "ap2_hap.h"
 #include "artwork.h"
@@ -159,6 +160,27 @@ static void status_print(const char *fmt, ...)
 static void status_connected(void)
 {
     status_print("[STATUS] connected");
+}
+
+/* Persistent-session engine (native AP2): generation 0 adopts the argv
+ * input; further generations arrive over the command pipe. */
+#define SESSION_PREFILL_MS        500     /* staging fill that emits `primed` */
+#define SESSION_IDLE_TIMEOUT_MS   120000  /* orphan safety net (cmdpipe only) */
+static struct ap2_session_s *g_session = NULL;
+static bool g_first_start_done = false;
+static uint64_t g_pend_generation = 0;
+static char g_pend_audio[512];
+static uint64_t g_pend_position_ms = 0;
+static uint64_t g_pend_start_unix_ms = 0;
+
+static uint64_t unix_ms_to_ntp(uint64_t ms)
+{
+    return ((ms / 1000) << 32) | (((ms % 1000) << 32) / 1000);
+}
+
+static uint64_t ntp_to_unix_ms(uint64_t ntp)
+{
+    return (ntp >> 32) * 1000ULL + (((ntp & 0xFFFFFFFFULL) * 1000ULL) >> 32);
 }
 
 static void status_playing(uint64_t elapsed_ms)
@@ -379,51 +401,6 @@ static int input_ring_read(uint8_t *buf, size_t want)
     return (int)n;
 }
 
-enum { INPUT_RING_TIMEOUT = -2 };
-
-/* Read with a bounded wait so native control failures remain observable while
- * the PCM producer is stalled. */
-static int input_ring_read_timed(uint8_t *buf, size_t want, int timeout_ms)
-{
-    struct timespec deadline;
-    clock_gettime(CLOCK_REALTIME, &deadline);
-    deadline.tv_sec += timeout_ms / 1000;
-    deadline.tv_nsec += (long)(timeout_ms % 1000) * 1000000L;
-    if (deadline.tv_nsec >= 1000000000L) {
-        deadline.tv_sec++;
-        deadline.tv_nsec -= 1000000000L;
-    }
-
-    pthread_mutex_lock(&g_inring.lock);
-    while (g_inring.fill == 0 && !g_inring.eof && !g_inring.error && g_running) {
-        int rc = pthread_cond_timedwait(&g_inring.can_read, &g_inring.lock,
-                                        &deadline);
-        if (rc == ETIMEDOUT) {
-            pthread_mutex_unlock(&g_inring.lock);
-            return INPUT_RING_TIMEOUT;
-        }
-    }
-    size_t n = g_inring.fill < want ? g_inring.fill : want;
-    size_t got = 0;
-    while (got < n) {
-        size_t to_end = INPUT_RING_BYTES - g_inring.rd;
-        size_t chunk_len = n - got;
-        if (chunk_len > to_end) chunk_len = to_end;
-        memcpy(buf + got, g_inring.data + g_inring.rd, chunk_len);
-        g_inring.rd = (g_inring.rd + chunk_len) % INPUT_RING_BYTES;
-        got += chunk_len;
-    }
-    g_inring.fill -= n;
-    if (n) pthread_cond_broadcast(&g_inring.can_write);
-    int error = g_inring.error;
-    pthread_mutex_unlock(&g_inring.lock);
-    if (!n && error) {
-        errno = error;
-        return -1;
-    }
-    return (int)n;
-}
-
 /* ---- Command pipe handler ---- */
 
 static struct {
@@ -506,6 +483,39 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
             ap2cl_set_volume(g_ap2cl, vol);
         }
+    } else if (strcmp(key, "GENERATION") == 0) {
+        g_pend_generation = strtoull(value, NULL, 10);
+    } else if (strcmp(key, "AUDIO") == 0) {
+        snprintf(g_pend_audio, sizeof(g_pend_audio), "%s", value);
+    } else if (strcmp(key, "POSITION_MS") == 0) {
+        g_pend_position_ms = strtoull(value, NULL, 10);
+    } else if (strcmp(key, "START_UNIX_MS") == 0) {
+        g_pend_start_unix_ms = strtoull(value, NULL, 10);
+    } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "PREPARE") == 0) {
+        ap2_generation_t gen = {
+            .number = g_pend_generation,
+            .audio_path = g_pend_audio[0] ? g_pend_audio : NULL,
+            .audio_fd = -1,
+            .position_ms = g_pend_position_ms,
+        };
+        if (!g_session || !ap2_session_prepare(g_session, &gen))
+            status_error("PREPARE failed");
+        g_pend_audio[0] = '\0';
+        g_pend_position_ms = 0;
+    } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "START") == 0) {
+        if (!g_session ||
+            !ap2_session_start(g_session, g_pend_generation,
+                               g_pend_start_unix_ms))
+            status_error("START failed");
+        g_pend_start_unix_ms = 0;
+    } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "FLUSH") == 0) {
+        if (!g_session || !ap2_session_flush(g_session, g_pend_generation))
+            status_error("FLUSH failed");
+    } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "STANDBY") == 0) {
+        if (g_session) ap2_session_standby(g_session);
+    } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "DISCONNECT") == 0) {
+        if (g_session) ap2_session_end(g_session);
+        g_status = STATUS_STOPPED;
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "PAUSE") == 0) {
         if (g_status == STATUS_PLAYING) {
             if (cfg->protocol == PROTO_RAOP && g_raopcl) {
@@ -570,6 +580,44 @@ static void send_initial_metadata(const cli_config_t *cfg)
                            metadata_str(g_metadata.album), g_metadata.duration);
         mrp_status_report(ap2cl_mrp_push(g_ap2cl));
     }
+}
+
+/* ---- Session engine transport callbacks ---- */
+
+static bool session_commit(void *transport, uint64_t start_unix_ms)
+{
+    cli_config_t *cfg = transport;
+    struct ap2cl_s *client = g_ap2cl;
+    if (!client) return false;
+    if (!g_first_start_done) {
+        /* First start: full timeline init (pid RTP offset, sequence seed).
+         * With no commanded instant, keep the classic one-lead default. */
+        uint64_t ntp = start_unix_ms
+            ? unix_ms_to_ntp(start_unix_ms)
+            : raopcl_get_ntp(NULL) + MS2NTP(cfg->latency_ms);
+        if (!ap2cl_start_at(client, ntp)) return false;
+        /* Placeholder metadata must follow the first start: it anchors to the
+         * RTP timeline that call establishes (metadata-gated receivers keep
+         * audio muted otherwise). */
+        send_initial_metadata(cfg);
+        g_first_start_done = true;
+    } else if (!ap2cl_warm_flush(client, start_unix_ms)) {
+        return false;
+    }
+    g_status = STATUS_PLAYING;
+    return true;
+}
+
+static void session_stop_op(void *transport)
+{
+    (void)transport;
+    if (g_ap2cl) ap2cl_standby(g_ap2cl);
+    if (g_status == STATUS_PLAYING) g_status = STATUS_PAUSED;
+}
+
+static void session_status_line(const char *line)
+{
+    status_print("%s", line);
 }
 
 static void *cmdpipe_reader_thread(void *arg)
@@ -928,42 +976,67 @@ static int run_airplay2(cli_config_t *cfg, int infile)
         ap2cl_set_volume(g_ap2cl, cfg->volume);
     }
 
-    /* Schedule start time */
-    bool started;
-    if (cfg->ntp_start) {
-        started = ap2cl_start_at(g_ap2cl, cfg->ntp_start);
-    } else {
-        uint64_t now = raopcl_get_ntp(NULL);
-        uint64_t start_at = now + MS2NTP(cfg->latency_ms);
-        started = ap2cl_start_at(g_ap2cl, start_at);
-    }
-    if (!started) {
-        status_error("Cannot start AirPlay 2 stream");
-        return 1;
-    }
-
-    /* Placeholder metadata must follow ap2cl_start_at: that call sets the RTP
-     * timeline the metadata's RTP-Info anchors to. Sent earlier it anchors to
-     * rtptime=0 — metadata-gated receivers (Sonos) then show the title but do
-     * not treat it as the audio timeline's metadata and keep audio muted. */
-    send_initial_metadata(cfg);
-
-    g_status = STATUS_PLAYING;
-    uint64_t last = 0, frames = 0;
+    /* Persistent session: generation 0 adopts the argv input; further
+     * generations arrive over the command pipe. Start times are commanded -
+     * an argv --start-unix-ms (or the absence of a command pipe) acts as the
+     * implicit START for generation 0; otherwise the caller sends START after
+     * seeing `connected` and `primed`, so it never guesses a setup lead. */
     int ap2_input_bpf = (cfg->bit_depth <= 16 ? 2 : 4) * cfg->channels;
     int ap2_alac_bpf = (cfg->bit_depth <= 16 ? 2 : 3) * cfg->channels;
+    ap2_session_ops_t ops = {
+        .commit = session_commit,
+        .stop = session_stop_op,
+        .status = session_status_line,
+        .transport = cfg,
+    };
+    g_session = ap2_session_create(
+        &ops, (unsigned)cfg->sample_rate * (unsigned)ap2_input_bpf,
+        SESSION_PREFILL_MS, cfg->cmdpipe ? SESSION_IDLE_TIMEOUT_MS : 0);
+    if (!g_session) {
+        status_error("Cannot create session engine");
+        return 1;
+    }
+    ap2_generation_t gen0 = {
+        .number = 0,
+        .audio_path = NULL,
+        .audio_fd = infile,
+        .position_ms = 0,
+    };
+    if (!ap2_session_prepare(g_session, &gen0)) {
+        status_error("Cannot stage the initial generation");
+        ap2_session_destroy(g_session);
+        g_session = NULL;
+        return 1;
+    }
+    if (cfg->ntp_start || !cfg->cmdpipe) {
+        if (!ap2_session_start(g_session, 0,
+                               cfg->ntp_start ? ntp_to_unix_ms(cfg->ntp_start)
+                                              : 0)) {
+            status_error("Cannot start AirPlay 2 stream");
+            ap2_session_destroy(g_session);
+            g_session = NULL;
+            return 1;
+        }
+    }
+
+    uint64_t last = 0, frames = 0;
+    uint64_t current_gen = ap2_session_active_generation(g_session);
     uint8_t *buf = malloc(AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
     uint8_t *ap2_alac_buf = (cfg->bit_depth > 16) ? malloc(AP2_FRAMES_PER_CHUNK * ap2_alac_bpf) : NULL;
-    bool got_eof = false;
     bool playback_failed = false;
     bool starving = false;
     uint64_t starvation_started = 0;
-
+    bool gen_eof = false;         /* active generation's input fully consumed */
+    bool eof_reported = false;
     uint64_t eof_time = 0;
+    int pcm_carry = 0;            /* sub-frame remainder between ring reads */
 
     /* Main audio loop */
-    while (g_status != STATUS_STOPPED && (!got_eof || ap2cl_is_playing(g_ap2cl))) {
+    while (g_status != STATUS_STOPPED) {
         uint64_t now = raopcl_get_ntp(NULL);
+        ap2_session_poll(g_session);
+        if (ap2_session_state(g_session) == AP2_SESSION_ENDED)
+            break;   /* DISCONNECT or idle timeout */
 
         if (!ap2cl_is_connected(g_ap2cl) ||
             !ap2cl_control_healthy(g_ap2cl)) {
@@ -972,15 +1045,20 @@ static int run_airplay2(cli_config_t *cfg, int infile)
             break;
         }
 
-        /* After EOF, drain for at most latency + 2 seconds then stop */
-        if (got_eof && eof_time && now - eof_time > MS2NTP(cfg->latency_ms + 2000)) {
-            LOG_INFO("Drain timeout reached, ending stream");
-            break;
+        /* A generation switch resets the per-generation bookkeeping. */
+        uint64_t active = ap2_session_active_generation(g_session);
+        if (active != current_gen) {
+            current_gen = active;
+            frames = 0;
+            gen_eof = false;
+            eof_reported = false;
+            eof_time = 0;
+            pcm_carry = 0;
         }
 
         /* Periodic status reporting (only while playing, so a pause does not keep
            emitting a "playing" status that would revive the sender's play state) */
-        if (g_status == STATUS_PLAYING && now - last > MS2NTP(1000)) {
+        if (g_status == STATUS_PLAYING && !gen_eof && now - last > MS2NTP(1000)) {
             last = now;
             uint32_t latency_frames = MS2TS(cfg->latency_ms, cfg->sample_rate);
             if (frames > latency_frames) {
@@ -989,11 +1067,47 @@ static int run_airplay2(cli_config_t *cfg, int infile)
             }
         }
 
+        if (gen_eof) {
+            /* Input consumed: let the receiver drain, report once, then either
+             * exit (one-shot: no command pipe means nothing further can
+             * arrive) or idle awaiting the next generation / idle timeout. */
+            bool drained = !ap2cl_is_playing(g_ap2cl) ||
+                           now - eof_time > MS2NTP(cfg->latency_ms + 2000);
+            if (drained && !eof_reported) {
+                eof_reported = true;
+                status_print("[STATUS] eof generation=%llu",
+                             (unsigned long long)current_gen);
+                status_eof();
+                if (!cfg->cmdpipe) break;
+            }
+            usleep(drained ? 50000 : 10000);
+            continue;
+        }
+
         /* Send audio chunk */
         if (g_status == STATUS_PLAYING && ap2cl_accept_frames(g_ap2cl)) {
-            int n = input_ring_read_timed(
-                buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf, 250);
-            if (n == INPUT_RING_TIMEOUT) {
+            int n = ap2_session_read(
+                g_session, buf + pcm_carry,
+                AP2_FRAMES_PER_CHUNK * ap2_input_bpf - pcm_carry, 250);
+            if (n > 0) {
+                /* Ring pops are byte-granular: carry any sub-frame remainder
+                 * into the next read so frame alignment never drifts. */
+                n += pcm_carry;
+                pcm_carry = n % ap2_input_bpf;
+                n -= pcm_carry;
+                if (n == 0) {
+                    continue;   /* only a partial frame arrived so far */
+                }
+            }
+            if (n == -2) break;
+            if (n == -1) {
+                LOG_INFO("End of generation %llu input, draining buffer...",
+                         (unsigned long long)current_gen);
+                gen_eof = true;
+                eof_time = raopcl_get_ntp(NULL);
+                continue;
+            }
+            if (n == 0) {
                 if (!starving) {
                     starving = true;
                     starvation_started = raopcl_get_ntp(NULL);
@@ -1001,18 +1115,6 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                     ap2cl_log_diagnostics(g_ap2cl);
                 }
                 ap2cl_recover_input_gap(g_ap2cl);
-                continue;
-            }
-            if (n < 0) {
-                status_error("Error reading from audio source");
-                playback_failed = true;
-                break;
-            } else if (n == 0) {
-                if (!got_eof) {
-                    LOG_INFO("End of audio stream, draining buffer...");
-                    got_eof = true;
-                    eof_time = raopcl_get_ntp(NULL);
-                }
                 continue;
             }
             if (starving) {
@@ -1038,13 +1140,16 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                 break;
             }
             frames += af;
+            if (pcm_carry) memmove(buf, buf + n, (size_t)pcm_carry);
         } else {
+            /* Paused, or connected and awaiting the commanded first START. */
             usleep(1000);
         }
     }
 
-    if (got_eof && !playback_failed) status_eof();
     g_running = false;
+    ap2_session_destroy(g_session);
+    g_session = NULL;
     free(buf);
     free(ap2_alac_buf);
     return playback_failed ? 1 : 0;
@@ -1156,10 +1261,11 @@ static int run_ptp_daemon(cli_config_t *cfg)
      * daemon and the per-stream sessions present one clock identity. Without
      * --dacp the default engine identity is kept (existing callers). */
     unsigned long long clock_id = 0;
-    if (cfg->dacp_id && sscanf(cfg->dacp_id, "%16llx", &clock_id) == 1)
+    if (cfg->dacp_id && sscanf(cfg->dacp_id, "%16llx", &clock_id) == 1) {
         LOG_INFO("[PTP] daemon grandmaster identity %016llx (from --dacp)", clock_id);
-    else
+    } else {
         clock_id = 0;
+    }
 
     return ap2_ptp_run_daemon(bind_addr, (uint64_t)clock_id, &g_ptp_daemon_stop);
 }
@@ -1499,15 +1605,15 @@ int main(int argc, char *argv[])
                       strerror(thread_result));
     }
 
-    /* Drain the audio source eagerly from here on (see the input ring note),
-     * keeping at most the pre-start prefill plus margin buffered. */
-    unsigned in_byte_rate =
-        (unsigned)((cfg.bit_depth <= 16 ? 2 : 4) * cfg.channels * cfg.sample_rate);
-    input_ring_start(infile, in_byte_rate, cfg.latency_ms + 2000);
-
-    /* Run the selected protocol */
+    /* Run the selected protocol. The RAOP path drains the audio source into
+     * the legacy input ring; the AirPlay 2 path hands the source to the
+     * session engine as generation 0 instead. */
     int result;
     if (cfg.protocol == PROTO_RAOP) {
+        unsigned in_byte_rate =
+            (unsigned)((cfg.bit_depth <= 16 ? 2 : 4) * cfg.channels *
+                       cfg.sample_rate);
+        input_ring_start(infile, in_byte_rate, cfg.latency_ms + 2000);
         result = run_raop(&cfg, infile);
     } else {
         result = run_airplay2(&cfg, infile);


### PR DESCRIPTION
Until now every play request opened a fresh connection to the AirPlay device, so seeking or skipping a track meant reconnecting from scratch.

This lets one connection stay open and play a sequence of tracks over it. A new track is staged on the side while the current one keeps playing, then committed with a single switch at a chosen moment, so the server can make seek and next-track feel instant. When invoked without the command channel the binary behaves exactly as before, so nothing changes for callers that do not opt in.
