### PR TITLE
Fix silent playback on Samsung AirPlay speakers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -96,17 +96,20 @@ Connect sequence (`ap2_native_connect()`):
    clock ID and advertised address. NTP sessions carry
    `timingProtocol=NTP` + `timingPort`. The response's `eventPort` is opened
    as a keep-open reverse TCP connection.
-6. **Stream SETUP** — a `streams` array entry: `type` 96,
-   `audioFormat` (§7), `ct=2` (ALAC), `spf=352`, `shk` (the 32-byte audio
-   key), our `controlPort` and `dataPort`,
+6. **RECORD, then Stream SETUP** — RECORD is sent first, on the session URL
+   with an empty body, before the stream SETUP; this matches the order used
+   by Apple senders and owntone, and some third-party receivers render
+   silence without it (§11). The stream SETUP is a `streams` array entry:
+   `type` 96, `audioFormat` (§7), `ct=2` (ALAC), `spf=352`, `shk` (the
+   32-byte audio key), our `controlPort` and `dataPort`,
    `latencyMin`/`latencyMax`. The response is parsed **by key** with a real
    binary-plist reader (`ap2_bplist`) — receivers typically serialize
    `controlPort` before `dataPort`, so positional parsing would send audio to
    the control port and mute the device. The receiver's reported
    `latencyMin`/`latencyMax` (when present) clamp our lead and size the
    pacing window (§6).
-7. **RECORD**, then for PTP sessions **SETPEERS** (a bare plist array
-   `[receiver, us]`) and the same peer list handed to the PTP engine.
+7. For PTP sessions, **SETPEERS** (a bare plist array `[receiver, us]`) and
+   the same peer list handed to the PTP engine.
 
 The audio key (`shk`) is the first 32 bytes of the pairing shared secret —
 the raw X25519 secret for pair-verify, `SHA512(S)[:32]` for transient.
@@ -549,3 +552,8 @@ callers:
 - **Sonos withholds audio until metadata arrives** (§10).
 - **Cross-VLAN**: HomeKit pairing and PTP do not survive subnet boundaries;
   same-L2 is assumed.
+- **Samsung AirPlay 2 receivers require RECORD before the stream SETUP.** The
+  Music Frame (HW-LS60D) 200-ACKs the session-SETUP → stream-SETUP → RECORD
+  order but renders silence; moving RECORD immediately before the stream
+  SETUP — the order Apple senders and owntone already use — fixes it, with
+  no regression seen on Apple TV 4K or Sonos Era 100 (§3).

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -1150,7 +1150,13 @@ static bool ap2_native_connect(struct ap2cl_s *p)
         }
     }
 
-    /* 5. Stream SETUP with streams array (BEFORE RECORD per Apple TV expectations) */
+    /* 5. RECORD (on the session URL, below), then stream SETUP with the
+     * streams array. RECORD before the stream SETUP matches the order used
+     * by Apple senders and owntone, and is REQUIRED by Samsung AirPlay 2
+     * receivers (e.g. Music Frame HW-LS60D), which 200-ACK the entire session
+     * but render silence otherwise; verified on hardware 2026-07-24 (A/B/A on
+     * the Frame; no regression on Apple TV 4K or Sonos Era, warm seek
+     * intact). */
     /* The shk audio key must be the first 32 bytes of the pairing shared
      * secret: that is also the key the audio sender encrypts with, and the
      * receiver uses shk to decrypt the RTP payloads. */
@@ -1213,6 +1219,21 @@ static bool ap2_native_connect(struct ap2cl_s *p)
 
     plist_len = ap2_plist_serialize(ssp, &plist_data);
     ap2_plist_free(ssp);
+
+    /* RECORD on the session URL, before the stream SETUP (see the note
+     * above): required for Samsung AirPlay 2 receivers to actually render
+     * audio. */
+    resp = NULL; resp_len = 0;
+    status = ap2_rtsp_send(p, "RECORD", p->session_url, NULL, 0, NULL, &resp, &resp_len);
+    free(resp);
+    if (status <= 0) {
+        free(plist_data);
+        return false;
+    } else if (status != 200) {
+        LOG_WARN("[AP2] RECORD returned %d", status);
+    } else {
+        LOG_INFO("[AP2] RECORD OK");
+    }
 
     resp = NULL; resp_len = 0;
     status = ap2_rtsp_send(p, "SETUP", p->session_url, plist_data, plist_len,
@@ -1308,19 +1329,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     LOG_INFO("[AP2] Stream SETUP OK");
     free(resp);
 
-    /* 6. RECORD to begin streaming */
-    resp = NULL; resp_len = 0;
-    status = ap2_rtsp_send(p, "RECORD", p->session_url, NULL, 0, NULL, &resp, &resp_len);
-    free(resp);
-    if (status <= 0) {
-        return false;
-    } else if (status != 200) {
-        LOG_WARN("[AP2] RECORD returned %d", status);
-    } else {
-        LOG_INFO("[AP2] RECORD OK");
-    }
-
-    /* 6b. SETPEERS (PTP only): a bare binary-plist array of IP strings
+    /* 6. SETPEERS (PTP only): a bare binary-plist array of IP strings
      * [receiver, us] so the receiver knows the timing group members. */
     if (p->use_ptp) {
         ap2_pl_node *arr = ap2_pl_array();
@@ -1346,7 +1355,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
         ap2_ptp_shared_kick(p->ptp);
     }
 
-    /* 6c. MRP now-playing. Ground-truth capture (DESIGN.md §8) shows a real
+    /* 6b. MRP now-playing. Ground-truth capture (DESIGN.md §8) shows a real
      * sender delivers now-playing over POST /command, NOT the type-130 channel
      * (its type-130 SETUPs never completed a data connection), and pushing state
      * over type-130 competes with /command. So the type-130 channel is OFF by


### PR DESCRIPTION
Samsung AirPlay 2 speakers (e.g. the Samsung Music Frame) accepted the entire session setup but produced no sound: they require the RTSP RECORD request to be sent before the stream SETUP. This is the same order Apple senders and owntone use. Verified on a Samsung Music Frame (HW-LS60D), with no regression on Apple TV 4K and Sonos Era 100 (warm seek/next included).

- Send RECORD before the stream SETUP in the native AirPlay 2 connect sequence (previously sent after, based on an Apple TV assumption that hardware testing disproved)
- Document the ordering requirement in DESIGN.md