### PR TITLE
Inject the release version at build time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,17 @@ jobs:
         if: matrix.packages != ''
         run: sudo apt-get update && sudo apt-get install -y ${{ matrix.packages }}
       - name: Build
-        run: make STATIC=1 CC=${{ matrix.cc }} CXX=${{ matrix.cxx }}
+        run: |
+          # RELEASE_TAG (workflow-level env, see top of file) covers both a
+          # direct `v*` tag push and an Auto Release run: in the latter,
+          # github.ref is the caller's ref (not the tag), so RELEASE_TAG is the
+          # only reliable signal. Other builds (branch pushes, PRs) fall back
+          # to the Makefile's own `git describe`.
+          VERSION_ARGS=()
+          if [[ "$RELEASE_TAG" == v* ]]; then
+            VERSION_ARGS=(VERSION="${RELEASE_TAG#v}")
+          fi
+          make STATIC=1 CC=${{ matrix.cc }} CXX=${{ matrix.cxx }} "${VERSION_ARGS[@]}"
       - name: Validate
         run: |
           bin="bin/cliairplay-linux-${{ matrix.platform }}"
@@ -103,11 +113,20 @@ jobs:
           submodules: recursive
       - name: Build
         run: |
+          # RELEASE_TAG (workflow-level env, see top of file) covers both a
+          # direct `v*` tag push and an Auto Release run: in the latter,
+          # github.ref is the caller's ref (not the tag), so RELEASE_TAG is the
+          # only reliable signal. Other builds (branch pushes, PRs) fall back
+          # to the Makefile's own `git describe`.
+          VERSION_ARGS=()
+          if [[ "$RELEASE_TAG" == v* ]]; then
+            VERSION_ARGS=(VERSION="${RELEASE_TAG#v}")
+          fi
           if [ "${{ matrix.platform }}" = "x86_64" ]; then
             make STATIC=1 CC=clang CXX=clang++ HOST=macos PLATFORM=x86_64 \
-              EXTRA_CFLAGS="-arch x86_64" EXTRA_LDFLAGS="-arch x86_64"
+              EXTRA_CFLAGS="-arch x86_64" EXTRA_LDFLAGS="-arch x86_64" "${VERSION_ARGS[@]}"
           else
-            make STATIC=1 CC=clang CXX=clang++
+            make STATIC=1 CC=clang CXX=clang++ "${VERSION_ARGS[@]}"
           fi
       - name: Validate
         run: |

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,18 @@ CFLAGS  += -Wall -fPIC -ggdb -O2 $(DEFINES) -fdata-sections -ffunction-sections
 CXXFLAGS += -std=gnu++17
 LDFLAGS += -lpthread -ldl -lm -L.
 
+# Version string reported by --check/--help (src/cliairplay.c). CI overrides this
+# with the exact tag (e.g. VERSION=0.3.3) when building a tagged release; local/dev
+# builds fall back to `git describe`. Strip a leading "v" either way since
+# cliairplay.c already prints its own "v" prefix. If git or tags aren't available
+# (shallow clone, no .git) this resolves to empty and the compiled-in literal in
+# cliairplay.c is used instead.
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null)
+VERSION := $(patsubst v%,%,$(VERSION))
+ifneq ($(VERSION),)
+DEFINES += -DCLIAIRPLAY_VERSION='"$(VERSION)"'
+endif
+
 # POSIX shared memory (shm_open/shm_unlink) for the --ptp-daemon shared clock:
 # glibc exposes these via librt; macOS has them in libSystem, so link -lrt on
 # Linux only.

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -41,7 +41,11 @@
 #include "raop_session.h"
 #include "artwork.h"
 
-#define VERSION "0.3.1"
+#define VERSION "0.3.3"
+/* Overridden at build time from the git tag for tagged releases (see Makefile). */
+#ifndef CLIAIRPLAY_VERSION
+#define CLIAIRPLAY_VERSION VERSION
+#endif
 #define AP2_FRAMES_PER_CHUNK 352
 
 /* Protocol selection (resolved, concrete protocol used for dispatch). */
@@ -1290,7 +1294,7 @@ static int run_ptp_daemon(cli_config_t *cfg)
 
 static void print_usage(const char *name)
 {
-    printf("cliairplay v%s - Unified AirPlay streaming CLI\n\n", VERSION);
+    printf("cliairplay v%s - Unified AirPlay streaming CLI\n\n", CLIAIRPLAY_VERSION);
     printf("Usage: %s [options] --cmdpipe <path> <host_ip>\n\n", name);
     printf("Protocol selection:\n");
     printf("  --protocol <auto|raop|airplay2>  Protocol to use (default: auto).\n");
@@ -1466,7 +1470,7 @@ int main(int argc, char *argv[])
         case 1013: pair_setup_mode = true; break;
         case 1012: cfg.ptp_shared = true; break;
         case 1002:
-            printf("cliairplay v%s check\n", VERSION);
+            printf("cliairplay v%s check\n", CLIAIRPLAY_VERSION);
             return 0;
         case 1003:
             pairing_mode = true;


### PR DESCRIPTION
## Summary

- `cliairplay.c`'s `VERSION` macro was hardcoded and never bumped past `0.3.1`, even though `v0.3.2` and `v0.3.3` were tagged and released since — every released binary has misreported its version via `--check`/`--help`.
- The Makefile now exposes an overridable `VERSION` (defaults to `git describe --tags --always --dirty`, with a leading `v` stripped) and injects it as `CLIAIRPLAY_VERSION`; `cliairplay.c` uses that when defined, falling back to its own literal (bumped to `0.3.3`) otherwise.
- CI passes the exact tag into the build for both a direct tag push and an Auto Release run (via the workflow's `RELEASE_TAG`), so tagged release binaries report their real version. Branch/PR builds keep using the `git describe` fallback.

## Why it matters

The server's `fetch_airplay_cli.py` parses `cliairplay vX.Y.Z check` to decide whether an installed binary is older than the Dockerfile pin. A version frozen at `0.3.1` broke that comparison and made it impossible to tell which build was actually running.

Forward-only fix: the already-published `v0.3.2`/`v0.3.3` binaries remain mislabeled as `0.3.1`; only future tagged releases will report correctly.

## Validation

- `make STATIC=1 VERSION=0.3.4 && ./bin/cliairplay-macos-arm64 --check` → `cliairplay v0.3.4 check`
- `make STATIC=1` (no override) → falls back to a `git describe` value (e.g. `v0.3.3-1-g<hash>-dirty` stripped to `0.3.3-1-g<hash>-dirty`), no doubled `v`
- `make test STATIC=1` — full suite passes