### PR TITLE
AirPlay streams now start from commands

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -178,8 +178,9 @@ grandmaster — but MA spawns one cliairplay per device. The split
 ## 6. Timing and the start contract
 
 **Contract: cmdpipe `START_UNIX_MS=T` means the first sample is AUDIBLE at
-exactly T.** AirPlay 2 group members are handed the same T after each one has
-reported its generation primed, then align by construction.
+exactly T on every streaming protocol.** Legacy RAOP, RAOP-compatible AirPlay 2,
+and native AirPlay 2 members are handed the same T after each one reports its
+generation primed, then align by construction.
 
 **Downstream render-latency is informational, not applied.** A receiver whose
 audible output sits behind an external pipeline reports that delay in its
@@ -488,19 +489,20 @@ capture.
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS
   to tear down a MediaRemote-active stream after roughly 30 seconds.
-- **Eager input ring** — a dedicated reader drains stdin into a 4 MB ring as
-  fast as the source delivers, decoupled from network pacing: the pipeline
-  fills before a scheduled start, while a full ring backpressures the pipe.
-  Native playback waits in 250 ms intervals so control failures remain visible
-  during producer starvation. If realtime lead is exhausted, it advances the
-  scheduling/PTP anchor while preserving contiguous RTP content.
+- **Generation staging rings** — each cmdpipe `PREPARE` drains its FIFO (or
+  single active `AUDIO=-` stdin source) into an independent bounded ring before
+  `START`, decoupled from network pacing. The active and staged generations
+  never share PCM, and
+  the sender waits in bounded intervals so control failures remain visible
+  during producer starvation.
 - **Realtime send outcomes** — local UDP backpressure is a bounded transient
   drop that advances sequence, RTP, and scheduling timestamps. Encode,
   allocation, encryption, socket, and control failures are terminal and produce
   a nonzero process exit rather than a false EOF.
-- **EOF drain** — after input EOF the session drains at most
-  `latency + 2 s`, then tears down.
-- **Initial metadata** — pushed at connect with a placeholder title if the
+- **EOF drain** — after generation EOF the receiver drains at most
+  `latency + 2 s`; the connection then remains idle for the next PREPARE until
+  the orphan timeout or DISCONNECT.
+- **Initial metadata** — pushed at the first START with a placeholder title if the
   caller has not set any (Sonos withholds audio until it has metadata; the
   native flow also requires `RTP-Info` on the metadata request — Sonos 400s
   without it).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -177,9 +177,9 @@ grandmaster — but MA spawns one cliairplay per device. The split
 
 ## 6. Timing and the start contract
 
-**Contract: `--start-unix-ms T` means the first sample is AUDIBLE at exactly
-T, on every protocol path.** Group members — including mixed RAOP + native-AP2
-groups — are handed the same T and align by construction.
+**Contract: cmdpipe `START_UNIX_MS=T` means the first sample is AUDIBLE at
+exactly T.** AirPlay 2 group members are handed the same T after each one has
+reported its generation primed, then align by construction.
 
 **Downstream render-latency is informational, not applied.** A receiver whose
 audible output sits behind an external pipeline reports that delay in its

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ AP2_SOURCES = ap2_client.c ap2_hap.c ap2_io.c ap2_ptp.c ap2_ptp_shm.c ap2_plist.
 
 # Common/CLI sources
 CLI_SOURCES = cross_log.c cross_ssl.c cross_util.c cross_net.c platform.c \
-	cliairplay.c artwork.c pairing.cpp bplist.cpp ap2_bplist.cpp alac_ext.cpp
+	cliairplay.c raop_session.c artwork.c pairing.cpp bplist.cpp ap2_bplist.cpp alac_ext.cpp
 
 # Pre-built static libraries
 # We use a patched copy of libcodecs.a with the buggy alac_create_encoder removed,
@@ -140,6 +140,7 @@ RAOP_LIFECYCLE_TEST_DEFINES = \
 	-Draopcl_connect=ap2_test_raopcl_connect \
 	-Draopcl_disconnect=ap2_test_raopcl_disconnect \
 	-Draopcl_destroy=ap2_test_raopcl_destroy
+RAOP_SESSION_TEST = build/tests/test_raop_session
 
 all: directory $(EXECUTABLE)
 
@@ -182,21 +183,28 @@ clean:
 	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED) build/tests
 
 test: directory $(EXECUTABLE) $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(CLIENT_TEST) \
-		$(TEST_EXECUTABLE) $(RAOP_LIFECYCLE_TEST_EXECUTABLE)
+		$(TEST_EXECUTABLE) $(RAOP_LIFECYCLE_TEST_EXECUTABLE) $(RAOP_SESSION_TEST)
 	$(TIMELINE_TEST)
 	$(EVENT_TEST)
 	$(IO_TEST)
 	$(CLIENT_TEST)
 	$(TEST_EXECUTABLE)
 	$(RAOP_LIFECYCLE_TEST_EXECUTABLE)
+	$(RAOP_SESSION_TEST)
 	python3 tests/mrp_artwork_matrix.py --help >/dev/null
-	@! $(EXECUTABLE) --help | grep -q -- '--start-unix-ms'
-	@removed="$$($(EXECUTABLE) --start-unix-ms 1 2>&1 || true)"; \
-		printf '%s\n' "$$removed" | grep -q "unrecognized option.*start-unix-ms"
-	@argv_audio="$$($(EXECUTABLE) --protocol airplay2 --cmdpipe \
+	@missing_pipe="$$($(EXECUTABLE) --protocol raop \
+		127.0.0.1 2>&1 || true)"; \
+		printf '%s\n' "$$missing_pipe" | grep -q "Streaming requires --cmdpipe"
+	@argv_audio="$$($(EXECUTABLE) --protocol raop --cmdpipe \
 		/tmp/cliairplay-test-unused 127.0.0.1 - 2>&1 || true)"; \
 		printf '%s\n' "$$argv_audio" | \
-		grep -q "AirPlay 2 audio must be provided by cmdpipe PREPARE"
+		grep -q "Streaming audio must be provided by cmdpipe PREPARE, not argv"
+
+$(RAOP_SESSION_TEST): tests/test_raop_session.c src/raop_session.c \
+		src/raop_session.h Makefile
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_CFLAGS) $(INCLUDE) tests/test_raop_session.c \
+		src/raop_session.c $(EXTRA_LDFLAGS) -o $@
 
 $(TIMELINE_TEST): tests/test_ap2_timeline.c src/ap2_timeline.h Makefile
 	@mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -134,12 +134,21 @@ TEST_OBJECTS = $(BUILDDIR)/test_mrp_artwork.o \
 RAOP_LIFECYCLE_TEST_EXECUTABLE = $(BUILDDIR)/test-ap2-raop-lifecycle
 RAOP_LIFECYCLE_TEST_OBJECTS = $(BUILDDIR)/test_ap2_raop_lifecycle.o \
 	$(BUILDDIR)/ap2_client_raop_lifecycle_test.o \
-	$(filter-out $(BUILDDIR)/ap2_client.o $(BUILDDIR)/cliairplay.o,$(OBJECTS_ALL))
+	$(BUILDDIR)/raop_session_raop_lifecycle_test.o \
+	$(filter-out $(BUILDDIR)/ap2_client.o $(BUILDDIR)/cliairplay.o \
+		$(BUILDDIR)/raop_session.o,$(OBJECTS_ALL))
 RAOP_LIFECYCLE_TEST_DEFINES = \
 	-Draopcl_create=ap2_test_raopcl_create \
 	-Draopcl_connect=ap2_test_raopcl_connect \
 	-Draopcl_disconnect=ap2_test_raopcl_disconnect \
-	-Draopcl_destroy=ap2_test_raopcl_destroy
+	-Draopcl_destroy=ap2_test_raopcl_destroy \
+	-Draopcl_state=ap2_test_raopcl_state \
+	-Draopcl_stop=ap2_test_raopcl_stop \
+	-Draopcl_flush=ap2_test_raopcl_flush \
+	-Draopcl_start_at=ap2_test_raopcl_start_at \
+	-Draopcl_get_ntp=ap2_test_raopcl_get_ntp \
+	-Draopcl_latency=ap2_test_raopcl_latency \
+	-Draopcl_sample_rate=ap2_test_raopcl_sample_rate
 RAOP_SESSION_TEST = build/tests/test_raop_session
 
 all: directory $(EXECUTABLE)
@@ -170,7 +179,10 @@ $(BUILDDIR)/test_mrp_artwork.o: tests/test_mrp_artwork.c
 $(BUILDDIR)/test_ap2_raop_lifecycle.o: tests/test_ap2_raop_lifecycle.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) $< -c -o $@
 
-$(BUILDDIR)/ap2_client_raop_lifecycle_test.o: $(SRC)/ap2_client.c
+$(BUILDDIR)/ap2_client_raop_lifecycle_test.o: $(SRC)/ap2_client.c Makefile
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) $(RAOP_LIFECYCLE_TEST_DEFINES) $< -c -o $@
+
+$(BUILDDIR)/raop_session_raop_lifecycle_test.o: $(SRC)/raop_session.c Makefile
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDE) $(RAOP_LIFECYCLE_TEST_DEFINES) $< -c -o $@
 
 $(BUILDDIR)/%.o: %.c

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ $(BUILDDIR)/%.o: %.cpp
 clean:
 	rm -rf $(BUILDDIR) $(EXECUTABLE) $(LIBCODECS_PATCHED) build/tests
 
-test: directory $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(CLIENT_TEST) \
+test: directory $(EXECUTABLE) $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(CLIENT_TEST) \
 		$(TEST_EXECUTABLE) $(RAOP_LIFECYCLE_TEST_EXECUTABLE)
 	$(TIMELINE_TEST)
 	$(EVENT_TEST)
@@ -190,6 +190,13 @@ test: directory $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(CLIENT_TEST) \
 	$(TEST_EXECUTABLE)
 	$(RAOP_LIFECYCLE_TEST_EXECUTABLE)
 	python3 tests/mrp_artwork_matrix.py --help >/dev/null
+	@! $(EXECUTABLE) --help | grep -q -- '--start-unix-ms'
+	@removed="$$($(EXECUTABLE) --start-unix-ms 1 2>&1 || true)"; \
+		printf '%s\n' "$$removed" | grep -q "unrecognized option.*start-unix-ms"
+	@argv_audio="$$($(EXECUTABLE) --protocol airplay2 --cmdpipe \
+		/tmp/cliairplay-test-unused 127.0.0.1 - 2>&1 || true)"; \
+		printf '%s\n' "$$argv_audio" | \
+		grep -q "AirPlay 2 audio must be provided by cmdpipe PREPARE"
 
 $(TIMELINE_TEST): tests/test_ap2_timeline.c src/ap2_timeline.h Makefile
 	@mkdir -p $(dir $@)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Protocol and architecture detail lives in `DESIGN.md`; open work in `TODO.md`.
   the device's mDNS TXT records.
 - **Hi-res audio**: 24-bit ALAC (44.1 kHz and 48 kHz) on the native realtime
   stream.
-- **Group starts**: `--start-unix-ms` schedules the first sample to be audible
-  at an exact wall-clock instant on every protocol path, so mixed
-  RAOP + AirPlay 2 groups start aligned.
+- **Commanded group starts**: every AirPlay 2 generation is staged with cmdpipe
+  `PREPARE`, then `START_UNIX_MS` schedules its first sample to be audible at
+  an exact wall-clock instant.
 
 ## Usage
 
@@ -42,25 +42,25 @@ ffmpeg -i song.flac -f s16le -ar 44100 -ac 2 - | \
   ./bin/cliairplay-macos-arm64 --protocol raop --port 5000 \
   --volume 50 --cmdpipe /tmp/cap 192.168.1.50 -
 
-# AirPlay 2, native flow with stored credentials (Apple TV / HomePod):
-ffmpeg -i song.flac -f s16le -ar 44100 -ac 2 - | \
-  ./bin/cliairplay-macos-arm64 --protocol airplay2 --port 7000 \
-  --auth <192-hex-credentials> --volume 50 192.168.1.50 -
+# AirPlay 2, native persistent session (audio is supplied through PREPARE):
+./bin/cliairplay-macos-arm64 --protocol airplay2 --port 7000 \
+  --auth <192-hex-credentials> --volume 50 --cmdpipe /tmp/cap 192.168.1.50
 ```
 
-Audio is read as raw interleaved PCM from `<filename>` or stdin (`-`) at the
-given `--samplerate`/`--bitdepth`/`--channels` (default s16le 44100 stereo).
-At `--bitdepth 24` the input must be **s32le**; the binary truncates it to the
-24-bit samples the ALAC encoder consumes. Input is drained eagerly into a 4 MB
-ring buffer, decoupled from network pacing, so the source pipeline fills ahead
-of a scheduled start.
+RAOP audio is read from `<filename>` or stdin (`-`). AirPlay 2 requires
+`--cmdpipe`; each generation's raw interleaved PCM arrives through the
+`AUDIO=<path>` supplied to `PREPARE`. The format is selected with
+`--samplerate`/`--bitdepth`/`--channels` (default s16le 44100 stereo). At
+`--bitdepth 24` the input must be **s32le**; the binary truncates it to the
+24-bit samples the ALAC encoder consumes.
 
 ### The start contract
 
-`--start-unix-ms <ms>` means: **the first sample is audible exactly at that
-unix-epoch instant**, on every protocol path (RAOP and both AirPlay 2 flows).
-Every member of a sync group is given the same value and aligns by
-construction — including mixed RAOP + AirPlay 2 groups.
+For AirPlay 2, `START_UNIX_MS=<ms>` followed by `ACTION=START` means: **the
+first sample is audible exactly at that unix-epoch instant**. Every generation,
+including generation 0, must first be staged with cmdpipe `PREPARE`. A caller
+waits for `[STATUS] primed generation=<n>`, then sends the same start value to
+every primed member of a sync group.
 
 Delivery is not gated on the start time: frames are released up to the
 receiver's buffer window ahead of each frame's deadline (the device-reported
@@ -97,9 +97,13 @@ cliairplay --ptp-daemon [--if <ip>] &
 # Grant only the privileged-port capability instead of running as root:
 sudo setcap cap_net_bind_service=+ep /path/to/cliairplay
 
-# Per device, each with --ptp-shared and the SAME start time:
-cliairplay --protocol airplay2 --ptp-shared --start-unix-ms <T> ... <ip1> -
-cliairplay --protocol airplay2 --ptp-shared --start-unix-ms <T> ... <ip2> -
+# Per device, connect a command-only session:
+cliairplay --protocol airplay2 --ptp-shared --cmdpipe /tmp/cap1 ... <ip1>
+cliairplay --protocol airplay2 --ptp-shared --cmdpipe /tmp/cap2 ... <ip2>
+
+# PREPARE each generation, wait until both are primed, then send the same:
+# START_UNIX_MS=<T>
+# ACTION=START
 ```
 
 The daemon binds 319/320 once, runs the PTP engine, publishes the elected
@@ -113,7 +117,7 @@ first PTP stream begins and stops it (SIGTERM) when the last one ends.
 ## Command-line reference
 
 ```
-cliairplay [options] <host_ip> <filename ('-' for stdin)>
+cliairplay [options] <host_ip> [filename ('-' for RAOP stdin)]
 ```
 
 ### Protocol selection
@@ -129,14 +133,13 @@ cliairplay [options] <host_ip> <filename ('-' for stdin)>
 | `--port <port>` | Device RTSP port (default: 5000; AirPlay 2 devices use 7000). |
 | `--volume <0-100>` | Initial volume. Mapped linear-in-dB onto -30..0 dB (the AirPlay ecosystem convention); 0 mutes. |
 | `--latency <ms>` | Playback lead / buffer (default: 2000, clamped into the device-reported window). |
-| `--start-unix-ms <ms>` | Absolute start time as unix-epoch milliseconds: the first sample is audible at exactly this instant. Pass the **same** value to every member of a sync group. |
 | `--samplerate <rate>` | Input sample rate (default: 44100). |
 | `--bitdepth <16\|24>` | Input bit depth (default: 16). 24 requires the native AirPlay 2 flow and s32le input. |
 | `--channels <n>` | Input channel count (default: 2). |
 | `--if <ip>` | Local interface IP to bind all sockets to (multi-homed hosts). |
 | `--dacp <id>` | DACP ID advertised for remote-control callbacks; also the HAP pairing identity. |
 | `--activeremote <id>` | Active-Remote ID for DACP callbacks. |
-| `--cmdpipe <path>` | Named pipe for runtime commands/metadata (see below). |
+| `--cmdpipe <path>` | Named pipe for runtime commands/metadata. Required for AirPlay 2 (see below). |
 | `--udn <name>` | UDN / instance name used for mDNS. |
 | `--debug <0-9>` | Log verbosity (default: 3). |
 
@@ -177,6 +180,11 @@ cliairplay [options] <host_ip> <filename ('-' for stdin)>
 Newline-terminated `KEY=VALUE` lines written to the command pipe control a
 running stream:
 
+- AirPlay 2 generations: `GENERATION=<n>`, `AUDIO=<FIFO path>`,
+  `POSITION_MS=<ms>`, `ACTION=PREPARE`; after the matching `primed` status,
+  send `START_UNIX_MS=<unix epoch ms>` and `ACTION=START`. Generation 0 follows
+  this same path and never starts from argv.
+- Session lifecycle: `ACTION=FLUSH|STANDBY|DISCONNECT`
 - `VOLUME=<0-100>`
 - `ACTION=PLAY|PAUSE|STOP`
 - Metadata: `TITLE=`, `ARTIST=`, `ALBUM=`, `DURATION=<s>`, `PROGRESS=<s>`,
@@ -184,8 +192,8 @@ running stream:
   `ACTION=SENDMETA` to push the set.
 
 Some receivers (notably Sonos) do not emit audio until they have received
-metadata; the binary pushes an initial metadata set at connect on its own, so
-audio starts regardless of whether the caller ever sends `SENDMETA`.
+metadata; the binary pushes an initial metadata set at the first commanded
+start, so audio starts regardless of whether the caller ever sends `SENDMETA`.
 Pair-verified native Apple sessions additionally mirror these updates over
 MediaRemote `POST /command`, including explicit play/pause/stop state. Set
 `CLIAIRPLAY_MRP=0` only to disable that path for comparison or diagnosis.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Unified AirPlay streaming CLI for Music Assistant. One binary speaks RAOP
 (AirPlay 1) and AirPlay 2 — both the RAOP-compatible flow and the native HAP
 flow — replacing the previous `cliraop` and `cliap2` binaries.
 
-Music Assistant spawns one `cliairplay` process per player and feeds it raw PCM
-on stdin. For synchronized multi-room AirPlay 2 playback it additionally runs
-one `cliairplay --ptp-daemon` per host, which owns the PTP clock that every
-per-device stream on that host shares.
+Music Assistant spawns one `cliairplay` process per player, then supplies each
+PCM generation through cmdpipe `PREPARE`/`START`. `AUDIO=-` reads a commanded
+generation from process stdin; named FIFOs allow later generations to be staged
+without reconnecting. For synchronized multi-room AirPlay 2 playback it also
+runs one `cliairplay --ptp-daemon` per host.
 
 Protocol and architecture detail lives in `DESIGN.md`; open work in `TODO.md`.
 
@@ -30,37 +31,39 @@ Protocol and architecture detail lives in `DESIGN.md`; open work in `TODO.md`.
   the device's mDNS TXT records.
 - **Hi-res audio**: 24-bit ALAC (44.1 kHz and 48 kHz) on the native realtime
   stream.
-- **Commanded group starts**: every AirPlay 2 generation is staged with cmdpipe
-  `PREPARE`, then `START_UNIX_MS` schedules its first sample to be audible at
-  an exact wall-clock instant.
+- **Commanded group starts**: every generation on every protocol is staged with
+  cmdpipe `PREPARE`, then `START_UNIX_MS` schedules its first sample to be
+  audible at an exact wall-clock instant.
 
 ## Usage
 
 ```bash
-# RAOP (or let --protocol auto decide from --txt):
-ffmpeg -i song.flac -f s16le -ar 44100 -ac 2 - | \
-  ./bin/cliairplay-macos-arm64 --protocol raop --port 5000 \
-  --volume 50 --cmdpipe /tmp/cap 192.168.1.50 -
+# RAOP command-only session (or let --protocol auto decide from --txt):
+./bin/cliairplay-macos-arm64 --protocol raop --port 5000 \
+  --volume 50 --cmdpipe /tmp/raop-cap 192.168.1.50
 
-# AirPlay 2, native persistent session (audio is supplied through PREPARE):
+# AirPlay 2 native command-only session:
 ./bin/cliairplay-macos-arm64 --protocol airplay2 --port 7000 \
-  --auth <192-hex-credentials> --volume 50 --cmdpipe /tmp/cap 192.168.1.50
+  --auth <192-hex-credentials> --volume 50 \
+  --cmdpipe /tmp/ap2-cap 192.168.1.50
 ```
 
-RAOP audio is read from `<filename>` or stdin (`-`). AirPlay 2 requires
-`--cmdpipe`; each generation's raw interleaved PCM arrives through the
-`AUDIO=<path>` supplied to `PREPARE`. The format is selected with
+Every streaming protocol requires `--cmdpipe`; each generation's raw
+interleaved PCM arrives through the `AUDIO=<path>` supplied to `PREPARE`.
+`AUDIO=-` duplicates process stdin for one commanded active generation; use
+named FIFOs when staging replacements. The format is selected with
 `--samplerate`/`--bitdepth`/`--channels` (default s16le 44100 stereo). At
 `--bitdepth 24` the input must be **s32le**; the binary truncates it to the
 24-bit samples the ALAC encoder consumes.
 
 ### The start contract
 
-For AirPlay 2, `START_UNIX_MS=<ms>` followed by `ACTION=START` means: **the
-first sample is audible exactly at that unix-epoch instant**. Every generation,
-including generation 0, must first be staged with cmdpipe `PREPARE`. A caller
-waits for `[STATUS] primed generation=<n>`, then sends the same start value to
-every primed member of a sync group.
+`START_UNIX_MS=<ms>` followed by `ACTION=START` means: **the first sample is
+audible exactly at that unix-epoch instant** for legacy RAOP, RAOP-compatible
+AirPlay 2, and native AirPlay 2. Every generation, including generation 0, must
+first be staged with cmdpipe `PREPARE`. A caller waits for
+`[STATUS] primed generation=<n>`, then sends the same start value to every
+primed member of a sync group.
 
 Delivery is not gated on the start time: frames are released up to the
 receiver's buffer window ahead of each frame's deadline (the device-reported
@@ -117,7 +120,7 @@ first PTP stream begins and stops it (SIGTERM) when the last one ends.
 ## Command-line reference
 
 ```
-cliairplay [options] <host_ip> [filename ('-' for RAOP stdin)]
+cliairplay [options] --cmdpipe <path> <host_ip>
 ```
 
 ### Protocol selection
@@ -139,7 +142,7 @@ cliairplay [options] <host_ip> [filename ('-' for RAOP stdin)]
 | `--if <ip>` | Local interface IP to bind all sockets to (multi-homed hosts). |
 | `--dacp <id>` | DACP ID advertised for remote-control callbacks; also the HAP pairing identity. |
 | `--activeremote <id>` | Active-Remote ID for DACP callbacks. |
-| `--cmdpipe <path>` | Named pipe for runtime commands/metadata. Required for AirPlay 2 (see below). |
+| `--cmdpipe <path>` | Required named pipe for runtime commands, metadata, and generation staging (see below). |
 | `--udn <name>` | UDN / instance name used for mDNS. |
 | `--debug <0-9>` | Log verbosity (default: 3). |
 
@@ -180,7 +183,8 @@ cliairplay [options] <host_ip> [filename ('-' for RAOP stdin)]
 Newline-terminated `KEY=VALUE` lines written to the command pipe control a
 running stream:
 
-- AirPlay 2 generations: `GENERATION=<n>`, `AUDIO=<FIFO path>`,
+- Generations on every streaming protocol: `GENERATION=<n>`,
+  `AUDIO=<FIFO path>` (or `AUDIO=-` for process stdin),
   `POSITION_MS=<ms>`, `ACTION=PREPARE`; after the matching `primed` status,
   send `START_UNIX_MS=<unix epoch ms>` and `ACTION=START`. Generation 0 follows
   this same path and never starts from argv.
@@ -249,6 +253,9 @@ src/cliairplay.c      CLI entry, route dispatch, playback loops, input ring,
                       cmdpipe, --pair-setup and --ptp-daemon modes
 src/ap2_client.c      AP2 orchestrator: route resolution, RAOP-compat + native
                       flows, the realtime sender, anchor & pacing
+src/ap2_session.c     Protocol-neutral persistent generation engine used by
+                      legacy RAOP and both AirPlay 2 flows
+src/raop_session.c    Legacy RAOP generation commit/standby scheduling
 src/ap2_hap.c         HAP pair-verify, transient and PIN pair-setup, encrypted
                       RTSP framing (ChaCha20-Poly1305)
 src/ap2_io.c          Absolute-deadline socket I/O shared by RTSP and MRP

--- a/TODO.md
+++ b/TODO.md
@@ -6,9 +6,9 @@ Genuinely open work only. Completed work lives in git history.
       across seek/next/resume: numbered media generations over per-generation
       input pipes, committed with RTSP `FLUSH` + a re-based frozen anchor line
       (measured working down to a 150 ms warm lead on Sonos and Apple TV).
-      The argv invocation is generation 0; an attached `--cmdpipe` means the
-      connection outlives it awaiting the next generation. Replaces today's
-      teardown-and-reconnect per `play_media`.
+      Every generation, including generation 0, arrives through `--cmdpipe`
+      PREPARE/START; the connection outlives it awaiting the next generation.
+      Replaces today's teardown-and-reconnect per `play_media`.
 - [ ] **Parse `audioLatencies` from GET /info.** The SETUP echo of
       `latencyMin`/`latencyMax` is receiver-optional (Sonos omits it); the
       /info table would populate the pacing window and the reported

--- a/scripts/debug_cmdpipe_start.sh
+++ b/scripts/debug_cmdpipe_start.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+
+set -eu
+
+usage()
+{
+    cat <<'EOF'
+Usage: scripts/debug_cmdpipe_start.sh <speaker-ip> <raw-pcm-file> [stream options...]
+
+Launches a shared PTP daemon and one command-only AirPlay 2 session, stages
+generation 0 through PREPARE, and sends START with a computed audible unix-ms
+instant. The PCM file must match the stream format (default: s16le 44100 stereo).
+
+Environment:
+  CLIAIRPLAY_BIN        Binary to run (default: native bin/cliairplay-* path)
+  PTP_INTERFACE         Optional local IP passed to ptp-daemon with --if
+  START_DELAY_MS        Future start lead in milliseconds (default: 3000)
+  CONNECT_TIMEOUT_SEC   Connection/prime timeout (default: 30)
+  SESSION_TIMEOUT_SEC   EOF timeout after START (default: 300)
+
+Example:
+  CLIAIRPLAY_BIN=./bin/cliairplay-macos-arm64 \
+    scripts/debug_cmdpipe_start.sh 192.168.1.50 song.s16le \
+    --port 7000 --auth <credentials> --name HomePod
+
+The PTP daemon needs permission to bind UDP 319/320 (root or the documented
+Linux capability). Logs and FIFOs live in a private temporary directory that
+is removed on exit.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+esac
+
+if [ "$#" -lt 2 ]; then
+    usage >&2
+    exit 2
+fi
+
+speaker_ip=$1
+pcm_file=$2
+shift 2
+
+if [ ! -r "$pcm_file" ]; then
+    echo "Raw PCM file is not readable: $pcm_file" >&2
+    exit 2
+fi
+
+if [ -z "${CLIAIRPLAY_BIN:-}" ]; then
+    case "$(uname -s)" in
+        Darwin) host=macos ;;
+        Linux) host=linux ;;
+        *)
+            echo "Set CLIAIRPLAY_BIN for this operating system." >&2
+            exit 2
+            ;;
+    esac
+    case "$(uname -m)" in
+        arm64|aarch64) platform=arm64 ;;
+        x86_64|amd64) platform=x86_64 ;;
+        *)
+            echo "Set CLIAIRPLAY_BIN for this architecture." >&2
+            exit 2
+            ;;
+    esac
+    CLIAIRPLAY_BIN="./bin/cliairplay-$host-$platform"
+fi
+
+if [ ! -x "$CLIAIRPLAY_BIN" ]; then
+    echo "cliairplay binary is not executable: $CLIAIRPLAY_BIN" >&2
+    exit 2
+fi
+
+start_delay_ms=${START_DELAY_MS:-3000}
+connect_timeout=${CONNECT_TIMEOUT_SEC:-30}
+session_timeout=${SESSION_TIMEOUT_SEC:-300}
+workdir=$(mktemp -d "${TMPDIR:-/tmp}/cliairplay-debug.XXXXXX")
+cmdpipe="$workdir/commands.fifo"
+audio_pipe="$workdir/generation-0.fifo"
+ptp_log="$workdir/ptp.log"
+session_log="$workdir/session.log"
+ptp_pid=
+session_pid=
+audio_pid=
+
+mkfifo "$cmdpipe" "$audio_pipe"
+
+cleanup()
+{
+    trap - EXIT HUP INT TERM
+    for pid in "$audio_pid" "$session_pid" "$ptp_pid"; do
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+    for pid in "$audio_pid" "$session_pid" "$ptp_pid"; do
+        if [ -n "$pid" ]; then
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+    rm -rf "$workdir"
+}
+trap cleanup EXIT HUP INT TERM
+
+wait_for_log()
+{
+    pattern=$1
+    timeout=$2
+    elapsed=0
+    while ! grep -F "$pattern" "$session_log" >/dev/null 2>&1; do
+        if ! kill -0 "$session_pid" 2>/dev/null; then
+            echo "cliairplay session exited before: $pattern" >&2
+            cat "$session_log" >&2
+            return 1
+        fi
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "Timed out waiting for: $pattern" >&2
+            cat "$session_log" >&2
+            return 1
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+}
+
+if [ -n "${PTP_INTERFACE:-}" ]; then
+    "$CLIAIRPLAY_BIN" --ptp-daemon --if "$PTP_INTERFACE" >"$ptp_log" 2>&1 &
+else
+    "$CLIAIRPLAY_BIN" --ptp-daemon >"$ptp_log" 2>&1 &
+fi
+ptp_pid=$!
+sleep 1
+if ! kill -0 "$ptp_pid" 2>/dev/null; then
+    echo "PTP daemon failed to start:" >&2
+    cat "$ptp_log" >&2
+    exit 1
+fi
+
+"$CLIAIRPLAY_BIN" --protocol airplay2 --ptp-shared \
+    --cmdpipe "$cmdpipe" "$@" "$speaker_ip" >"$session_log" 2>&1 &
+session_pid=$!
+wait_for_log "[STATUS] connected" "$connect_timeout"
+
+cat "$pcm_file" >"$audio_pipe" &
+audio_pid=$!
+{
+    printf 'GENERATION=0\n'
+    printf 'AUDIO=%s\n' "$audio_pipe"
+    printf 'POSITION_MS=0\n'
+    printf 'ACTION=PREPARE\n'
+} >"$cmdpipe"
+wait_for_log "[STATUS] primed generation=0" "$connect_timeout"
+
+audible_start_ms=$(($(date +%s) * 1000 + start_delay_ms))
+{
+    printf 'GENERATION=0\n'
+    printf 'START_UNIX_MS=%s\n' "$audible_start_ms"
+    printf 'ACTION=START\n'
+} >"$cmdpipe"
+echo "Generation 0 scheduled for audible unix-ms $audible_start_ms"
+
+wait "$audio_pid"
+audio_pid=
+wait_for_log "[STATUS] eof generation=0" "$session_timeout"
+printf 'ACTION=DISCONNECT\n' >"$cmdpipe"
+wait "$session_pid"
+session_pid=
+
+cat "$session_log"

--- a/scripts/debug_cmdpipe_start.sh
+++ b/scripts/debug_cmdpipe_start.sh
@@ -5,11 +5,12 @@ set -eu
 usage()
 {
     cat <<'EOF'
-Usage: scripts/debug_cmdpipe_start.sh <speaker-ip> <raw-pcm-file> [stream options...]
+Usage: scripts/debug_cmdpipe_start.sh <raop|airplay2> <speaker-ip> <raw-pcm-file> [stream options...]
 
-Launches a shared PTP daemon and one command-only AirPlay 2 session, stages
-generation 0 through PREPARE, and sends START with a computed audible unix-ms
-instant. The PCM file must match the stream format (default: s16le 44100 stereo).
+Launches one command-only AirPlay session, stages generation 0 through PREPARE,
+and sends START with a computed audible unix-ms instant. AirPlay 2 also launches
+the shared PTP daemon. The PCM file must match the stream format (default:
+s16le 44100 stereo).
 
 Environment:
   CLIAIRPLAY_BIN        Binary to run (default: native bin/cliairplay-* path)
@@ -18,14 +19,18 @@ Environment:
   CONNECT_TIMEOUT_SEC   Connection/prime timeout (default: 30)
   SESSION_TIMEOUT_SEC   EOF timeout after START (default: 300)
 
-Example:
+Examples:
   CLIAIRPLAY_BIN=./bin/cliairplay-macos-arm64 \
-    scripts/debug_cmdpipe_start.sh 192.168.1.50 song.s16le \
+    scripts/debug_cmdpipe_start.sh raop 192.168.1.40 song.s16le \
+    --port 5000
+
+  CLIAIRPLAY_BIN=./bin/cliairplay-macos-arm64 \
+    scripts/debug_cmdpipe_start.sh airplay2 192.168.1.50 song.s16le \
     --port 7000 --auth <credentials> --name HomePod
 
-The PTP daemon needs permission to bind UDP 319/320 (root or the documented
-Linux capability). Logs and FIFOs live in a private temporary directory that
-is removed on exit.
+For AirPlay 2, the PTP daemon needs permission to bind UDP 319/320 (root or the
+documented Linux capability). Logs and FIFOs live in a private temporary
+directory that is removed on exit.
 EOF
 }
 
@@ -36,14 +41,23 @@ case "${1:-}" in
         ;;
 esac
 
-if [ "$#" -lt 2 ]; then
+if [ "$#" -lt 3 ]; then
     usage >&2
     exit 2
 fi
 
-speaker_ip=$1
-pcm_file=$2
-shift 2
+protocol=$1
+speaker_ip=$2
+pcm_file=$3
+shift 3
+
+case "$protocol" in
+    raop|airplay2) ;;
+    *)
+        echo "Protocol must be 'raop' or 'airplay2'." >&2
+        exit 2
+        ;;
+esac
 
 if [ ! -r "$pcm_file" ]; then
     echo "Raw PCM file is not readable: $pcm_file" >&2
@@ -127,21 +141,28 @@ wait_for_log()
     done
 }
 
-if [ -n "${PTP_INTERFACE:-}" ]; then
-    "$CLIAIRPLAY_BIN" --ptp-daemon --if "$PTP_INTERFACE" >"$ptp_log" 2>&1 &
-else
-    "$CLIAIRPLAY_BIN" --ptp-daemon >"$ptp_log" 2>&1 &
-fi
-ptp_pid=$!
-sleep 1
-if ! kill -0 "$ptp_pid" 2>/dev/null; then
-    echo "PTP daemon failed to start:" >&2
-    cat "$ptp_log" >&2
-    exit 1
+if [ "$protocol" = airplay2 ]; then
+    if [ -n "${PTP_INTERFACE:-}" ]; then
+        "$CLIAIRPLAY_BIN" --ptp-daemon --if "$PTP_INTERFACE" >"$ptp_log" 2>&1 &
+    else
+        "$CLIAIRPLAY_BIN" --ptp-daemon >"$ptp_log" 2>&1 &
+    fi
+    ptp_pid=$!
+    sleep 1
+    if ! kill -0 "$ptp_pid" 2>/dev/null; then
+        echo "PTP daemon failed to start:" >&2
+        cat "$ptp_log" >&2
+        exit 1
+    fi
 fi
 
-"$CLIAIRPLAY_BIN" --protocol airplay2 --ptp-shared \
-    --cmdpipe "$cmdpipe" "$@" "$speaker_ip" >"$session_log" 2>&1 &
+if [ "$protocol" = airplay2 ]; then
+    "$CLIAIRPLAY_BIN" --protocol airplay2 --ptp-shared \
+        --cmdpipe "$cmdpipe" "$@" "$speaker_ip" >"$session_log" 2>&1 &
+else
+    "$CLIAIRPLAY_BIN" --protocol raop \
+        --cmdpipe "$cmdpipe" "$@" "$speaker_ip" >"$session_log" 2>&1 &
+fi
 session_pid=$!
 wait_for_log "[STATUS] connected" "$connect_timeout"
 

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -1940,9 +1940,21 @@ bool ap2cl_disconnect(struct ap2cl_s *p)
     return true;
 }
 
-bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start)
+static uint64_t commanded_start_ntp(uint64_t start_unix_ms)
+{
+    uint64_t start_ntp = start_unix_ms
+        ? ((start_unix_ms / 1000) << 32) |
+              (((start_unix_ms % 1000) << 32) / 1000)
+        : 0;
+    uint64_t min_start =
+        raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS);
+    return start_ntp < min_start ? min_start : start_ntp;
+}
+
+bool ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms)
 {
     if (!p) return false;
+    uint64_t ntp_start = commanded_start_ntp(start_unix_ms);
     if (p->flow == FLOW_NATIVE_AP2) {
         /* Offset the RTP timeline per process: streams in one group share
          * ntpstart, and with identical pos0 two sessions from one host are
@@ -2027,13 +2039,7 @@ bool ap2cl_warm_flush(struct ap2cl_s *p, uint64_t start_unix_ms)
 {
     if (!p || p->state == AP2_DOWN) return false;
 
-    uint64_t now_ntp = raopcl_get_ntp(NULL);
-    uint64_t start_ntp = start_unix_ms
-        ? ((start_unix_ms / 1000) << 32) |
-              (((start_unix_ms % 1000) << 32) / 1000)
-        : 0;
-    uint64_t min_start = now_ntp + MS2NTP(AP2_MIN_WARM_LEAD_MS);
-    if (start_ntp < min_start) start_ntp = min_start;
+    uint64_t start_ntp = commanded_start_ntp(start_unix_ms);
 
     if (p->flow != FLOW_NATIVE_AP2) {
         if (!p->raopcl) return false;

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2794,4 +2794,19 @@ void ap2cl_test_unlock_mrp(struct ap2cl_s *p)
 {
     pthread_mutex_unlock(&p->mrp_lock);
 }
+
+void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd)
+{
+    p->sock_fd = fd;
+    p->rtsp_established = true;
+    atomic_store(&p->rtsp_dead, false);
+    snprintf(p->session_url, sizeof(p->session_url), "rtsp://test/session");
+}
+
+void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p)
+{
+    p->sock_fd = -1;
+    p->rtsp_established = false;
+    p->state = AP2_DOWN;
+}
 #endif

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -49,6 +49,7 @@
 #include "ap2_plist.h"
 #include "ap2_bplist.h"
 #include "ap2_ptp.h"
+#include "raop_session.h"
 #include "ap2_timeline.h"
 
 extern log_level *loglevel;
@@ -2006,7 +2007,7 @@ void ap2cl_standby(struct ap2cl_s *p)
 {
     if (!p || p->state == AP2_DOWN) return;
     if (p->flow != FLOW_NATIVE_AP2) {
-        if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
+        if (p->raopcl) raop_session_standby(p->raopcl);
         p->state = AP2_CONNECTED;
         return;
     }
@@ -2042,12 +2043,7 @@ bool ap2cl_warm_flush(struct ap2cl_s *p, uint64_t start_unix_ms)
     uint64_t start_ntp = commanded_start_ntp(start_unix_ms);
 
     if (p->flow != FLOW_NATIVE_AP2) {
-        if (!p->raopcl) return false;
-        raopcl_pause(p->raopcl);
-        raopcl_flush(p->raopcl);
-        int latency = raopcl_latency(p->raopcl);
-        raopcl_start_at(p->raopcl,
-                        start_ntp - TS2NTP(latency, p->format.sample_rate));
+        if (!raop_session_commit(p->raopcl, start_unix_ms)) return false;
         p->state = AP2_STREAMING;
         return true;
     }

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -149,8 +149,9 @@ bool ap2cl_connect(struct ap2cl_s *p);
 /* Disconnect from the device. */
 bool ap2cl_disconnect(struct ap2cl_s *p);
 
-/* Start playback at the given NTP timestamp. */
-bool ap2cl_start_at(struct ap2cl_s *p, uint64_t ntp_start);
+/* Start playback at a commanded unix-epoch millisecond instant. A start of 0
+ * or one already in the past is clamped to now + the minimum warm lead. */
+bool ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms);
 
 /*
  * Warm-flush a live session for a generation switch (persistent session

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -137,7 +137,9 @@ static void *reader_thread(void *arg)
     struct ap2_session_s *s = a.s;
     slot_t *slot = a.slot;
 
-    int fd = open(slot->path_owned, O_RDONLY | O_NONBLOCK);
+    int fd = strcmp(slot->path_owned, "-") == 0
+        ? dup(STDIN_FILENO)
+        : open(slot->path_owned, O_RDONLY | O_NONBLOCK);
     if (fd < 0) {
         pthread_mutex_lock(&s->lock);
         slot->ring.eof = true;
@@ -319,6 +321,17 @@ void ap2_session_destroy(struct ap2_session_s *s)
 bool ap2_session_prepare(struct ap2_session_s *s, const ap2_generation_t *gen)
 {
     if (!s || !gen || !gen->audio_path) return false;
+    if (strcmp(gen->audio_path, "-") == 0) {
+        pthread_mutex_lock(&s->lock);
+        bool stdin_active =
+            s->active && strcmp(s->active->path_owned, "-") == 0;
+        pthread_mutex_unlock(&s->lock);
+        if (stdin_active) {
+            LOG_ERROR("[SESSION] cannot stage AUDIO=- while another stdin "
+                      "generation is active; use a named FIFO");
+            return false;
+        }
+    }
     /* A superseded staged generation is discarded: the caller only ever wants
      * the newest one (rapid seek/seek/seek collapses naturally). */
     retire_slot(s, detach(s, &s->staged));

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -19,11 +19,13 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -135,21 +137,30 @@ static void *reader_thread(void *arg)
     struct ap2_session_s *s = a.s;
     slot_t *slot = a.slot;
 
-    int fd = slot->gen.audio_fd;
+    int fd = open(slot->path_owned, O_RDONLY | O_NONBLOCK);
     if (fd < 0) {
-        /* Blocking open pairs with the writer's open; an abort unblocks it by
-         * briefly opening the write side (abort_slot). */
-        fd = open(slot->path_owned, O_RDONLY);
-        if (fd < 0) {
-            pthread_mutex_lock(&s->lock);
-            slot->ring.eof = true;
-            pthread_cond_broadcast(&s->can_read);
-            pthread_mutex_unlock(&s->lock);
-            LOG_ERROR("[SESSION] cannot open %s: %s", slot->path_owned,
-                      strerror(errno));
-            return NULL;
-        }
+        pthread_mutex_lock(&s->lock);
+        slot->ring.eof = true;
+        pthread_cond_broadcast(&s->can_read);
+        pthread_mutex_unlock(&s->lock);
+        LOG_ERROR("[SESSION] cannot open %s: %s", slot->path_owned,
+                  strerror(errno));
+        return NULL;
     }
+    struct stat input_stat;
+    if (fstat(fd, &input_stat) < 0) {
+        int open_errno = errno;
+        pthread_mutex_lock(&s->lock);
+        slot->ring.eof = true;
+        emit(s, "[STATUS] input_error generation=%llu errno=%d (%s)",
+             (unsigned long long)slot->gen.number, open_errno,
+             strerror(open_errno));
+        pthread_cond_broadcast(&s->can_read);
+        pthread_mutex_unlock(&s->lock);
+        close(fd);
+        return NULL;
+    }
+    bool writer_seen = !S_ISFIFO(input_stat.st_mode);
 
     pthread_mutex_lock(&s->lock);
     if (!slot->ring.abort && !slot->ready_sent) {
@@ -164,9 +175,32 @@ static void *reader_thread(void *arg)
      * abort covers the never-started cases. */
     uint8_t buf[16384];
     for (;;) {
-        ssize_t n = read(fd, buf, sizeof(buf));
+        pthread_mutex_lock(&s->lock);
+        bool abort = slot->ring.abort;
+        pthread_mutex_unlock(&s->lock);
+        if (abort) break;
+
+        struct pollfd pfd = {.fd = fd, .events = POLLIN};
+        int polled = poll(&pfd, 1, 250);
+        if (polled < 0 && errno == EINTR) continue;
+        if (polled == 0) {
+            /* A FIFO with a connected but idle writer has no poll events. */
+            writer_seen = true;
+            continue;
+        }
+        if (!writer_seen && (pfd.revents & POLLHUP) &&
+            !(pfd.revents & POLLIN)) {
+            /* No writer has connected yet. Avoid treating that as input EOF. */
+            usleep(10000);
+            continue;
+        }
+        if (pfd.revents & POLLIN) writer_seen = true;
+
+        ssize_t n = polled < 0 ? -1 : read(fd, buf, sizeof(buf));
         if (n < 0 && errno == EINTR)
             continue;  /* interrupted syscall, not an error — retry the read */
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            continue;
         int read_errno = errno;
         pthread_mutex_lock(&s->lock);
         if (slot->ring.abort) {
@@ -175,6 +209,13 @@ static void *reader_thread(void *arg)
         }
         if (n <= 0) {
             slot->ring.eof = true;
+            if (n == 0 && slot->ring.fill > 0 && !slot->primed_sent) {
+                slot->primed_sent = true;
+                emit(s, "[STATUS] primed generation=%llu prefill_ms=%llu",
+                     (unsigned long long)slot->gen.number,
+                     (unsigned long long)(slot->ring.fill * 1000ULL /
+                                          s->byte_rate));
+            }
             /* A clean EOF (0) is the normal retirement path; a negative return
              * is a real read error (e.g. a broken pipe) and is surfaced
              * distinctly instead of being hidden as end-of-input. */
@@ -206,7 +247,7 @@ static void *reader_thread(void *arg)
         }
         pthread_mutex_unlock(&s->lock);
     }
-    if (fd != slot->gen.audio_fd) close(fd);
+    close(fd);
     return NULL;
 }
 
@@ -222,11 +263,6 @@ static void retire_slot(struct ap2_session_s *s, slot_t *slot)
     pthread_mutex_unlock(&s->lock);
 
     if (started) {
-        /* Unblock a reader stuck in open(O_RDONLY) on a writerless FIFO. */
-        if (slot->gen.audio_fd < 0 && slot->path_owned) {
-            int wfd = open(slot->path_owned, O_WRONLY | O_NONBLOCK);
-            if (wfd >= 0) close(wfd);
-        }
         pthread_join(slot->thread, NULL);
     }
     free(slot->ring.data);
@@ -250,7 +286,8 @@ struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
                                          unsigned byte_rate, int prefill_ms,
                                          int idle_timeout_ms)
 {
-    if (!ops || !ops->commit || !ops->stop || !ops->status || !byte_rate)
+    if (!ops || !ops->quiesce || !ops->commit || !ops->resume ||
+        !ops->stop || !ops->status || !byte_rate)
         return NULL;
     struct ap2_session_s *s = calloc(1, sizeof(*s));
     if (!s) return NULL;
@@ -281,7 +318,7 @@ void ap2_session_destroy(struct ap2_session_s *s)
 
 bool ap2_session_prepare(struct ap2_session_s *s, const ap2_generation_t *gen)
 {
-    if (!s || !gen || (gen->audio_fd < 0 && !gen->audio_path)) return false;
+    if (!s || !gen || !gen->audio_path) return false;
     /* A superseded staged generation is discarded: the caller only ever wants
      * the newest one (rapid seek/seek/seek collapses naturally). */
     retire_slot(s, detach(s, &s->staged));
@@ -343,26 +380,34 @@ bool ap2_session_start(struct ap2_session_s *s, uint64_t generation,
         return false;
     }
 
+    /* Stop the audio loop between its current chunk and the transport FLUSH;
+     * keep it stopped until the staged slot is active. */
+    s->ops.quiesce(s->ops.transport);
+    pthread_mutex_lock(&s->lock);
+    ok = s->staged && s->staged->gen.number == generation &&
+         s->state != AP2_SESSION_ENDED;
+    pthread_mutex_unlock(&s->lock);
+    if (!ok) {
+        s->ops.resume(s->ops.transport);
+        return false;
+    }
+
     /* Transport commit outside the lock: it does RTSP round-trips. The staged
-     * reader keeps filling meanwhile; the audio loop still consumes the OLD
-     * ring until the swap below, and anything it sends between flush and swap
-     * lands behind the flush point. */
+     * reader keeps filling meanwhile; audio sends remain quiesced. */
     if (!s->ops.commit(s->ops.transport, start_unix_ms)) {
+        s->ops.resume(s->ops.transport);
         LOG_ERROR("[SESSION] transport commit failed for generation %llu",
                   (unsigned long long)generation);
         return false;
     }
 
     pthread_mutex_lock(&s->lock);
-    /* commit() ran without the lock held, so a concurrent PREPARE (e.g. an
-     * argv gen-0 START on the main thread racing a cmdpipe PREPARE) can have
-     * superseded and freed the generation we just committed. Re-validate the
-     * staged slot by generation number before the swap so we never activate a
-     * freed slot or the wrong generation; MA sends START for the newer
-     * generation next. */
+    /* Command actions are serialized by the cmdpipe thread. Re-validate after
+     * the unlocked transport round-trip as a defensive API invariant. */
     if (!s->staged || s->staged->gen.number != generation ||
         s->state == AP2_SESSION_ENDED) {
         pthread_mutex_unlock(&s->lock);
+        s->ops.resume(s->ops.transport);
         LOG_WARN("[SESSION] generation %llu superseded before activation",
                  (unsigned long long)generation);
         return false;
@@ -375,6 +420,7 @@ bool ap2_session_start(struct ap2_session_s *s, uint64_t generation,
     pthread_cond_broadcast(&s->can_read);
     pthread_cond_broadcast(&s->can_write);
     pthread_mutex_unlock(&s->lock);
+    s->ops.resume(s->ops.transport);
 
     retire_slot(s, old);
     return true;
@@ -390,11 +436,24 @@ bool ap2_session_flush(struct ap2_session_s *s, uint64_t generation)
 
     if (is_staged) {
         retire_slot(s, detach(s, &s->staged));
+        pthread_mutex_lock(&s->lock);
+        if (s->state != AP2_SESSION_ENDED) {
+            if (s->active &&
+                (!s->active->ring.eof || s->active->ring.fill > 0)) {
+                s->state = AP2_SESSION_PLAYING;
+            } else {
+                s->state = AP2_SESSION_IDLE;
+                s->idle_since_ms = ap2_io_monotonic_ms();
+            }
+        }
+        pthread_cond_broadcast(&s->can_read);
+        pthread_mutex_unlock(&s->lock);
         return true;
     }
     if (is_active) {
+        s->ops.quiesce(s->ops.transport);
         s->ops.stop(s->ops.transport);
-        retire_slot(s, detach(s, &s->active));
+        slot_t *old = detach(s, &s->active);
         pthread_mutex_lock(&s->lock);
         if (s->state != AP2_SESSION_ENDED) {
             s->state = s->staged ? AP2_SESSION_PREPARING : AP2_SESSION_IDLE;
@@ -402,6 +461,8 @@ bool ap2_session_flush(struct ap2_session_s *s, uint64_t generation)
         }
         pthread_cond_broadcast(&s->can_read);
         pthread_mutex_unlock(&s->lock);
+        s->ops.resume(s->ops.transport);
+        retire_slot(s, old);
         return true;
     }
     return false;
@@ -410,8 +471,9 @@ bool ap2_session_flush(struct ap2_session_s *s, uint64_t generation)
 bool ap2_session_standby(struct ap2_session_s *s)
 {
     if (!s) return false;
+    s->ops.quiesce(s->ops.transport);
     s->ops.stop(s->ops.transport);
-    retire_slot(s, detach(s, &s->active));
+    slot_t *old = detach(s, &s->active);
     pthread_mutex_lock(&s->lock);
     if (s->state != AP2_SESSION_ENDED) {
         s->state = s->staged ? AP2_SESSION_PREPARING : AP2_SESSION_STANDBY;
@@ -419,6 +481,8 @@ bool ap2_session_standby(struct ap2_session_s *s)
     }
     pthread_cond_broadcast(&s->can_read);
     pthread_mutex_unlock(&s->lock);
+    s->ops.resume(s->ops.transport);
+    retire_slot(s, old);
     return true;
 }
 
@@ -453,6 +517,12 @@ int ap2_session_read(struct ap2_session_s *s, uint8_t *buf, int len,
             return (int)n;
         }
         if (s->active && s->active->ring.eof) {
+            if (s->state == AP2_SESSION_PLAYING) {
+                s->state = s->staged
+                    ? AP2_SESSION_PREPARING : AP2_SESSION_IDLE;
+                if (s->state == AP2_SESSION_IDLE)
+                    s->idle_since_ms = ap2_io_monotonic_ms();
+            }
             pthread_mutex_unlock(&s->lock);
             return -1;   /* generation fully consumed */
         }

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -2,11 +2,10 @@
  * Persistent session - generation state machine
  *
  * Separates connection lifetime from media lifetime: the binary connects once
- * (HAP, RTSP, timing, MRP) and plays a sequence of numbered media GENERATIONS
- * over that one connection, so seek/next/resume never pay the connect cost
- * again. Every generation is supplied through the command pipe, including
- * generation 0; the connection outlives each generation (bounded by the idle
- * timeout) awaiting the next PREPARE.
+ * and plays a sequence of numbered media GENERATIONS over that connection, so
+ * seek/next/resume never pay the protocol setup cost again. Every generation is
+ * supplied through the command pipe, including generation 0; the connection
+ * outlives each generation (bounded by the idle timeout) awaiting PREPARE.
  *
  * Start times are COMMANDED, not configured: every generation (including
  * generation 0) starts on an explicit START, which the caller sends after
@@ -65,7 +64,8 @@ typedef enum {
 } ap2_session_state_t;
 
 /* One staged/active generation. Audio comes from opening `audio_path`, normally
- * a FIFO created by the caller. */
+ * a FIFO created by the caller; "-" duplicates process stdin and is limited to
+ * one active generation because duplicated descriptors share the same stream. */
 typedef struct {
     uint64_t number;          /* caller-assigned generation number */
     const char *audio_path;   /* FIFO delivering this generation's PCM */

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -4,20 +4,17 @@
  * Separates connection lifetime from media lifetime: the binary connects once
  * (HAP, RTSP, timing, MRP) and plays a sequence of numbered media GENERATIONS
  * over that one connection, so seek/next/resume never pay the connect cost
- * again. This is not a mode: the argv invocation defines generation 0, and
- * whenever a command pipe is attached the connection simply outlives the
- * generation (bounded by the idle timeout) awaiting the next PREPARE. Without
- * a command pipe there is no way to receive further generations, so input EOF
- * drains and exits - the classic one-shot behavior, by construction.
+ * again. Every generation is supplied through the command pipe, including
+ * generation 0; the connection outlives each generation (bounded by the idle
+ * timeout) awaiting the next PREPARE.
  *
  * Start times are COMMANDED, not configured: every generation (including
  * generation 0) starts on an explicit START, which the caller sends after
  * seeing `connected` and `primed`. The caller therefore never has to guess a
  * safe setup lead in advance - it picks the start once the expensive work has
  * already succeeded, and a group start is simply the same START_UNIX_MS sent
- * to every primed member. An argv --start-unix-ms, when present, acts as an
- * implicit START for generation 0 (manual one-shot use, and the transitional
- * caller); starts of 0 or in the past clamp to now + the minimum warm lead.
+ * to every primed member. Starts of 0 or in the past clamp to now + the
+ * minimum warm lead.
  *
  *   PREPARE(gen, audio pipe, position)  ->  ready  ->  primed
  *   START(gen, start time)              ->  flush old + swap + anchor -> playing
@@ -67,13 +64,11 @@ typedef enum {
     AP2_SESSION_ENDED,        /* DISCONNECT requested or idle timeout hit */
 } ap2_session_state_t;
 
-/* One staged/active generation. Audio comes from `audio_fd` when >= 0 (an
- * already-open descriptor - generation 0 adopts stdin/the argv file this
- * way), else from opening `audio_path` (a FIFO created by the caller). */
+/* One staged/active generation. Audio comes from opening `audio_path`, normally
+ * a FIFO created by the caller. */
 typedef struct {
     uint64_t number;          /* caller-assigned generation number */
     const char *audio_path;   /* FIFO delivering this generation's PCM */
-    int audio_fd;             /* pre-opened input fd, or -1 to open the path */
     uint64_t position_ms;     /* media position of byte zero (progress base) */
 } ap2_generation_t;
 
@@ -88,7 +83,9 @@ struct ap2_session_s;
  * terminally (the caller then ends the session so MA can fall back cold).
  */
 typedef struct {
+    void (*quiesce)(void *transport);    /* pause audio sends across commit */
     bool (*commit)(void *transport, uint64_t start_unix_ms);
+    void (*resume)(void *transport);     /* resume sends after active swap */
     void (*stop)(void *transport);      /* silence the receiver, keep session */
     void (*status)(const char *line);   /* emit one [STATUS] line */
     void *transport;
@@ -97,7 +94,7 @@ typedef struct {
 /*
  * Create the session engine.
  *
- * :param ops: transport commit + status emit callbacks.
+ * :param ops: transport quiesce/commit/resume + status emit callbacks.
  * :param byte_rate: PCM byte rate of the input format (ring sizing/timing).
  * :param prefill_ms: staging ring fill level that emits `primed`.
  * :param idle_timeout_ms: end the session after this long without a playing
@@ -108,7 +105,7 @@ struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
                                          int idle_timeout_ms);
 void ap2_session_destroy(struct ap2_session_s *s);
 
-/* Command-pipe entry points (called from the cmdpipe thread). Invalid
+/* Command-pipe entry points, serialized by the single cmdpipe thread. Invalid
  * transitions are rejected with a [STATUS]/log line and return false. */
 bool ap2_session_prepare(struct ap2_session_s *s, const ap2_generation_t *gen);
 bool ap2_session_start(struct ap2_session_s *s, uint64_t generation,

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -38,6 +38,7 @@
 #include "ap2_session.h"
 #include "ap2_ptp.h"
 #include "ap2_hap.h"
+#include "raop_session.h"
 #include "artwork.h"
 
 #define VERSION "0.3.0"
@@ -72,7 +73,6 @@ typedef struct {
     char *active_remote;
     char *cmdpipe;
     char *udn;
-    char *audio_source;  /* RAOP filename or "-" for stdin */
 
     /* RAOP-specific */
     bool encrypt;
@@ -105,7 +105,7 @@ typedef struct {
 
 /* Globals */
 static atomic_bool g_running = true;
-static playback_status_t g_status = STATUS_STOPPED;
+static _Atomic playback_status_t g_status = STATUS_STOPPED;
 static pthread_t g_cmdpipe_thread;
 static bool g_cmdpipe_started = false;
 static int g_cmdpipe_fd = -1;
@@ -161,8 +161,8 @@ static void status_connected(void)
     status_print("[STATUS] connected");
 }
 
-/* Persistent-session engine: every AirPlay 2 generation is commanded through
- * the command pipe, including generation 0. */
+/* Persistent-session engine: every generation is commanded through the
+ * command pipe, including generation 0. */
 #define SESSION_PREFILL_MS        500     /* staging fill that emits `primed` */
 #define SESSION_IDLE_TIMEOUT_MS   120000  /* orphan safety net */
 static struct ap2_session_s *g_session = NULL;
@@ -292,117 +292,6 @@ static int truncate_32to24(const uint8_t *in, int in_bytes, uint8_t *out)
     return samples * 3;
 }
 
-/* ---- Eager input buffering ---- */
-
-/*
- * A dedicated reader drains the audio source into this ring as fast as the
- * source can deliver, decoupled from network pacing. The caller (MA) can
- * therefore fill the pipeline well before a scheduled group start instead of
- * being throttled to the send schedule, so playback start cannot underrun on
- * slow source startup. When the ring is full the reader blocks, which
- * backpressures the pipe as before.
- */
-#define INPUT_RING_BYTES (4u * 1024 * 1024)  /* allocation; admission is capped by playtime */
-
-static struct {
-    uint8_t *data;
-    size_t rd, wr, fill;
-    size_t max_fill;
-    bool eof;
-    int error;
-    bool started;
-    int fd;
-    pthread_t thread;
-    pthread_mutex_t lock;
-    pthread_cond_t can_read;
-    pthread_cond_t can_write;
-} g_inring = { .fd = -1, .lock = PTHREAD_MUTEX_INITIALIZER,
-               .can_read = PTHREAD_COND_INITIALIZER,
-               .can_write = PTHREAD_COND_INITIALIZER };
-
-static void *input_ring_thread(void *arg)
-{
-    (void)arg;
-    uint8_t chunk[65536];
-    while (g_running) {
-        ssize_t n = read(g_inring.fd, chunk, sizeof(chunk));
-        if (n < 0 && errno == EINTR) continue;
-        int read_error = n < 0 ? errno : 0;
-        pthread_mutex_lock(&g_inring.lock);
-        if (n <= 0) {
-            if (n == 0)
-                g_inring.eof = true;
-            else
-                g_inring.error = read_error;
-            pthread_cond_broadcast(&g_inring.can_read);
-            pthread_mutex_unlock(&g_inring.lock);
-            break;
-        }
-        size_t off = 0;
-        while (off < (size_t)n && g_running) {
-            while (g_inring.fill >= g_inring.max_fill && g_running)
-                pthread_cond_wait(&g_inring.can_write, &g_inring.lock);
-            size_t space = g_inring.max_fill - g_inring.fill;
-            size_t chunk_len = (size_t)n - off;
-            if (chunk_len > space) chunk_len = space;
-            size_t to_end = INPUT_RING_BYTES - g_inring.wr;
-            if (chunk_len > to_end) chunk_len = to_end;
-            memcpy(g_inring.data + g_inring.wr, chunk + off, chunk_len);
-            g_inring.wr = (g_inring.wr + chunk_len) % INPUT_RING_BYTES;
-            g_inring.fill += chunk_len;
-            off += chunk_len;
-            pthread_cond_broadcast(&g_inring.can_read);
-        }
-        pthread_mutex_unlock(&g_inring.lock);
-    }
-    return NULL;
-}
-
-static void input_ring_start(int fd, unsigned byte_rate, int cap_ms)
-{
-    g_inring.data = malloc(INPUT_RING_BYTES);
-    g_inring.fd = fd;
-    /* Cap admission by buffered PLAYTIME, not allocation size: an over-deep
-     * ring lets the feeder run tens of seconds ahead of the audible position,
-     * which breaks anything mapping feed position to wall clock (sync-group
-     * late joiners join silent until the clock catches up). The cap covers
-     * the pre-start prefill (latency) plus margin. */
-    uint64_t cap = (uint64_t)byte_rate * (uint64_t)cap_ms / 1000;
-    g_inring.max_fill = (cap && cap < INPUT_RING_BYTES) ? (size_t)cap : INPUT_RING_BYTES;
-    g_inring.rd = g_inring.wr = g_inring.fill = 0;
-    g_inring.eof = false;
-    g_inring.error = 0;
-    g_inring.started = true;
-    pthread_create(&g_inring.thread, NULL, input_ring_thread, NULL);
-}
-
-/* Read up to `want` bytes; blocks until data or EOF. Returns 0 only at EOF. */
-static int input_ring_read(uint8_t *buf, size_t want)
-{
-    pthread_mutex_lock(&g_inring.lock);
-    while (g_inring.fill == 0 && !g_inring.eof && !g_inring.error && g_running)
-        pthread_cond_wait(&g_inring.can_read, &g_inring.lock);
-    size_t n = g_inring.fill < want ? g_inring.fill : want;
-    size_t got = 0;
-    while (got < n) {
-        size_t to_end = INPUT_RING_BYTES - g_inring.rd;
-        size_t chunk_len = n - got;
-        if (chunk_len > to_end) chunk_len = to_end;
-        memcpy(buf + got, g_inring.data + g_inring.rd, chunk_len);
-        g_inring.rd = (g_inring.rd + chunk_len) % INPUT_RING_BYTES;
-        got += chunk_len;
-    }
-    g_inring.fill -= n;
-    if (n) pthread_cond_broadcast(&g_inring.can_write);
-    int error = g_inring.error;
-    pthread_mutex_unlock(&g_inring.lock);
-    if (!n && error) {
-        errno = error;
-        return -1;
-    }
-    return (int)n;
-}
-
 /* ---- Command pipe handler ---- */
 
 static struct {
@@ -527,29 +416,39 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         g_status = STATUS_STOPPED;
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "PAUSE") == 0) {
         if (g_status == STATUS_PLAYING) {
-            if (cfg->protocol == PROTO_RAOP && g_raopcl) {
-                raopcl_pause(g_raopcl);
-                raopcl_flush(g_raopcl);
-            } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
-                ap2cl_pause(g_ap2cl);
+            pthread_mutex_lock(&g_audio_send_lock);
+            if (g_status == STATUS_PLAYING) {
+                if (cfg->protocol == PROTO_RAOP && g_raopcl) {
+                    if (!raop_session_pause(g_raopcl))
+                        status_error("RAOP pause failed");
+                } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
+                    ap2cl_pause(g_ap2cl);
+                }
+                g_status = STATUS_PAUSED;
+                status_paused(0);
             }
-            g_status = STATUS_PAUSED;
-            status_paused(0);
+            pthread_mutex_unlock(&g_audio_send_lock);
         }
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "PLAY") == 0) {
+        pthread_mutex_lock(&g_audio_send_lock);
+        bool play_ok = true;
         if (cfg->protocol == PROTO_RAOP && g_raopcl) {
-            int latency = raopcl_latency(g_raopcl);
-            uint64_t now = raopcl_get_ntp(NULL);
-            uint64_t start_at = now + MS2NTP(200) - TS2NTP(latency, raopcl_sample_rate(g_raopcl));
-            raopcl_start_at(g_raopcl, start_at);
+            if (!raop_session_resume(g_raopcl)) {
+                status_error("RAOP play failed");
+                play_ok = false;
+            }
         } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
             ap2cl_play(g_ap2cl);
+        } else {
+            play_ok = false;
         }
         /* No status emission here: reporting elapsed_ms=0 would snap the
          * sender's position display backwards. The periodic reporter (gated on
          * STATUS_PLAYING) re-reports the true elapsed within a second. */
-        g_status = STATUS_PLAYING;
+        if (play_ok) g_status = STATUS_PLAYING;
+        pthread_mutex_unlock(&g_audio_send_lock);
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "STOP") == 0) {
+        pthread_mutex_lock(&g_audio_send_lock);
         g_status = STATUS_STOPPED;
         if (cfg->protocol == PROTO_RAOP && g_raopcl) {
             raopcl_stop(g_raopcl);
@@ -557,6 +456,7 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
             ap2cl_stop(g_ap2cl);
         }
         status_print("[STATUS] stopped");
+        pthread_mutex_unlock(&g_audio_send_lock);
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "SENDMETA") == 0) {
         if (cfg->protocol == PROTO_RAOP && g_raopcl) {
             raopcl_set_daap(g_raopcl, 4, "minm", 's', metadata_str(g_metadata.title),
@@ -572,11 +472,9 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
     }
 }
 
-/* Some receivers (notably Sonos) will not emit any audio until they have received
- * at least one metadata command. Push the current metadata (or a minimal
- * placeholder title) once the session is established, so audio starts regardless
- * of whether — or when — the caller sends a SENDMETA command. Any later metadata
- * from the caller simply overwrites this. */
+/* Some receivers (notably Sonos) will not emit audio until they have received
+ * metadata. Push the current values (or a placeholder title) at the first
+ * commanded START, before any PCM is sent. */
 static void send_initial_metadata(const cli_config_t *cfg)
 {
     const char *title = (g_metadata.title && *g_metadata.title) ? g_metadata.title : "cliairplay";
@@ -596,28 +494,35 @@ static void send_initial_metadata(const cli_config_t *cfg)
 static bool session_commit(void *transport, uint64_t start_unix_ms)
 {
     cli_config_t *cfg = transport;
-    struct ap2cl_s *client = g_ap2cl;
-    if (!client) return false;
-    if (!g_first_start_done) {
-        /* First start: full timeline init (pid RTP offset, sequence seed).
-         * The client clamps stale commands to its minimum safe lead. */
-        if (!ap2cl_start(client, start_unix_ms)) return false;
-        /* Placeholder metadata must follow the first start: it anchors to the
-         * RTP timeline that call establishes (metadata-gated receivers keep
-         * audio muted otherwise). */
-        send_initial_metadata(cfg);
-        g_first_start_done = true;
-    } else if (!ap2cl_warm_flush(client, start_unix_ms)) {
-        return false;
+    bool committed;
+    if (cfg->protocol == PROTO_RAOP) {
+        struct raopcl_s *client = g_raopcl;
+        committed = client && raop_session_commit(client, start_unix_ms);
+    } else {
+        struct ap2cl_s *client = g_ap2cl;
+        if (!client) return false;
+        committed = !g_first_start_done
+            ? ap2cl_start(client, start_unix_ms)
+            : ap2cl_warm_flush(client, start_unix_ms);
     }
+    if (!committed) return false;
+
+    /* Metadata-gated receivers must receive a placeholder before audio. */
+    if (!g_first_start_done) send_initial_metadata(cfg);
+    g_first_start_done = true;
     g_status = STATUS_PLAYING;
     return true;
 }
 
 static void session_stop_op(void *transport)
 {
-    (void)transport;
-    if (g_ap2cl) ap2cl_standby(g_ap2cl);
+    cli_config_t *cfg = transport;
+    if (cfg->protocol == PROTO_RAOP) {
+        if (g_raopcl && !raop_session_standby(g_raopcl))
+            status_error("RAOP standby failed");
+    } else if (g_ap2cl) {
+        ap2cl_standby(g_ap2cl);
+    }
     if (g_status == STATUS_PLAYING) g_status = STATUS_PAUSED;
 }
 
@@ -729,19 +634,41 @@ static bool start_command_thread(cli_config_t *cfg)
     return true;
 }
 
+static bool start_stream_session(cli_config_t *cfg, int input_bpf)
+{
+    ap2_session_ops_t ops = {
+        .quiesce = session_quiesce,
+        .commit = session_commit,
+        .resume = session_resume,
+        .stop = session_stop_op,
+        .status = session_status_line,
+        .transport = cfg,
+    };
+    g_session = ap2_session_create(
+        &ops, (unsigned)cfg->sample_rate * (unsigned)input_bpf,
+        SESSION_PREFILL_MS, SESSION_IDLE_TIMEOUT_MS);
+    if (!g_session) {
+        status_error("Cannot create session engine");
+        return false;
+    }
+    g_status = STATUS_PAUSED;
+    if (!start_command_thread(cfg)) {
+        ap2_session_destroy(g_session);
+        g_session = NULL;
+        return false;
+    }
+    return true;
+}
+
 /* ---- RAOP playback loop ---- */
 
-static int run_raop(cli_config_t *cfg, int infile)
+static int run_raop(cli_config_t *cfg)
 {
     struct in_addr host_addr, player_addr;
     struct hostent *hostent;
     uint32_t netmask;
     char *iface = NULL;
     raop_crypto_t crypto = RAOP_CLEAR;
-    int latency;
-    uint64_t last = 0, frames = 0;
-    uint8_t *buf;
-    bool got_eof = false;
 
     /* Resolve local interface */
     host_addr = get_interface(cfg->iface, &iface, &netmask);
@@ -777,7 +704,7 @@ static int run_raop(cli_config_t *cfg, int infile)
         }
     }
 
-    latency = MS2TS(cfg->latency_ms, cfg->sample_rate);
+    int latency = MS2TS(cfg->latency_ms, cfg->sample_rate);
 
     /* Codec selection: default to compressed ALAC, which virtually every RAOP
      * receiver advertises and which saves LAN bandwidth. Fall back to uncompressed
@@ -819,28 +746,65 @@ static int run_raop(cli_config_t *cfg, int infile)
     atomic_store(&g_raopcl, client);
 
     latency = raopcl_latency(g_raopcl);
+    int input_bpf = (cfg->bit_depth <= 16 ? 2 : 4) * cfg->channels;
+    int alac_bpf = (cfg->bit_depth <= 16 ? 2 : 3) * cfg->channels;
+    if (!start_stream_session(cfg, input_bpf)) return 1;
     status_connected_legacy(inet_ntoa(player_addr), cfg->port,
                             (int)TS2MS(latency, raopcl_sample_rate(g_raopcl)));
-    send_initial_metadata(cfg);
 
-    g_status = STATUS_PLAYING;
-    /* Stdin audio format:
+    /* Commanded PCM format:
      * For 16-bit: s16le (2 bytes per sample, 4 bytes per frame stereo)
      * For 24-bit: s32le (4 bytes per sample, 8 bytes per frame stereo)
      *   ALAC encoder expects s24le (3 bytes/sample), so we truncate s32le→s24le.
      */
-    int input_bpf = (cfg->bit_depth <= 16 ? 2 : 4) * cfg->channels;
-    int alac_bpf = (cfg->bit_depth <= 16 ? 2 : 3) * cfg->channels;  /* what ALAC encoder expects */
-    buf = malloc(DEFAULT_FRAMES_PER_CHUNK * input_bpf);
+    uint8_t *buf = malloc(DEFAULT_FRAMES_PER_CHUNK * input_bpf);
     uint8_t *alac_buf = (cfg->bit_depth > 16) ? malloc(DEFAULT_FRAMES_PER_CHUNK * alac_bpf) : NULL;
+    if (!buf || (cfg->bit_depth > 16 && !alac_buf)) {
+        status_error("Cannot allocate RAOP audio buffer");
+        free(buf);
+        free(alac_buf);
+        request_command_stop();
+        join_command_thread();
+        ap2_session_destroy(g_session);
+        g_session = NULL;
+        return 1;
+    }
+
+    uint64_t last = 0, frames = 0;
+    uint64_t current_gen = ap2_session_active_generation(g_session);
+    bool playback_failed = false;
+    bool gen_eof = false;
+    bool eof_reported = false;
+    uint64_t eof_time = 0;
+    int pcm_carry = 0;
 
     /* Main audio loop */
-    while (g_status != STATUS_STOPPED && (!got_eof || raopcl_is_playing(g_raopcl))) {
+    while (g_status != STATUS_STOPPED) {
         uint64_t now = raopcl_get_ntp(NULL);
+        ap2_session_poll(g_session);
+        if (ap2_session_state(g_session) == AP2_SESSION_ENDED)
+            break;
+
+        if (!raopcl_is_connected(g_raopcl) || !raopcl_is_sane(g_raopcl)) {
+            status_error("RAOP control or media channel failed");
+            playback_failed = true;
+            break;
+        }
+
+        uint64_t active = ap2_session_active_generation(g_session);
+        if (active != current_gen) {
+            current_gen = active;
+            frames = 0;
+            gen_eof = false;
+            eof_reported = false;
+            eof_time = 0;
+            pcm_carry = 0;
+        }
 
         /* Periodic status reporting (only while playing, so a pause does not keep
            emitting a "playing" status that would revive the sender's play state) */
-        if (g_status == STATUS_PLAYING && now - last > MS2NTP(1000)) {
+        if (g_status == STATUS_PLAYING && !gen_eof &&
+            now - last > MS2NTP(1000)) {
             last = now;
             if (frames > (uint64_t)raopcl_latency(g_raopcl)) {
                 uint32_t elapsed = TS2MS(frames - raopcl_latency(g_raopcl), raopcl_sample_rate(g_raopcl));
@@ -848,17 +812,65 @@ static int run_raop(cli_config_t *cfg, int infile)
             }
         }
 
+        if (gen_eof) {
+            bool drained = !raopcl_is_playing(g_raopcl) ||
+                           now - eof_time > MS2NTP(
+                               TS2MS(raopcl_latency(g_raopcl),
+                                     raopcl_sample_rate(g_raopcl)) + 2000);
+            if (drained && !eof_reported) {
+                eof_reported = true;
+                status_print("[STATUS] eof generation=%llu",
+                             (unsigned long long)current_gen);
+                status_eof();
+            }
+            usleep(drained ? 50000 : 10000);
+            continue;
+        }
+
         /* Send audio chunk */
-        if (g_status == STATUS_PLAYING && raopcl_accept_frames(g_raopcl)) {
-            int n = input_ring_read(buf, DEFAULT_FRAMES_PER_CHUNK * input_bpf);
-            if (n < 0) {
-                status_error("Error reading from audio source");
-                break;
-            } else if (n == 0) {
-                if (!got_eof) {
-                    LOG_INFO("End of audio stream, draining buffer...");
-                    got_eof = true;
+        if (g_status == STATUS_PLAYING) {
+            pthread_mutex_lock(&g_audio_send_lock);
+            if (g_status != STATUS_PLAYING ||
+                !raopcl_accept_frames(g_raopcl)) {
+                pthread_mutex_unlock(&g_audio_send_lock);
+                usleep(1000);
+                continue;
+            }
+            active = ap2_session_active_generation(g_session);
+            if (active != current_gen) {
+                current_gen = active;
+                frames = 0;
+                gen_eof = false;
+                eof_reported = false;
+                eof_time = 0;
+                pcm_carry = 0;
+            }
+            int n = ap2_session_read(
+                g_session, buf + pcm_carry,
+                DEFAULT_FRAMES_PER_CHUNK * input_bpf - pcm_carry, 250);
+            if (n > 0) {
+                n += pcm_carry;
+                pcm_carry = n % input_bpf;
+                n -= pcm_carry;
+                if (n == 0) {
+                    pthread_mutex_unlock(&g_audio_send_lock);
+                    continue;
                 }
+            }
+            if (n == -2) {
+                pthread_mutex_unlock(&g_audio_send_lock);
+                break;
+            }
+            if (n == -1) {
+                LOG_INFO("End of RAOP generation %llu input, draining...",
+                         (unsigned long long)current_gen);
+                gen_eof = true;
+                eof_time = raopcl_get_ntp(NULL);
+                pthread_mutex_unlock(&g_audio_send_lock);
+                continue;
+            }
+            if (n == 0) {
+                pthread_mutex_unlock(&g_audio_send_lock);
                 continue;
             }
 
@@ -870,24 +882,28 @@ static int run_raop(cli_config_t *cfg, int infile)
                 send_buf = alac_buf;
             }
             uint64_t playtime;
-            raopcl_send_chunk(g_raopcl, send_buf, audio_frames, &playtime);
+            if (!raopcl_send_chunk(
+                    g_raopcl, send_buf, audio_frames, &playtime)) {
+                status_error("RAOP audio send failed");
+                playback_failed = true;
+                pthread_mutex_unlock(&g_audio_send_lock);
+                break;
+            }
             frames += audio_frames;
+            if (pcm_carry) memmove(buf, buf + n, (size_t)pcm_carry);
+            pthread_mutex_unlock(&g_audio_send_lock);
         } else {
             usleep(1000);
         }
     }
 
-    status_eof();
     request_command_stop();
+    bool command_joined = join_command_thread();
+    ap2_session_destroy(g_session);
+    g_session = NULL;
     free(buf);
     free(alac_buf);
-    if (!join_command_thread()) return 1;
-    client = atomic_exchange(&g_raopcl, NULL);
-    if (client) {
-        raopcl_disconnect(client);
-        raopcl_destroy(client);
-    }
-    return 0;
+    return playback_failed || !command_joined ? 1 : 0;
 }
 
 /* ---- AirPlay 2 playback loop ---- */
@@ -993,27 +1009,7 @@ static int run_airplay2(cli_config_t *cfg)
      * prepared and started by the command-pipe thread after connection setup. */
     int ap2_input_bpf = (cfg->bit_depth <= 16 ? 2 : 4) * cfg->channels;
     int ap2_alac_bpf = (cfg->bit_depth <= 16 ? 2 : 3) * cfg->channels;
-    ap2_session_ops_t ops = {
-        .quiesce = session_quiesce,
-        .commit = session_commit,
-        .resume = session_resume,
-        .stop = session_stop_op,
-        .status = session_status_line,
-        .transport = cfg,
-    };
-    g_session = ap2_session_create(
-        &ops, (unsigned)cfg->sample_rate * (unsigned)ap2_input_bpf,
-        SESSION_PREFILL_MS, SESSION_IDLE_TIMEOUT_MS);
-    if (!g_session) {
-        status_error("Cannot create session engine");
-        return 1;
-    }
-    g_status = STATUS_PAUSED;
-    if (!start_command_thread(cfg)) {
-        ap2_session_destroy(g_session);
-        g_session = NULL;
-        return 1;
-    }
+    if (!start_stream_session(cfg, ap2_input_bpf)) return 1;
     status_connected();
 
     uint64_t last = 0, frames = 0;
@@ -1080,10 +1076,12 @@ static int run_airplay2(cli_config_t *cfg)
         }
 
         /* Send audio chunk */
-        if (g_status == STATUS_PLAYING && ap2cl_accept_frames(g_ap2cl)) {
+        if (g_status == STATUS_PLAYING) {
             pthread_mutex_lock(&g_audio_send_lock);
-            if (g_status != STATUS_PLAYING) {
+            if (g_status != STATUS_PLAYING ||
+                !ap2cl_accept_frames(g_ap2cl)) {
                 pthread_mutex_unlock(&g_audio_send_lock);
+                usleep(1000);
                 continue;
             }
             active = ap2_session_active_generation(g_session);
@@ -1293,7 +1291,7 @@ static int run_ptp_daemon(cli_config_t *cfg)
 static void print_usage(const char *name)
 {
     printf("cliairplay v%s - Unified AirPlay streaming CLI\n\n", VERSION);
-    printf("Usage: %s [options] <host_ip> [filename ('-' for RAOP stdin)]\n\n", name);
+    printf("Usage: %s [options] --cmdpipe <path> <host_ip>\n\n", name);
     printf("Protocol selection:\n");
     printf("  --protocol <auto|raop|airplay2>  Protocol to use (default: auto).\n");
     printf("                             auto picks RAOP vs AirPlay 2 from the mDNS\n");
@@ -1305,7 +1303,7 @@ static void print_usage(const char *name)
     printf("                             clamped into the device-reported window)\n");
     printf("  --dacp <id>                DACP ID\n");
     printf("  --activeremote <id>        Active Remote ID\n");
-    printf("  --cmdpipe <path>           Named pipe for metadata/commands\n");
+    printf("  --cmdpipe <path>           Required named pipe for commands/audio staging\n");
     printf("  --udn <name>               UDN name for mDNS\n");
     printf("  --samplerate <rate>        Sample rate (default: 44100)\n");
     printf("  --bitdepth <bits>          Bit depth: 16 or 24 (default: 16). 24-bit\n");
@@ -1349,11 +1347,11 @@ static void print_usage(const char *name)
     printf("                             serve the control channel until signaled. One per\n");
     printf("                             host; needs root. Takes no host/audio args.\n\n");
     printf("Examples:\n");
-    printf("  # RAOP streaming from stdin:\n");
-    printf("  ffmpeg -i song.flac -f s16le -ar 44100 -ac 2 - | %s 192.168.1.50 -\n\n", name);
-    printf("  # AirPlay 2 persistent session (audio starts through --cmdpipe):\n");
+    printf("  # RAOP command-only session:\n");
+    printf("  %s --protocol raop --cmdpipe /tmp/raop-cap 192.168.1.50\n\n", name);
+    printf("  # AirPlay 2 command-only session:\n");
     printf("  %s --protocol airplay2 --auth <creds> --name \"HomePod\" \\\n", name);
-    printf("    --cmdpipe /tmp/cap 192.168.1.50\n");
+    printf("    --cmdpipe /tmp/ap2-cap 192.168.1.50\n");
 }
 
 /* ---- Main ---- */
@@ -1382,7 +1380,6 @@ int main(int argc, char *argv[])
     bool pairing_mode = false;
     bool ptp_daemon_mode = false;
     bool pair_setup_mode = false;
-    int infile = -1;
 
     static struct option long_options[] = {
         {"protocol",     required_argument, 0, 'P'},
@@ -1481,9 +1478,8 @@ int main(int argc, char *argv[])
         }
     }
 
-    /* Remaining positional args: host and filename */
+    /* The only streaming positional argument is the target host. */
     if (optind < argc) cfg.host = argv[optind++];
-    if (optind < argc) cfg.audio_source = argv[optind++];
 
     /* Setup debug levels */
     if (cfg.debug_level >= (int)NUM_DEBUG_LEVELS)
@@ -1521,7 +1517,7 @@ int main(int argc, char *argv[])
         return rc;
     }
 
-    /* PTP daemon mode: no host/audio source; run the shared clock until signaled.
+    /* PTP daemon mode: no host; run the shared clock until signaled.
      * MA starts one of these per host for multi-room AirPlay 2 (see README). */
     if (ptp_daemon_mode) {
         int rc = run_ptp_daemon(&cfg);
@@ -1533,6 +1529,11 @@ int main(int argc, char *argv[])
     /* Validate the common positional argument before route resolution. */
     if (!cfg.host) {
         print_usage(argv[0]);
+        return 1;
+    }
+    if (optind < argc) {
+        status_error(
+            "Streaming audio must be provided by cmdpipe PREPARE, not argv");
         return 1;
     }
 
@@ -1563,16 +1564,8 @@ int main(int argc, char *argv[])
            (!cfg.route.use_raop && cfg.route.ptp) ? "ptp" : "ntp");
     fflush(stdout);
 
-    if (cfg.protocol == PROTO_RAOP && !cfg.audio_source) {
-        status_error("RAOP requires an audio filename or '-' for stdin");
-        return 1;
-    }
-    if (cfg.protocol == PROTO_AIRPLAY2 && !cfg.cmdpipe) {
-        status_error("AirPlay 2 requires --cmdpipe");
-        return 1;
-    }
-    if (cfg.protocol == PROTO_AIRPLAY2 && cfg.audio_source) {
-        status_error("AirPlay 2 audio must be provided by cmdpipe PREPARE");
+    if (!cfg.cmdpipe) {
+        status_error("Streaming requires --cmdpipe");
         return 1;
     }
 
@@ -1581,61 +1574,19 @@ int main(int argc, char *argv[])
     signal(SIGTERM, signal_handler);
     signal(SIGPIPE, SIG_IGN);
 
-    /* RAOP retains its direct audio input. AirPlay 2 receives every generation
-     * from the AUDIO path supplied with cmdpipe PREPARE. */
-    if (cfg.protocol == PROTO_RAOP && strcmp(cfg.audio_source, "-") == 0) {
-        infile = fileno(stdin);
-        LOG_INFO("Reading RAOP audio from stdin");
-    } else if (cfg.protocol == PROTO_RAOP) {
-        struct stat st;
-        bool is_fifo = false;
-        if (stat(cfg.audio_source, &st) == 0) {
-            is_fifo = S_ISFIFO(st.st_mode);
-        } else if (mkfifo(cfg.audio_source, 0666) == 0) {
-            is_fifo = true;
-        }
-        int flags = O_RDONLY;
-        if (is_fifo) flags |= O_NONBLOCK;
-        if ((infile = open(cfg.audio_source, flags)) == -1) {
-            status_error("Cannot open audio source");
+    /* Setup command pipe */
+    struct stat st;
+    if (stat(cfg.cmdpipe, &st) != 0) {
+        if (mkfifo(cfg.cmdpipe, 0666) != 0) {
+            status_error("Failed to create command pipe");
             return 1;
         }
-        if (is_fifo) {
-            int file_flags = fcntl(infile, F_GETFL);
-            fcntl(infile, F_SETFL, file_flags & ~O_NONBLOCK);
-        }
     }
 
-    /* Setup command pipe */
-    if (cfg.cmdpipe) {
-        struct stat st;
-        if (stat(cfg.cmdpipe, &st) != 0) {
-            if (mkfifo(cfg.cmdpipe, 0666) != 0) {
-                status_error("Failed to create command pipe");
-                return 1;
-            }
-        }
-    }
-
-    /* RAOP starts its command reader before connecting, preserving its existing
-     * behavior. AirPlay 2 starts it only after its session engine is ready. */
-    int result;
-    if (cfg.protocol == PROTO_RAOP) {
-        if (!start_command_thread(&cfg)) {
-            result = 1;
-            goto cleanup;
-        }
-        unsigned in_byte_rate =
-            (unsigned)((cfg.bit_depth <= 16 ? 2 : 4) * cfg.channels *
-                       cfg.sample_rate);
-        input_ring_start(infile, in_byte_rate, cfg.latency_ms + 2000);
-        result = run_raop(&cfg, infile);
-    } else {
-        result = run_airplay2(&cfg);
-    }
+    int result = cfg.protocol == PROTO_RAOP
+        ? run_raop(&cfg) : run_airplay2(&cfg);
 
     /* Cleanup */
-cleanup:
     request_command_stop();
     if (!join_command_thread()) return 1;
     struct ap2cl_s *ap2_client = atomic_exchange(&g_ap2cl, NULL);
@@ -1653,7 +1604,6 @@ cleanup:
     free(g_metadata.artist);
     free(g_metadata.album);
     g_metadata.title = g_metadata.artist = g_metadata.album = NULL;
-    if (infile >= 0 && infile != fileno(stdin)) close(infile);
     netsock_close();
     cross_ssl_free();
 

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -72,8 +72,7 @@ typedef struct {
     char *active_remote;
     char *cmdpipe;
     char *udn;
-    uint64_t ntp_start;
-    char *audio_source;  /* filename or "-" for stdin */
+    char *audio_source;  /* RAOP filename or "-" for stdin */
 
     /* RAOP-specific */
     bool encrypt;
@@ -162,25 +161,28 @@ static void status_connected(void)
     status_print("[STATUS] connected");
 }
 
-/* Persistent-session engine (native AP2): generation 0 adopts the argv
- * input; further generations arrive over the command pipe. */
+/* Persistent-session engine: every AirPlay 2 generation is commanded through
+ * the command pipe, including generation 0. */
 #define SESSION_PREFILL_MS        500     /* staging fill that emits `primed` */
-#define SESSION_IDLE_TIMEOUT_MS   120000  /* orphan safety net (cmdpipe only) */
+#define SESSION_IDLE_TIMEOUT_MS   120000  /* orphan safety net */
 static struct ap2_session_s *g_session = NULL;
+static pthread_mutex_t g_audio_send_lock = PTHREAD_MUTEX_INITIALIZER;
 static bool g_first_start_done = false;
 static uint64_t g_pend_generation = 0;
 static char g_pend_audio[512];
 static uint64_t g_pend_position_ms = 0;
 static uint64_t g_pend_start_unix_ms = 0;
 
-static uint64_t unix_ms_to_ntp(uint64_t ms)
+static void session_quiesce(void *transport)
 {
-    return ((ms / 1000) << 32) | (((ms % 1000) << 32) / 1000);
+    (void)transport;
+    pthread_mutex_lock(&g_audio_send_lock);
 }
 
-static uint64_t ntp_to_unix_ms(uint64_t ntp)
+static void session_resume(void *transport)
 {
-    return (ntp >> 32) * 1000ULL + (((ntp & 0xFFFFFFFFULL) * 1000ULL) >> 32);
+    (void)transport;
+    pthread_mutex_unlock(&g_audio_send_lock);
 }
 
 static void status_playing(uint64_t elapsed_ms)
@@ -503,7 +505,6 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         ap2_generation_t gen = {
             .number = g_pend_generation,
             .audio_path = g_pend_audio[0] ? g_pend_audio : NULL,
-            .audio_fd = -1,
             .position_ms = g_pend_position_ms,
         };
         if (!g_session || !ap2_session_prepare(g_session, &gen))
@@ -599,11 +600,8 @@ static bool session_commit(void *transport, uint64_t start_unix_ms)
     if (!client) return false;
     if (!g_first_start_done) {
         /* First start: full timeline init (pid RTP offset, sequence seed).
-         * With no commanded instant, keep the classic one-lead default. */
-        uint64_t ntp = start_unix_ms
-            ? unix_ms_to_ntp(start_unix_ms)
-            : raopcl_get_ntp(NULL) + MS2NTP(cfg->latency_ms);
-        if (!ap2cl_start_at(client, ntp)) return false;
+         * The client clamps stale commands to its minimum safe lead. */
+        if (!ap2cl_start(client, start_unix_ms)) return false;
         /* Placeholder metadata must follow the first start: it anchors to the
          * RTP timeline that call establishes (metadata-gated receivers keep
          * audio muted otherwise). */
@@ -633,11 +631,6 @@ static void *cmdpipe_reader_thread(void *arg)
     cli_config_t *cfg = (cli_config_t *)arg;
     uint64_t last_keepalive = raopcl_get_ntp(NULL);
 
-    g_cmdpipe_fd = open(cfg->cmdpipe, O_RDWR | O_NONBLOCK);
-    if (g_cmdpipe_fd == -1) {
-        LOG_ERROR("Failed to open command pipe: %s (errno=%d)", cfg->cmdpipe, errno);
-        return NULL;
-    }
     LOG_INFO("Command pipe ready: %s", cfg->cmdpipe);
 
     while (g_running) {
@@ -710,6 +703,29 @@ static bool join_command_thread(void)
         return false;
     }
     g_cmdpipe_started = false;
+    return true;
+}
+
+static bool start_command_thread(cli_config_t *cfg)
+{
+    if (!cfg->cmdpipe || g_cmdpipe_started) return true;
+    g_cmdpipe_fd = open(cfg->cmdpipe, O_RDWR | O_NONBLOCK);
+    if (g_cmdpipe_fd == -1) {
+        LOG_ERROR("Failed to open command pipe: %s (errno=%d)",
+                  cfg->cmdpipe, errno);
+        status_error("Failed to open command pipe");
+        return false;
+    }
+    int result = pthread_create(
+        &g_cmdpipe_thread, NULL, cmdpipe_reader_thread, cfg);
+    if (result != 0) {
+        LOG_ERROR("Failed to start command pipe thread: %s", strerror(result));
+        status_error("Failed to start command pipe thread");
+        close(g_cmdpipe_fd);
+        g_cmdpipe_fd = -1;
+        return false;
+    }
+    g_cmdpipe_started = true;
     return true;
 }
 
@@ -807,15 +823,6 @@ static int run_raop(cli_config_t *cfg, int infile)
                             (int)TS2MS(latency, raopcl_sample_rate(g_raopcl)));
     send_initial_metadata(cfg);
 
-    /* Schedule start time */
-    if (cfg->ntp_start) {
-        /* Contract: the first sample is AUDIBLE exactly at the requested start
-         * (RAOP renders a frame latency after its frame-clock position, so the
-         * timeline starts latency early). */
-        raopcl_start_at(g_raopcl,
-                        cfg->ntp_start - TS2NTP(latency, raopcl_sample_rate(g_raopcl)));
-    }
-
     g_status = STATUS_PLAYING;
     /* Stdin audio format:
      * For 16-bit: s16le (2 bytes per sample, 4 bytes per frame stereo)
@@ -885,7 +892,7 @@ static int run_raop(cli_config_t *cfg, int infile)
 
 /* ---- AirPlay 2 playback loop ---- */
 
-static int run_airplay2(cli_config_t *cfg, int infile)
+static int run_airplay2(cli_config_t *cfg)
 {
     ap2_device_info_t device = {
         .name = cfg->ap2_name,
@@ -933,8 +940,6 @@ static int run_airplay2(cli_config_t *cfg, int infile)
         return 1;
     }
     atomic_store(&g_ap2cl, client);
-
-    status_connected();
 
     /* Report the MRP now-playing path so MA can log which one is active. The
      * type-130 data channel (path B) is opt-in; -1 means it was not attempted
@@ -984,48 +989,32 @@ static int run_airplay2(cli_config_t *cfg, int infile)
         ap2cl_set_volume(g_ap2cl, cfg->volume);
     }
 
-    /* Persistent session: generation 0 adopts the argv input; further
-     * generations arrive over the command pipe. Start times are commanded -
-     * an argv --start-unix-ms (or the absence of a command pipe) acts as the
-     * implicit START for generation 0; otherwise the caller sends START after
-     * seeing `connected` and `primed`, so it never guesses a setup lead. */
+    /* The session starts empty. Every generation, including generation 0, is
+     * prepared and started by the command-pipe thread after connection setup. */
     int ap2_input_bpf = (cfg->bit_depth <= 16 ? 2 : 4) * cfg->channels;
     int ap2_alac_bpf = (cfg->bit_depth <= 16 ? 2 : 3) * cfg->channels;
     ap2_session_ops_t ops = {
+        .quiesce = session_quiesce,
         .commit = session_commit,
+        .resume = session_resume,
         .stop = session_stop_op,
         .status = session_status_line,
         .transport = cfg,
     };
     g_session = ap2_session_create(
         &ops, (unsigned)cfg->sample_rate * (unsigned)ap2_input_bpf,
-        SESSION_PREFILL_MS, cfg->cmdpipe ? SESSION_IDLE_TIMEOUT_MS : 0);
+        SESSION_PREFILL_MS, SESSION_IDLE_TIMEOUT_MS);
     if (!g_session) {
         status_error("Cannot create session engine");
         return 1;
     }
-    ap2_generation_t gen0 = {
-        .number = 0,
-        .audio_path = NULL,
-        .audio_fd = infile,
-        .position_ms = 0,
-    };
-    if (!ap2_session_prepare(g_session, &gen0)) {
-        status_error("Cannot stage the initial generation");
+    g_status = STATUS_PAUSED;
+    if (!start_command_thread(cfg)) {
         ap2_session_destroy(g_session);
         g_session = NULL;
         return 1;
     }
-    if (cfg->ntp_start || !cfg->cmdpipe) {
-        if (!ap2_session_start(g_session, 0,
-                               cfg->ntp_start ? ntp_to_unix_ms(cfg->ntp_start)
-                                              : 0)) {
-            status_error("Cannot start AirPlay 2 stream");
-            ap2_session_destroy(g_session);
-            g_session = NULL;
-            return 1;
-        }
-    }
+    status_connected();
 
     uint64_t last = 0, frames = 0;
     uint64_t current_gen = ap2_session_active_generation(g_session);
@@ -1076,9 +1065,8 @@ static int run_airplay2(cli_config_t *cfg, int infile)
         }
 
         if (gen_eof) {
-            /* Input consumed: let the receiver drain, report once, then either
-             * exit (one-shot: no command pipe means nothing further can
-             * arrive) or idle awaiting the next generation / idle timeout. */
+            /* Input consumed: let the receiver drain, report once, then idle
+             * awaiting the next commanded generation or idle timeout. */
             bool drained = !ap2cl_is_playing(g_ap2cl) ||
                            now - eof_time > MS2NTP(cfg->latency_ms + 2000);
             if (drained && !eof_reported) {
@@ -1086,7 +1074,6 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                 status_print("[STATUS] eof generation=%llu",
                              (unsigned long long)current_gen);
                 status_eof();
-                if (!cfg->cmdpipe) break;
             }
             usleep(drained ? 50000 : 10000);
             continue;
@@ -1094,6 +1081,20 @@ static int run_airplay2(cli_config_t *cfg, int infile)
 
         /* Send audio chunk */
         if (g_status == STATUS_PLAYING && ap2cl_accept_frames(g_ap2cl)) {
+            pthread_mutex_lock(&g_audio_send_lock);
+            if (g_status != STATUS_PLAYING) {
+                pthread_mutex_unlock(&g_audio_send_lock);
+                continue;
+            }
+            active = ap2_session_active_generation(g_session);
+            if (active != current_gen) {
+                current_gen = active;
+                frames = 0;
+                gen_eof = false;
+                eof_reported = false;
+                eof_time = 0;
+                pcm_carry = 0;
+            }
             int n = ap2_session_read(
                 g_session, buf + pcm_carry,
                 AP2_FRAMES_PER_CHUNK * ap2_input_bpf - pcm_carry, 250);
@@ -1104,15 +1105,20 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                 pcm_carry = n % ap2_input_bpf;
                 n -= pcm_carry;
                 if (n == 0) {
+                    pthread_mutex_unlock(&g_audio_send_lock);
                     continue;   /* only a partial frame arrived so far */
                 }
             }
-            if (n == -2) break;
+            if (n == -2) {
+                pthread_mutex_unlock(&g_audio_send_lock);
+                break;
+            }
             if (n == -1) {
                 LOG_INFO("End of generation %llu input, draining buffer...",
                          (unsigned long long)current_gen);
                 gen_eof = true;
                 eof_time = raopcl_get_ntp(NULL);
+                pthread_mutex_unlock(&g_audio_send_lock);
                 continue;
             }
             if (n == 0) {
@@ -1123,6 +1129,7 @@ static int run_airplay2(cli_config_t *cfg, int infile)
                     ap2cl_log_diagnostics(g_ap2cl);
                 }
                 ap2cl_recover_input_gap(g_ap2cl);
+                pthread_mutex_unlock(&g_audio_send_lock);
                 continue;
             }
             if (starving) {
@@ -1145,22 +1152,25 @@ static int run_airplay2(cli_config_t *cfg, int infile)
             if (result == AP2_SEND_FATAL) {
                 status_error("AirPlay 2 realtime send failed");
                 playback_failed = true;
+                pthread_mutex_unlock(&g_audio_send_lock);
                 break;
             }
             frames += af;
             if (pcm_carry) memmove(buf, buf + n, (size_t)pcm_carry);
+            pthread_mutex_unlock(&g_audio_send_lock);
         } else {
             /* Paused, or connected and awaiting the commanded first START. */
             usleep(1000);
         }
     }
 
-    g_running = false;
+    request_command_stop();
+    bool command_joined = join_command_thread();
     ap2_session_destroy(g_session);
     g_session = NULL;
     free(buf);
     free(ap2_alac_buf);
-    return playback_failed ? 1 : 0;
+    return playback_failed || !command_joined ? 1 : 0;
 }
 
 
@@ -1283,7 +1293,7 @@ static int run_ptp_daemon(cli_config_t *cfg)
 static void print_usage(const char *name)
 {
     printf("cliairplay v%s - Unified AirPlay streaming CLI\n\n", VERSION);
-    printf("Usage: %s [options] <host_ip> <filename ('-' for stdin)>\n\n", name);
+    printf("Usage: %s [options] <host_ip> [filename ('-' for RAOP stdin)]\n\n", name);
     printf("Protocol selection:\n");
     printf("  --protocol <auto|raop|airplay2>  Protocol to use (default: auto).\n");
     printf("                             auto picks RAOP vs AirPlay 2 from the mDNS\n");
@@ -1293,9 +1303,6 @@ static void print_usage(const char *name)
     printf("  --volume <0-100>           Initial volume level\n");
     printf("  --latency <ms>             Playback lead / buffer in ms (default: 2000,\n");
     printf("                             clamped into the device-reported window)\n");
-    printf("  --start-unix-ms <ms>       Start at unix epoch milliseconds (preferred:\n");
-    printf("                             the caller never handles NTP formats; pass the\n");
-    printf("                             SAME value to every member of a sync group)\n");
     printf("  --dacp <id>                DACP ID\n");
     printf("  --activeremote <id>        Active Remote ID\n");
     printf("  --cmdpipe <path>           Named pipe for metadata/commands\n");
@@ -1344,9 +1351,9 @@ static void print_usage(const char *name)
     printf("Examples:\n");
     printf("  # RAOP streaming from stdin:\n");
     printf("  ffmpeg -i song.flac -f s16le -ar 44100 -ac 2 - | %s 192.168.1.50 -\n\n", name);
-    printf("  # AirPlay 2 streaming:\n");
-    printf("  ffmpeg -i song.flac -f s16le -ar 44100 -ac 2 - | \\\n");
-    printf("    %s --protocol airplay2 --auth <creds> --name \"HomePod\" 192.168.1.50 -\n", name);
+    printf("  # AirPlay 2 persistent session (audio starts through --cmdpipe):\n");
+    printf("  %s --protocol airplay2 --auth <creds> --name \"HomePod\" \\\n", name);
+    printf("    --cmdpipe /tmp/cap 192.168.1.50\n");
 }
 
 /* ---- Main ---- */
@@ -1382,7 +1389,6 @@ int main(int argc, char *argv[])
         {"port",         required_argument, 0, 'p'},
         {"volume",       required_argument, 0, 'v'},
         {"latency",      required_argument, 0, 'l'},
-        {"start-unix-ms", required_argument, 0, 1014},
         {"dacp",         required_argument, 0, 'D'},
         {"activeremote", required_argument, 0, 'R'},
         {"cmdpipe",      required_argument, 0, 'C'},
@@ -1433,15 +1439,6 @@ int main(int argc, char *argv[])
         case 'p': cfg.port = atoi(optarg); break;
         case 'v': cfg.volume = atoi(optarg); break;
         case 'l': cfg.latency_ms = atoi(optarg); break;
-        case 1014: {
-            /* Group start as plain unix epoch milliseconds; converted to the
-             * NTP fixed-point (unix seconds << 32 | frac) used internally so
-             * callers never handle NTP formats. */
-            uint64_t ms = 0;
-            sscanf(optarg, "%" PRIu64, &ms);
-            cfg.ntp_start = ((ms / 1000) << 32) | (((ms % 1000) << 32) / 1000);
-            break;
-        }
         case 'D': cfg.dacp_id = optarg; break;
         case 'R': cfg.active_remote = optarg; break;
         case 'C': cfg.cmdpipe = optarg; break;
@@ -1533,8 +1530,8 @@ int main(int argc, char *argv[])
         return rc;
     }
 
-    /* Validate required args */
-    if (!cfg.host || !cfg.audio_source) {
+    /* Validate the common positional argument before route resolution. */
+    if (!cfg.host) {
         print_usage(argv[0]);
         return 1;
     }
@@ -1566,16 +1563,30 @@ int main(int argc, char *argv[])
            (!cfg.route.use_raop && cfg.route.ptp) ? "ptp" : "ntp");
     fflush(stdout);
 
+    if (cfg.protocol == PROTO_RAOP && !cfg.audio_source) {
+        status_error("RAOP requires an audio filename or '-' for stdin");
+        return 1;
+    }
+    if (cfg.protocol == PROTO_AIRPLAY2 && !cfg.cmdpipe) {
+        status_error("AirPlay 2 requires --cmdpipe");
+        return 1;
+    }
+    if (cfg.protocol == PROTO_AIRPLAY2 && cfg.audio_source) {
+        status_error("AirPlay 2 audio must be provided by cmdpipe PREPARE");
+        return 1;
+    }
+
     /* Setup signal handlers */
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
     signal(SIGPIPE, SIG_IGN);
 
-    /* Open audio source */
-    if (strcmp(cfg.audio_source, "-") == 0) {
+    /* RAOP retains its direct audio input. AirPlay 2 receives every generation
+     * from the AUDIO path supplied with cmdpipe PREPARE. */
+    if (cfg.protocol == PROTO_RAOP && strcmp(cfg.audio_source, "-") == 0) {
         infile = fileno(stdin);
-        LOG_INFO("Reading audio from stdin");
-    } else {
+        LOG_INFO("Reading RAOP audio from stdin");
+    } else if (cfg.protocol == PROTO_RAOP) {
         struct stat st;
         bool is_fifo = false;
         if (stat(cfg.audio_source, &st) == 0) {
@@ -1604,30 +1615,27 @@ int main(int argc, char *argv[])
                 return 1;
             }
         }
-        int thread_result = pthread_create(
-            &g_cmdpipe_thread, NULL, cmdpipe_reader_thread, &cfg);
-        if (thread_result == 0)
-            g_cmdpipe_started = true;
-        else
-            LOG_ERROR("Failed to start command pipe thread: %s",
-                      strerror(thread_result));
     }
 
-    /* Run the selected protocol. The RAOP path drains the audio source into
-     * the legacy input ring; the AirPlay 2 path hands the source to the
-     * session engine as generation 0 instead. */
+    /* RAOP starts its command reader before connecting, preserving its existing
+     * behavior. AirPlay 2 starts it only after its session engine is ready. */
     int result;
     if (cfg.protocol == PROTO_RAOP) {
+        if (!start_command_thread(&cfg)) {
+            result = 1;
+            goto cleanup;
+        }
         unsigned in_byte_rate =
             (unsigned)((cfg.bit_depth <= 16 ? 2 : 4) * cfg.channels *
                        cfg.sample_rate);
         input_ring_start(infile, in_byte_rate, cfg.latency_ms + 2000);
         result = run_raop(&cfg, infile);
     } else {
-        result = run_airplay2(&cfg, infile);
+        result = run_airplay2(&cfg);
     }
 
     /* Cleanup */
+cleanup:
     request_command_stop();
     if (!join_command_thread()) return 1;
     struct ap2cl_s *ap2_client = atomic_exchange(&g_ap2cl, NULL);

--- a/src/raop_session.c
+++ b/src/raop_session.c
@@ -1,0 +1,67 @@
+#include "raop_session.h"
+
+#include "raop_client.h"
+
+#define RAOP_SESSION_MIN_START_LEAD_MS 200
+
+static uint64_t commanded_audible_ntp(uint64_t start_unix_ms)
+{
+    uint64_t start_ntp = start_unix_ms
+        ? ((start_unix_ms / 1000) << 32) |
+              (((start_unix_ms % 1000) << 32) / 1000)
+        : 0;
+    uint64_t min_start =
+        raopcl_get_ntp(NULL) + MS2NTP(RAOP_SESSION_MIN_START_LEAD_MS);
+    return start_ntp < min_start ? min_start : start_ntp;
+}
+
+bool raop_session_commit(struct raopcl_s *client, uint64_t start_unix_ms)
+{
+    if (!client) return false;
+
+    raop_state_t state = raopcl_state(client);
+    if (state != RAOP_STREAMING && state != RAOP_FLUSHED) return false;
+    /* Generation switches discard old backlog. pause() would preserve one
+     * latency window and replay it before the new generation. */
+    raopcl_stop(client);
+    if (state == RAOP_STREAMING) {
+        if (!raopcl_flush(client)) return false;
+    }
+
+    uint64_t audible_ntp = commanded_audible_ntp(start_unix_ms);
+    uint64_t latency_ntp =
+        TS2NTP(raopcl_latency(client), raopcl_sample_rate(client));
+    return raopcl_start_at(client, audible_ntp - latency_ntp);
+}
+
+bool raop_session_standby(struct raopcl_s *client)
+{
+    if (!client) return false;
+    raop_state_t state = raopcl_state(client);
+    if (state != RAOP_STREAMING && state != RAOP_FLUSHED) return false;
+    raopcl_stop(client);
+    if (state == RAOP_FLUSHED) return true;
+    return raopcl_flush(client);
+}
+
+bool raop_session_pause(struct raopcl_s *client)
+{
+    if (!client) return false;
+    raop_state_t state = raopcl_state(client);
+    if (state == RAOP_FLUSHED) return true;
+    if (state != RAOP_STREAMING) return false;
+    raopcl_pause(client);
+    return raopcl_flush(client);
+}
+
+bool raop_session_resume(struct raopcl_s *client)
+{
+    if (!client) return false;
+    raop_state_t state = raopcl_state(client);
+    if (state != RAOP_FLUSHED && state != RAOP_STREAMING) return false;
+
+    uint64_t audible_ntp = commanded_audible_ntp(0);
+    uint64_t latency_ntp =
+        TS2NTP(raopcl_latency(client), raopcl_sample_rate(client));
+    return raopcl_start_at(client, audible_ntp - latency_ntp);
+}

--- a/src/raop_session.h
+++ b/src/raop_session.h
@@ -1,5 +1,5 @@
-#ifndef __RAOP_SESSION_H_
-#define __RAOP_SESSION_H_
+#ifndef RAOP_SESSION_H
+#define RAOP_SESSION_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -20,4 +20,4 @@ bool raop_session_pause(struct raopcl_s *client);
 /* Resume a paused generation without discarding libraop's retained backlog. */
 bool raop_session_resume(struct raopcl_s *client);
 
-#endif /* __RAOP_SESSION_H_ */
+#endif /* RAOP_SESSION_H */

--- a/src/raop_session.h
+++ b/src/raop_session.h
@@ -1,0 +1,23 @@
+#ifndef __RAOP_SESSION_H_
+#define __RAOP_SESSION_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+struct raopcl_s;
+
+/* Commit a commanded generation on an existing RAOP connection. The command
+ * carries the audible first-sample unix time; 0 or stale values use a safe
+ * ASAP lead. A currently streaming generation is flushed before re-anchoring. */
+bool raop_session_commit(struct raopcl_s *client, uint64_t start_unix_ms);
+
+/* Silence playback while preserving the RAOP connection for a later START. */
+bool raop_session_standby(struct raopcl_s *client);
+
+/* Pause and retain the current generation's backlog for ACTION=PLAY. */
+bool raop_session_pause(struct raopcl_s *client);
+
+/* Resume a paused generation without discarding libraop's retained backlog. */
+bool raop_session_resume(struct raopcl_s *client);
+
+#endif /* __RAOP_SESSION_H_ */

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -22,11 +23,14 @@ log_level raop_loglevel = lSILENCE;
 
 void ap2cl_test_lock_mrp(struct ap2cl_s *p);
 void ap2cl_test_unlock_mrp(struct ap2cl_s *p);
+void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd);
+void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p);
 
 typedef struct {
     atomic_bool ready;
     atomic_bool primed;
     int commit_count;
+    int stop_count;
     uint64_t start_unix_ms;
 } session_test_state_t;
 
@@ -52,7 +56,8 @@ static void session_test_resume(void *transport)
 
 static void session_test_stop(void *transport)
 {
-    (void)transport;
+    session_test_state_t *state = transport;
+    state->stop_count++;
 }
 
 static void session_test_status(const char *line)
@@ -261,6 +266,151 @@ static void test_stdin_generation_uses_command_path(void)
     assert(close(saved_stdin) == 0);
 }
 
+static void test_standby_keeps_session_reusable(void)
+{
+    static const uint8_t audio[] = {0x20, 0x21, 0x22, 0x23};
+    char first_path[] = "/tmp/cliairplay-standby-first.XXXXXX";
+    char second_path[] = "/tmp/cliairplay-standby-second.XXXXXX";
+    int first_fd = mkstemp(first_path);
+    int second_fd = mkstemp(second_path);
+    assert(first_fd >= 0);
+    assert(second_fd >= 0);
+    assert(write(first_fd, audio, sizeof(audio)) == (ssize_t)sizeof(audio));
+    assert(write(second_fd, audio, sizeof(audio)) == (ssize_t)sizeof(audio));
+    assert(close(first_fd) == 0);
+    assert(close(second_fd) == 0);
+
+    session_test_state_t state = {0};
+    atomic_init(&state.ready, false);
+    atomic_init(&state.primed, false);
+    session_status_state = &state;
+    ap2_session_ops_t ops = {
+        .quiesce = session_test_quiesce,
+        .commit = session_test_commit,
+        .resume = session_test_resume,
+        .stop = session_test_stop,
+        .status = session_test_status,
+        .transport = &state,
+    };
+    struct ap2_session_s *session =
+        ap2_session_create(&ops, 1000, 1, 0);
+    assert(session);
+
+    ap2_generation_t first = {
+        .number = 0,
+        .audio_path = first_path,
+    };
+    assert(ap2_session_prepare(session, &first));
+    assert(ap2_session_start(session, 0, 1700000000000ULL));
+    assert(ap2_session_standby(session));
+    assert(state.stop_count == 1);
+    assert(ap2_session_state(session) == AP2_SESSION_STANDBY);
+
+    ap2_generation_t second = {
+        .number = 1,
+        .audio_path = second_path,
+    };
+    assert(ap2_session_prepare(session, &second));
+    assert(ap2_session_start(session, 1, 1700000005000ULL));
+    assert(state.commit_count == 2);
+    assert(ap2_session_active_generation(session) == 1);
+    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
+
+    ap2_session_destroy(session);
+    session_status_state = NULL;
+    assert(unlink(first_path) == 0);
+    assert(unlink(second_path) == 0);
+}
+
+typedef struct {
+    int fd;
+    int request_count;
+    bool ok;
+} rtsp_peer_t;
+
+static void *run_rtsp_flush_peer(void *arg)
+{
+    rtsp_peer_t *peer = arg;
+    peer->ok = true;
+    for (int request = 0; request < 2; request++) {
+        char buffer[2048] = {0};
+        size_t fill = 0;
+        while (!strstr(buffer, "\r\n\r\n")) {
+            ssize_t n = read(peer->fd, buffer + fill,
+                             sizeof(buffer) - fill - 1);
+            if (n <= 0) {
+                peer->ok = false;
+                return NULL;
+            }
+            fill += (size_t)n;
+            if (fill >= sizeof(buffer) - 1) {
+                peer->ok = false;
+                return NULL;
+            }
+        }
+        int cseq = 0;
+        char *cseq_header = strstr(buffer, "\r\nCSeq: ");
+        if (strncmp(buffer, "FLUSH ", 6) != 0 || !cseq_header ||
+            sscanf(cseq_header, "\r\nCSeq: %d", &cseq) != 1) {
+            peer->ok = false;
+            return NULL;
+        }
+        peer->request_count++;
+        char response[96];
+        int response_len = snprintf(
+            response, sizeof(response),
+            "RTSP/1.0 200 OK\r\nCSeq: %d\r\nContent-Length: 0\r\n\r\n",
+            cseq);
+        if (write(peer->fd, response, (size_t)response_len) != response_len) {
+            peer->ok = false;
+            return NULL;
+        }
+    }
+    return NULL;
+}
+
+static void test_native_standby_keeps_rtsp_session_reusable(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    rtsp_peer_t peer = {
+        .fd = sockets[1],
+    };
+    pthread_t peer_thread;
+    assert(pthread_create(
+               &peer_thread, NULL, run_rtsp_flush_peer, &peer) == 0);
+
+    ap2_device_info_t device = {
+        .name = "standby test",
+        .address = "127.0.0.1",
+        .port = 7000,
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+    assert(ap2cl_start(client, 1700000000000ULL));
+
+    ap2cl_standby(client);
+    assert(ap2cl_state(client) == AP2_CONNECTED);
+    assert(ap2cl_warm_flush(client, 1700000005000ULL));
+    assert(ap2cl_state(client) == AP2_STREAMING);
+
+    assert(pthread_join(peer_thread, NULL) == 0);
+    assert(peer.ok);
+    assert(peer.request_count == 2);
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+}
+
 typedef struct {
     struct ap2cl_s *client;
     atomic_bool done;
@@ -349,6 +499,8 @@ int main(void)
     test_generation_zero_requires_prepare_then_start();
     test_idle_fifo_does_not_block_shutdown();
     test_stdin_generation_uses_command_path();
+    test_standby_keeps_session_reusable();
+    test_native_standby_keeps_rtsp_session_reusable();
 
     ap2_device_info_t device = {
         .name = "test",

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -200,6 +200,67 @@ static void test_idle_fifo_does_not_block_shutdown(void)
     assert(unlink(path) == 0);
 }
 
+static void test_stdin_generation_uses_command_path(void)
+{
+    static const uint8_t audio[] = {
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+    };
+    int input[2];
+    assert(pipe(input) == 0);
+    int saved_stdin = dup(STDIN_FILENO);
+    assert(saved_stdin >= 0);
+    assert(dup2(input[0], STDIN_FILENO) == STDIN_FILENO);
+    assert(close(input[0]) == 0);
+
+    session_test_state_t state = {0};
+    atomic_init(&state.ready, false);
+    atomic_init(&state.primed, false);
+    session_status_state = &state;
+    ap2_session_ops_t ops = {
+        .quiesce = session_test_quiesce,
+        .commit = session_test_commit,
+        .resume = session_test_resume,
+        .stop = session_test_stop,
+        .status = session_test_status,
+        .transport = &state,
+    };
+    struct ap2_session_s *session =
+        ap2_session_create(&ops, 1000, 500, 0);
+    assert(session);
+    ap2_generation_t generation = {
+        .number = 0,
+        .audio_path = "-",
+    };
+    assert(ap2_session_prepare(session, &generation));
+    assert(write(input[1], audio, sizeof(audio)) == (ssize_t)sizeof(audio));
+    assert(close(input[1]) == 0);
+    for (int i = 0;
+         i < 200 && (!atomic_load(&state.ready) ||
+                     !atomic_load(&state.primed));
+         i++)
+        usleep(5000);
+    assert(atomic_load(&state.ready));
+    assert(atomic_load(&state.primed));
+    assert(state.commit_count == 0);
+    assert(ap2_session_start(session, 0, 1700000000000ULL));
+    ap2_generation_t overlapping_stdin = {
+        .number = 1,
+        .audio_path = "-",
+    };
+    assert(!ap2_session_prepare(session, &overlapping_stdin));
+
+    uint8_t received[sizeof(audio)] = {0};
+    assert(ap2_session_read(
+               session, received, sizeof(received), 100) ==
+           (int)sizeof(received));
+    assert(memcmp(received, audio, sizeof(audio)) == 0);
+    ap2_session_destroy(session);
+    session_status_state = NULL;
+
+    assert(dup2(saved_stdin, STDIN_FILENO) == STDIN_FILENO);
+    assert(close(saved_stdin) == 0);
+}
+
 typedef struct {
     struct ap2cl_s *client;
     atomic_bool done;
@@ -287,6 +348,7 @@ int main(void)
     test_info_format_tables();
     test_generation_zero_requires_prepare_then_start();
     test_idle_fifo_does_not_block_shutdown();
+    test_stdin_generation_uses_command_path();
 
     ap2_device_info_t device = {
         .name = "test",

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -1,12 +1,18 @@
 #include <assert.h>
+#include <fcntl.h>
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "ap2_bplist.h"
 #include "ap2_client.h"
+#include "ap2_io.h"
+#include "ap2_session.h"
 #include "cross_log.h"
 
 static log_level test_log_level = lSILENCE;
@@ -16,6 +22,183 @@ log_level raop_loglevel = lSILENCE;
 
 void ap2cl_test_lock_mrp(struct ap2cl_s *p);
 void ap2cl_test_unlock_mrp(struct ap2cl_s *p);
+
+typedef struct {
+    atomic_bool ready;
+    atomic_bool primed;
+    int commit_count;
+    uint64_t start_unix_ms;
+} session_test_state_t;
+
+static session_test_state_t *session_status_state;
+
+static bool session_test_commit(void *transport, uint64_t start_unix_ms)
+{
+    session_test_state_t *state = transport;
+    state->commit_count++;
+    state->start_unix_ms = start_unix_ms;
+    return true;
+}
+
+static void session_test_quiesce(void *transport)
+{
+    (void)transport;
+}
+
+static void session_test_resume(void *transport)
+{
+    (void)transport;
+}
+
+static void session_test_stop(void *transport)
+{
+    (void)transport;
+}
+
+static void session_test_status(const char *line)
+{
+    if (strstr(line, "[STATUS] ready generation=0"))
+        atomic_store(&session_status_state->ready, true);
+    if (strstr(line, "[STATUS] primed generation=0"))
+        atomic_store(&session_status_state->primed, true);
+}
+
+static void test_generation_zero_requires_prepare_then_start(void)
+{
+    static const uint8_t audio[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    };
+    char path[] = "/tmp/cliairplay-session-test.XXXXXX";
+    int fd = mkstemp(path);
+    assert(fd >= 0);
+    assert(write(fd, audio, sizeof(audio)) == (ssize_t)sizeof(audio));
+    assert(close(fd) == 0);
+
+    session_test_state_t state = {0};
+    atomic_init(&state.ready, false);
+    atomic_init(&state.primed, false);
+    session_status_state = &state;
+    ap2_session_ops_t ops = {
+        .quiesce = session_test_quiesce,
+        .commit = session_test_commit,
+        .resume = session_test_resume,
+        .stop = session_test_stop,
+        .status = session_test_status,
+        .transport = &state,
+    };
+    struct ap2_session_s *session =
+        ap2_session_create(&ops, 1000, 500, 20);
+    assert(session);
+
+    ap2_generation_t generation = {
+        .number = 0,
+        .audio_path = path,
+        .position_ms = 0,
+    };
+    assert(ap2_session_prepare(session, &generation));
+    for (int i = 0;
+         i < 200 && (!atomic_load(&state.ready) ||
+                     !atomic_load(&state.primed));
+         i++)
+        usleep(5000);
+    assert(atomic_load(&state.ready));
+    assert(atomic_load(&state.primed));
+    assert(state.commit_count == 0);
+    assert(ap2_session_state(session) == AP2_SESSION_PREPARING);
+
+    uint8_t received[sizeof(audio)] = {0};
+    assert(ap2_session_read(
+               session, received, sizeof(received), 10) == 0);
+    const uint64_t audible_start = 1770000000123ULL;
+    assert(ap2_session_start(session, 0, audible_start));
+    assert(state.commit_count == 1);
+    assert(state.start_unix_ms == audible_start);
+    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
+
+    char staged_path[] = "/tmp/cliairplay-staged-fifo.XXXXXX";
+    int staged_placeholder = mkstemp(staged_path);
+    assert(staged_placeholder >= 0);
+    assert(close(staged_placeholder) == 0);
+    assert(unlink(staged_path) == 0);
+    assert(mkfifo(staged_path, 0600) == 0);
+    ap2_generation_t staged_generation = {
+        .number = 1,
+        .audio_path = staged_path,
+    };
+    assert(ap2_session_prepare(session, &staged_generation));
+    assert(ap2_session_flush(session, 1));
+    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
+    assert(unlink(staged_path) == 0);
+
+    assert(ap2_session_read(
+               session, received, sizeof(received), 10) ==
+           (int)sizeof(received));
+    assert(memcmp(received, audio, sizeof(audio)) == 0);
+    assert(ap2_session_read(
+               session, received, sizeof(received), 100) == -1);
+    assert(ap2_session_state(session) == AP2_SESSION_IDLE);
+    usleep(30000);
+    ap2_session_poll(session);
+    assert(ap2_session_state(session) == AP2_SESSION_ENDED);
+
+    ap2_session_destroy(session);
+    session_status_state = NULL;
+    assert(unlink(path) == 0);
+}
+
+static void test_idle_fifo_does_not_block_shutdown(void)
+{
+    char path[] = "/tmp/cliairplay-session-fifo.XXXXXX";
+    int placeholder = mkstemp(path);
+    assert(placeholder >= 0);
+    assert(close(placeholder) == 0);
+    assert(unlink(path) == 0);
+    assert(mkfifo(path, 0600) == 0);
+
+    session_test_state_t state = {0};
+    atomic_init(&state.ready, false);
+    atomic_init(&state.primed, false);
+    session_status_state = &state;
+    ap2_session_ops_t ops = {
+        .quiesce = session_test_quiesce,
+        .commit = session_test_commit,
+        .resume = session_test_resume,
+        .stop = session_test_stop,
+        .status = session_test_status,
+        .transport = &state,
+    };
+    struct ap2_session_s *session =
+        ap2_session_create(&ops, 1000, 500, 0);
+    assert(session);
+    ap2_generation_t generation = {
+        .number = 0,
+        .audio_path = path,
+    };
+    assert(ap2_session_prepare(session, &generation));
+
+    uint64_t started = ap2_io_monotonic_ms();
+    assert(ap2_session_flush(session, 0));
+    assert(ap2_io_monotonic_ms() - started < 1000);
+    assert(ap2_session_state(session) == AP2_SESSION_IDLE);
+    ap2_session_destroy(session);
+
+    atomic_store(&state.ready, false);
+    session = ap2_session_create(&ops, 1000, 500, 0);
+    assert(session);
+    assert(ap2_session_prepare(session, &generation));
+    int writer = open(path, O_WRONLY);
+    assert(writer >= 0);
+    for (int i = 0; i < 200 && !atomic_load(&state.ready); i++)
+        usleep(5000);
+    assert(atomic_load(&state.ready));
+
+    started = ap2_io_monotonic_ms();
+    ap2_session_destroy(session);
+    assert(ap2_io_monotonic_ms() - started < 1000);
+    session_status_state = NULL;
+    assert(close(writer) == 0);
+    assert(unlink(path) == 0);
+}
 
 typedef struct {
     struct ap2cl_s *client;
@@ -102,6 +285,8 @@ static void test_info_format_tables(void)
 int main(void)
 {
     test_info_format_tables();
+    test_generation_zero_requires_prepare_then_start();
+    test_idle_fifo_does_not_block_shutdown();
 
     ap2_device_info_t device = {
         .name = "test",

--- a/tests/test_ap2_raop_lifecycle.c
+++ b/tests/test_ap2_raop_lifecycle.c
@@ -25,6 +25,9 @@ log_level raop_loglevel = lSILENCE;
 
 struct raopcl_s {
     int id;
+    raop_state_t state;
+    uint32_t latency;
+    uint32_t sample_rate;
 };
 
 typedef enum {
@@ -50,6 +53,10 @@ static struct {
     int disconnects;
     int destroys;
     int destroy_counts[MAX_CLIENTS];
+    int stops;
+    int flushes;
+    int starts;
+    struct raopcl_s *last_transport_client;
 } mock;
 
 static void record_event(event_type_t type, int client_id)
@@ -96,6 +103,9 @@ struct raopcl_s *ap2_test_raopcl_create(
     int id = ++mock.creates;
     if (id >= MAX_CLIENTS) return NULL;
     mock.clients[id].id = id;
+    mock.clients[id].state = RAOP_DOWN;
+    mock.clients[id].latency = 11025;
+    mock.clients[id].sample_rate = 44100;
     record_event(EVENT_CREATE, id);
     return &mock.clients[id];
 }
@@ -110,8 +120,10 @@ bool ap2_test_raopcl_connect(
 
     record_event(EVENT_CONNECT, client->id);
     int call = mock.connect_calls++;
-    return call < (int)mock.connect_result_count
+    bool connected = call < (int)mock.connect_result_count
         ? mock.connect_results[call] : false;
+    if (connected) client->state = RAOP_FLUSHED;
+    return connected;
 }
 
 bool ap2_test_raopcl_disconnect(struct raopcl_s *client)
@@ -127,6 +139,51 @@ bool ap2_test_raopcl_destroy(struct raopcl_s *client)
     mock.destroy_counts[client->id]++;
     record_event(EVENT_DESTROY, client->id);
     return true;
+}
+
+raop_state_t ap2_test_raopcl_state(struct raopcl_s *client)
+{
+    return client->state;
+}
+
+void ap2_test_raopcl_stop(struct raopcl_s *client)
+{
+    mock.stops++;
+    mock.last_transport_client = client;
+}
+
+bool ap2_test_raopcl_flush(struct raopcl_s *client)
+{
+    mock.flushes++;
+    mock.last_transport_client = client;
+    client->state = RAOP_FLUSHED;
+    return true;
+}
+
+bool ap2_test_raopcl_start_at(
+    struct raopcl_s *client, uint64_t start_time)
+{
+    (void)start_time;
+    mock.starts++;
+    mock.last_transport_client = client;
+    client->state = RAOP_STREAMING;
+    return true;
+}
+
+uint64_t ap2_test_raopcl_get_ntp(struct ntp_s *ntp)
+{
+    (void)ntp;
+    return ((uint64_t)1700000000) << 32;
+}
+
+uint32_t ap2_test_raopcl_latency(struct raopcl_s *client)
+{
+    return client->latency;
+}
+
+uint32_t ap2_test_raopcl_sample_rate(struct raopcl_s *client)
+{
+    return client->sample_rate;
 }
 
 static struct ap2cl_s *create_test_client(void)
@@ -221,10 +278,48 @@ static bool test_final_cleanup_order(void)
     return true;
 }
 
+static bool test_standby_reuses_raop_compatible_connection(void)
+{
+    reset_mock();
+    mock.connect_results[0] = true;
+    mock.connect_result_count = 1;
+
+    struct ap2cl_s *client = create_test_client();
+    CHECK(client != NULL);
+    CHECK(ap2cl_connect(client));
+    struct raopcl_s *transport_client = &mock.clients[1];
+    CHECK(ap2cl_start(client, 1700000003000ULL));
+    CHECK(ap2cl_state(client) == AP2_STREAMING);
+    CHECK(mock.starts == 1);
+
+    ap2cl_standby(client);
+    CHECK(ap2cl_state(client) == AP2_CONNECTED);
+    CHECK(mock.last_transport_client == transport_client);
+    CHECK(mock.stops == 1);
+    CHECK(mock.flushes == 1);
+    CHECK(mock.disconnects == 0);
+    CHECK(mock.destroys == 0);
+
+    CHECK(ap2cl_warm_flush(client, 1700000008000ULL));
+    CHECK(ap2cl_state(client) == AP2_STREAMING);
+    CHECK(mock.last_transport_client == transport_client);
+    CHECK(mock.stops == 2);
+    CHECK(mock.flushes == 1);
+    CHECK(mock.starts == 2);
+    CHECK(mock.disconnects == 0);
+    CHECK(mock.destroys == 0);
+
+    CHECK(ap2cl_destroy(client));
+    CHECK(mock.disconnects == 1);
+    CHECK(mock.destroys == 1);
+    return true;
+}
+
 int main(void)
 {
     if (!test_disconnect_reconnect_and_failure_cleanup() ||
-        !test_final_cleanup_order())
+        !test_final_cleanup_order() ||
+        !test_standby_reuses_raop_compatible_connection())
         return 1;
     puts("AP2 RAOP reconnect lifecycle tests passed");
     return 0;

--- a/tests/test_raop_session.c
+++ b/tests/test_raop_session.c
@@ -1,0 +1,155 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "raop_client.h"
+#include "raop_session.h"
+
+struct raopcl_s {
+    raop_state_t state;
+    uint32_t latency;
+    uint32_t sample_rate;
+};
+
+static uint64_t mock_now;
+static struct raopcl_s *last_client;
+static uint64_t last_start;
+static int pause_calls;
+static int stop_calls;
+static int flush_calls;
+static int start_calls;
+static bool flush_result;
+
+uint64_t raopcl_get_ntp(struct ntp_s *ntp)
+{
+    (void)ntp;
+    return mock_now;
+}
+
+raop_state_t raopcl_state(struct raopcl_s *client)
+{
+    return client->state;
+}
+
+uint32_t raopcl_latency(struct raopcl_s *client)
+{
+    return client->latency;
+}
+
+uint32_t raopcl_sample_rate(struct raopcl_s *client)
+{
+    return client->sample_rate;
+}
+
+void raopcl_pause(struct raopcl_s *client)
+{
+    last_client = client;
+    pause_calls++;
+}
+
+void raopcl_stop(struct raopcl_s *client)
+{
+    last_client = client;
+    stop_calls++;
+}
+
+bool raopcl_flush(struct raopcl_s *client)
+{
+    last_client = client;
+    flush_calls++;
+    if (flush_result) client->state = RAOP_FLUSHED;
+    return flush_result;
+}
+
+bool raopcl_start_at(struct raopcl_s *client, uint64_t start_time)
+{
+    last_client = client;
+    last_start = start_time;
+    start_calls++;
+    return true;
+}
+
+static uint64_t unix_ms_to_ntp(uint64_t ms)
+{
+    return ((ms / 1000) << 32) | (((ms % 1000) << 32) / 1000);
+}
+
+static void reset_mocks(void)
+{
+    last_client = NULL;
+    last_start = 0;
+    pause_calls = 0;
+    stop_calls = 0;
+    flush_calls = 0;
+    start_calls = 0;
+    flush_result = true;
+}
+
+int main(void)
+{
+    struct raopcl_s client = {
+        .state = RAOP_FLUSHED,
+        .latency = 11025,
+        .sample_rate = 44100,
+    };
+    const uint64_t now_ms = 1700000000000ULL;
+    const uint64_t future_ms = now_ms + 3000;
+    mock_now = unix_ms_to_ntp(now_ms);
+    reset_mocks();
+
+    assert(raop_session_commit(&client, future_ms));
+    assert(last_client == &client);
+    assert(pause_calls == 0);
+    assert(stop_calls == 1);
+    assert(flush_calls == 0);
+    assert(start_calls == 1);
+    assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
+           unix_ms_to_ntp(future_ms));
+
+    client.state = RAOP_STREAMING;
+    const uint64_t replacement_ms = future_ms + 5000;
+    assert(raop_session_commit(&client, replacement_ms));
+    assert(last_client == &client);
+    assert(pause_calls == 0);
+    assert(stop_calls == 2);
+    assert(flush_calls == 1);
+    assert(start_calls == 2);
+    assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
+           unix_ms_to_ntp(replacement_ms));
+
+    client.state = RAOP_FLUSHED;
+    assert(raop_session_commit(&client, 0));
+    assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
+           mock_now + MS2NTP(200));
+
+    client.state = RAOP_STREAMING;
+    assert(raop_session_standby(&client));
+    assert(client.state == RAOP_FLUSHED);
+    assert(stop_calls == 4);
+    int stops_after_standby = stop_calls;
+    int flushes_after_standby = flush_calls;
+    assert(raop_session_standby(&client));
+    assert(stop_calls == stops_after_standby + 1);
+    assert(flush_calls == flushes_after_standby);
+
+    client.state = RAOP_STREAMING;
+    assert(raop_session_pause(&client));
+    assert(pause_calls == 1);
+    assert(client.state == RAOP_FLUSHED);
+    int stops_before_resume = stop_calls;
+    assert(raop_session_resume(&client));
+    assert(stop_calls == stops_before_resume);
+    assert(start_calls == 4);
+    assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
+           mock_now + MS2NTP(200));
+
+    client.state = RAOP_DOWN;
+    assert(!raop_session_commit(&client, future_ms));
+    assert(!raop_session_standby(&client));
+    assert(!raop_session_pause(&client));
+    assert(!raop_session_resume(&client));
+
+    puts("RAOP command-only session tests passed");
+    return 0;
+}

--- a/tests/test_raop_session.c
+++ b/tests/test_raop_session.c
@@ -133,6 +133,15 @@ int main(void)
     assert(stop_calls == stops_after_standby + 1);
     assert(flush_calls == flushes_after_standby);
 
+    /* Standby keeps the same connected libraop client reusable. A later
+     * commanded START only re-anchors it; no reconnect API is involved. */
+    const uint64_t post_standby_ms = replacement_ms + 5000;
+    assert(raop_session_commit(&client, post_standby_ms));
+    assert(last_client == &client);
+    assert(start_calls == 4);
+    assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
+           unix_ms_to_ntp(post_standby_ms));
+
     client.state = RAOP_STREAMING;
     assert(raop_session_pause(&client));
     assert(pause_calls == 1);
@@ -140,7 +149,7 @@ int main(void)
     int stops_before_resume = stop_calls;
     assert(raop_session_resume(&client));
     assert(stop_calls == stops_before_resume);
-    assert(start_calls == 4);
+    assert(start_calls == 5);
     assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
            mock_now + MS2NTP(200));
 


### PR DESCRIPTION
## Summary
- connect every AirPlay streaming protocol without argv audio and require cmdpipe `PREPARE` then `START` for every generation
- keep legacy RAOP and RAOP-compatible AirPlay 2 sessions warm across latency-correct starts and generation replacements
- preserve commanded stdin/FIFO sources and legacy RAOP pause/resume behavior
- support reusable `STANDBY` sessions across legacy RAOP, RAOP-compatible AirPlay 2, and native AirPlay 2
- add a protocol-neutral debugging script and remove the `--start-unix-ms` CLI option

## Tests
- `make STATIC=1 -j8`
- `make STATIC=1 test` (16 test groups, including standby/restart coverage)