### PR TITLE
Add immutable auto release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,99 @@
+name: Auto Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      should_release: ${{ steps.version.outputs.should_release }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate next version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          latest_release="$(
+            gh release list \
+              --repo "$GITHUB_REPOSITORY" \
+              --exclude-drafts \
+              --exclude-pre-releases \
+              --limit 100 \
+              --json tagName,publishedAt \
+              --jq 'map(select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))) | sort_by(.publishedAt) | last | .tagName // ""'
+          )"
+
+          if [[ -z "$latest_release" ]]; then
+            release_tag="v0.1.0"
+            commit_count="$(git rev-list --count HEAD)"
+          else
+            if ! git merge-base --is-ancestor "$latest_release" HEAD; then
+              echo "::error::Latest release $latest_release is not an ancestor of HEAD"
+              exit 1
+            fi
+
+            version="${latest_release#v}"
+            IFS=. read -r major minor patch <<< "$version"
+            release_tag="v${major}.${minor}.$((10#$patch + 1))"
+            commit_count="$(git rev-list --count "${latest_release}..HEAD")"
+          fi
+
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          if (( commit_count == 0 )); then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "No commits found since ${latest_release:-the repository was created}; skipping release."
+            exit 0
+          fi
+
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "Preparing $release_tag from $commit_count new commit(s)."
+
+      - name: Create release tag
+        if: steps.version.outputs.should_release == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          head_sha="$(git rev-parse HEAD)"
+          if git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"; then
+            tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [[ "$tag_sha" != "$head_sha" ]]; then
+              echo "::error::$RELEASE_TAG already points to $tag_sha instead of $head_sha"
+              exit 1
+            fi
+            echo "Reusing $RELEASE_TAG at $head_sha."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$RELEASE_TAG" -m "Release $RELEASE_TAG"
+          git push origin "refs/tags/$RELEASE_TAG"
+
+  release:
+    name: Build and release
+    needs: prepare-release
+    if: needs.prepare-release.outputs.should_release == 'true'
+    uses: ./.github/workflows/build.yml
+    with:
+      release_tag: ${{ needs.prepare-release.outputs.release_tag }}
+    secrets:
+      PRIVILEGED_GITHUB_TOKEN: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,21 @@ on:
     tags: ["v*"]
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Existing v-prefixed tag to build and release"
+        required: true
+        type: string
+    secrets:
+      PRIVILEGED_GITHUB_TOKEN:
+        required: true
 
 permissions:
   contents: read
+
+env:
+  RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
 
 jobs:
   test-updater:
@@ -17,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           persist-credentials: false
       - name: Run updater unit tests
         run: python3 -m unittest discover -s tests -v
@@ -39,6 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           submodules: recursive
       - name: Install cross toolchain
         if: matrix.packages != ''
@@ -85,6 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           submodules: recursive
       - name: Build
         run: |
@@ -112,8 +127,8 @@ jobs:
           if-no-files-found: error
 
   release:
-    # Publish binaries as release assets when a version tag is pushed.
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Publish binaries for tag-based and reusable release runs.
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(inputs.release_tag, 'v')
     needs: [test-updater, build-linux, build-macos]
     runs-on: ubuntu-latest
     permissions:
@@ -137,28 +152,41 @@ jobs:
           chmod +x release/cliairplay-*
           (cd release && sha256sum "${binaries[@]}" > SHA256SUMS)
           ls -la release
+      # gh uploads assets to a temporary draft and publishes only after every
+      # upload succeeds, making the resulting release safe to lock.
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: >
-          gh release create "${{ github.ref_name }}" release/*
+          gh release create "$RELEASE_TAG" release/*
           --repo "${{ github.repository }}"
-          --title "${{ github.ref_name }}"
+          --title "$RELEASE_TAG"
           --generate-notes
+          --verify-tag
 
   verify-release:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(inputs.release_tag, 'v')
     needs: release
     runs-on: ubuntu-22.04
     outputs:
       checksums_sha256: ${{ steps.checksums_digest.outputs.sha256 }}
     steps:
+      - name: Verify release is immutable
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          test "$(
+            gh release view "$RELEASE_TAG" \
+              --repo "${{ github.repository }}" \
+              --json isImmutable \
+              --jq .isImmutable
+          )" = "true"
       - name: Download published assets
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir release
-          gh release download "${{ github.ref_name }}" \
+          gh release download "$RELEASE_TAG" \
             --repo "${{ github.repository }}" \
             --dir release
       - name: Verify asset contract and checksums
@@ -223,7 +251,7 @@ jobs:
 
   server-repo-pr:
     name: Update server release pins
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(inputs.release_tag, 'v')
     needs: verify-release
     runs-on: ubuntu-latest
     permissions:
@@ -245,6 +273,7 @@ jobs:
       - name: Checkout airplay-cli
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           path: airplay-cli
           persist-credentials: false
       - name: Checkout server
@@ -257,7 +286,6 @@ jobs:
           persist-credentials: false
       - name: Update server Dockerfile pins
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
           CHECKSUMS_SHA256: ${{ needs.verify-release.outputs.checksums_sha256 }}
         run: |
           set -euo pipefail
@@ -270,19 +298,19 @@ jobs:
         with:
           token: ${{ secrets.PRIVILEGED_GITHUB_TOKEN }}
           path: server
-          commit-message: Update airplay-cli to ${{ github.ref_name }}
+          commit-message: Update airplay-cli to ${{ env.RELEASE_TAG }}
           # This branch deliberately avoids the server's auto-merge prefixes.
-          branch: bump-airplay-cli-${{ github.ref_name }}
+          branch: bump-airplay-cli-${{ env.RELEASE_TAG }}
           base: dev
           delete-branch: true
-          title: Update airplay-cli to ${{ github.ref_name }}
+          title: Update airplay-cli to ${{ env.RELEASE_TAG }}
           body: |
             # What does this implement/fix?
 
             Updates the server Dockerfile to use the verified
-            [airplay-cli ${{ github.ref_name }} release](https://github.com/music-assistant/airplay-cli/releases/tag/${{ github.ref_name }}).
+            [airplay-cli ${{ env.RELEASE_TAG }} release](https://github.com/music-assistant/airplay-cli/releases/tag/${{ env.RELEASE_TAG }}).
 
-            - Pins `CLIAIRPLAY_VERSION` to `${{ github.ref_name }}`.
+            - Pins `CLIAIRPLAY_VERSION` to `${{ env.RELEASE_TAG }}`.
             - Pins `CLIAIRPLAY_CHECKSUMS_SHA256` to `${{ needs.verify-release.outputs.checksums_sha256 }}`.
             - The release workflow verified the four published binaries and `SHA256SUMS` before opening this PR.
 

--- a/README.md
+++ b/README.md
@@ -240,10 +240,13 @@ libcodecs, libmdns).
 CI (`.github/workflows/build.yml`) cross-builds four targets on every push —
 `linux-x86_64`, `linux-aarch64`, `macos-arm64`, `macos-x86_64` — validates
 `--check` on the natively runnable ones, and uploads the binaries as
-artifacts. Pushing a `v*` tag additionally runs a release job (GitHub Release
-with the four binaries + `SHA256SUMS`). After verifying the published assets,
-CI hashes `SHA256SUMS` and opens or updates a non-auto-merge PR against the
-server `dev` branch with both Dockerfile pins. That step requires the
+artifacts. Pushing a `v*` tag additionally runs a release job. The release is
+published only after the four binaries and `SHA256SUMS` are ready, at which
+point GitHub locks its tag and assets. The manually dispatched **Auto Release**
+workflow calculates the next patch version, creates its tag, and runs the same
+release pipeline with generated release notes. After verifying the published
+assets, CI hashes `SHA256SUMS` and opens or updates a non-auto-merge PR against
+the server `dev` branch with both Dockerfile pins. That step requires the
 `PRIVILEGED_GITHUB_TOKEN` Actions secret to have server write access.
 
 ## Architecture


### PR DESCRIPTION
## Summary

- add a manually dispatched Auto Release workflow that calculates the next patch version and invokes the build/release pipeline
- publish releases only after all binaries and checksums are ready
- verify published releases are immutable before updating server pins
- document the release flow

The repository-level immutable releases setting is already enabled.