### PR TITLE
Instant warm seek via single-stdin flush-and-refill

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -182,8 +182,15 @@ grandmaster — but MA spawns one cliairplay per device. The split
 
 **Contract: cmdpipe `START_UNIX_MS=T` means the first sample is AUDIBLE at
 exactly T on every streaming protocol.** Legacy RAOP, RAOP-compatible AirPlay 2,
-and native AirPlay 2 members are handed the same T after each one reports its
-generation primed, then align by construction.
+and native AirPlay 2 members are handed the same T, then align by construction.
+The first `ACTION=START` begins the session; a `START` after an `ACTION=FLUSH`
+re-anchors the same live stream (§10) by re-basing the frozen anchor line below,
+with no reconnect and no crypto/sequence reset. The caller can gate the command
+on the one-shot `[STATUS] audio buffered_ms=` line — emitted once the current
+track's feed is flowing, and re-armed by each FLUSH — so it commits a start only
+after the feed is confirmed. A T of 0 or in the past clamps to now plus the
+minimum commanded-start lead (250 ms; 200 ms on RAOP), which covers only the
+commit round-trips since the connection and the feed are already up.
 
 **Downstream render-latency is informational, not applied.** A receiver whose
 audible output sits behind an external pipeline reports that delay in its
@@ -492,19 +499,26 @@ capture.
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS
   to tear down a MediaRemote-active stream after roughly 30 seconds.
-- **Generation staging rings** — each cmdpipe `PREPARE` drains its FIFO (or
-  single active `AUDIO=-` stdin source) into an independent bounded ring before
-  `START`, decoupled from network pacing. The active and staged generations
-  never share PCM, and
-  the sender waits in bounded intervals so control failures remain visible
-  during producer starvation.
+- **Single-stream flush-and-refill** — one reader thread drains the persistent
+  stdin input into one bounded ring for the whole session, decoupled from
+  network pacing. A warm seek/next is `ACTION=FLUSH`: it quiesces the audio
+  sends, flushes the receiver (RTSP FLUSH), parks the reader to take exclusive
+  fd access, resets the ring, and drains stdin to `EAGAIN` — removing exactly
+  the pre-flush audio the caller stopped writing — then acks `[STATUS] flushed`
+  and releases the reader onto the empty ring. The stream is then idle-primed:
+  it keeps buffering the next track but sends nothing until the next `START`,
+  which re-anchors it. The one-shot `[STATUS] audio` signal (§6) is re-armed by
+  the flush, so the caller learns when the next track's feed is flowing. The
+  sender waits in bounded intervals so control failures remain visible during
+  producer starvation.
 - **Realtime send outcomes** — local UDP backpressure is a bounded transient
   drop that advances sequence, RTP, and scheduling timestamps. Encode,
   allocation, encryption, socket, and control failures are terminal and produce
   a nonzero process exit rather than a false EOF.
-- **EOF drain** — after generation EOF the receiver drains at most
-  `latency + 2 s`; the connection then remains idle for the next PREPARE until
-  the orphan timeout or DISCONNECT.
+- **EOF drain** — `[STATUS] eof` means the single stdin input ended (the whole
+  feed, not one track). The receiver then drains at most `latency + 2 s`, and
+  the connection idles awaiting the next `START` or the orphan idle timeout /
+  `DISCONNECT`.
 - **Initial metadata** — pushed at the first START with a placeholder title if the
   caller has not set any (Sonos withholds audio until it has metadata; the
   native flow also requires `RTP-Info` on the metadata request — Sonos 400s

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ test: directory $(EXECUTABLE) $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(CLIENT
 	@argv_audio="$$($(EXECUTABLE) --protocol raop --cmdpipe \
 		/tmp/cliairplay-test-unused 127.0.0.1 - 2>&1 || true)"; \
 		printf '%s\n' "$$argv_audio" | \
-		grep -q "Streaming audio must be provided by cmdpipe PREPARE, not argv"
+		grep -q "Streaming audio must be provided on stdin, not argv"
 
 $(RAOP_SESSION_TEST): tests/test_raop_session.c src/raop_session.c \
 		src/raop_session.h Makefile

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ Unified AirPlay streaming CLI for Music Assistant. One binary speaks RAOP
 (AirPlay 1) and AirPlay 2 — both the RAOP-compatible flow and the native HAP
 flow — replacing the previous `cliraop` and `cliap2` binaries.
 
-Music Assistant spawns one `cliairplay` process per player, then supplies each
-PCM generation through cmdpipe `PREPARE`/`START`. `AUDIO=-` reads a commanded
-generation from process stdin; named FIFOs allow later generations to be staged
-without reconnecting. For synchronized multi-room AirPlay 2 playback it also
-runs one `cliairplay --ptp-daemon` per host.
+Music Assistant spawns one `cliairplay` process per player and feeds it a
+single, persistent PCM stream on the process stdin for the whole process
+lifetime. Seek and next-track flush the live stream in place (cmdpipe
+`ACTION=FLUSH`) and re-anchor it with a new `ACTION=START` — the connection and
+the input are never re-opened. For synchronized multi-room AirPlay 2 playback it
+also runs one `cliairplay --ptp-daemon` per host.
 
 Protocol and architecture detail lives in `DESIGN.md`; open work in `TODO.md`.
 
@@ -31,9 +32,9 @@ Protocol and architecture detail lives in `DESIGN.md`; open work in `TODO.md`.
   the device's mDNS TXT records.
 - **Hi-res audio**: 24-bit ALAC (44.1 kHz and 48 kHz) on the native realtime
   stream.
-- **Commanded group starts**: every generation on every protocol is staged with
-  cmdpipe `PREPARE`, then `START_UNIX_MS` schedules its first sample to be
-  audible at an exact wall-clock instant.
+- **Commanded group starts**: on every protocol, `START_UNIX_MS` schedules the
+  first sample to be audible at an exact wall-clock instant, so every member of
+  a sync group is handed the same instant and aligns by construction.
 
 ## Usage
 
@@ -48,10 +49,9 @@ Protocol and architecture detail lives in `DESIGN.md`; open work in `TODO.md`.
   --cmdpipe /tmp/ap2-cap 192.168.1.50
 ```
 
-Every streaming protocol requires `--cmdpipe`; each generation's raw
-interleaved PCM arrives through the `AUDIO=<path>` supplied to `PREPARE`.
-`AUDIO=-` duplicates process stdin for one commanded active generation; use
-named FIFOs when staging replacements. The format is selected with
+Every streaming protocol requires `--cmdpipe`; the raw interleaved PCM arrives
+on the process stdin, which is the single persistent audio input for the whole
+process lifetime. The format is selected with
 `--samplerate`/`--bitdepth`/`--channels` (default s16le 44100 stereo). At
 `--bitdepth 24` the input must be **s32le**; the binary truncates it to the
 24-bit samples the ALAC encoder consumes.
@@ -60,10 +60,13 @@ named FIFOs when staging replacements. The format is selected with
 
 `START_UNIX_MS=<ms>` followed by `ACTION=START` means: **the first sample is
 audible exactly at that unix-epoch instant** for legacy RAOP, RAOP-compatible
-AirPlay 2, and native AirPlay 2. Every generation, including generation 0, must
-first be staged with cmdpipe `PREPARE`. A caller waits for
-`[STATUS] primed generation=<n>`, then sends the same start value to every
-primed member of a sync group.
+AirPlay 2, and native AirPlay 2. The first `ACTION=START` begins the session; a
+`START` after an `ACTION=FLUSH` re-anchors the same live stream to a new instant
+without reconnecting. A caller can wait for the one-shot
+`[STATUS] audio buffered_ms=<ms>` line — emitted once the (new) track's feed is
+flowing — before it commands the start, then send the same start value to every
+member of a sync group. A `START_UNIX_MS` of 0 or in the past clamps to now plus
+the minimum commanded-start lead (250 ms, 200 ms on RAOP).
 
 Delivery is not gated on the start time: frames are released up to the
 receiver's buffer window ahead of each frame's deadline (the device-reported
@@ -104,7 +107,7 @@ sudo setcap cap_net_bind_service=+ep /path/to/cliairplay
 cliairplay --protocol airplay2 --ptp-shared --cmdpipe /tmp/cap1 ... <ip1>
 cliairplay --protocol airplay2 --ptp-shared --cmdpipe /tmp/cap2 ... <ip2>
 
-# PREPARE each generation, wait until both are primed, then send the same:
+# Wait until both report [STATUS] audio, then send the same start to both:
 # START_UNIX_MS=<T>
 # ACTION=START
 ```
@@ -142,7 +145,7 @@ cliairplay [options] --cmdpipe <path> <host_ip>
 | `--if <ip>` | Local interface IP to bind all sockets to (multi-homed hosts). |
 | `--dacp <id>` | DACP ID advertised for remote-control callbacks; also the HAP pairing identity. |
 | `--activeremote <id>` | Active-Remote ID for DACP callbacks. |
-| `--cmdpipe <path>` | Required named pipe for runtime commands, metadata, and generation staging (see below). |
+| `--cmdpipe <path>` | Required named pipe for runtime commands and metadata (see below). Audio is not carried here — it is the process stdin. |
 | `--udn <name>` | UDN / instance name used for mDNS. |
 | `--debug <0-9>` | Log verbosity (default: 3). |
 
@@ -181,19 +184,29 @@ cliairplay [options] --cmdpipe <path> <host_ip>
 ### Runtime commands (`--cmdpipe`)
 
 Newline-terminated `KEY=VALUE` lines written to the command pipe control a
-running stream:
+running stream. The raw PCM audio is **not** carried here — it is the process
+stdin, the single persistent audio input for the whole process lifetime.
 
-- Generations on every streaming protocol: `GENERATION=<n>`,
-  `AUDIO=<FIFO path>` (or `AUDIO=-` for process stdin),
-  `POSITION_MS=<ms>`, `ACTION=PREPARE`; after the matching `primed` status,
-  send `START_UNIX_MS=<unix epoch ms>` and `ACTION=START`. Generation 0 follows
-  this same path and never starts from argv.
-- Session lifecycle: `ACTION=FLUSH|STANDBY|DISCONNECT`
-- `VOLUME=<0-100>`
-- `ACTION=PLAY|PAUSE|STOP`
+- Start / re-anchor: `START_UNIX_MS=<unix epoch ms>` then `ACTION=START`. The
+  first `START` begins the session; a `START` after an `ACTION=FLUSH` re-anchors
+  the same live stream (no reconnect). `START_UNIX_MS=0` (or a past instant)
+  starts as soon as possible, at the minimum commanded-start lead.
+- `ACTION=FLUSH` — in-place warm flush for seek/next: flush the receiver (RTSP
+  FLUSH), discard the internal ring, and drain stdin to empty; acks with
+  `[STATUS] flushed` and then keeps buffering the next track while sending
+  nothing until the next `START` (idle-primed). The one-shot
+  `[STATUS] audio buffered_ms=<ms>` line fires again when the next track's feed
+  starts flowing.
+- Session lifecycle: `ACTION=STANDBY` (silence the receiver, keep the connection
+  warm), `ACTION=DISCONNECT` (end the session).
+- Transport: `ACTION=PLAY|PAUSE|STOP`.
+- `VOLUME=<0-100>`.
 - Metadata: `TITLE=`, `ARTIST=`, `ALBUM=`, `DURATION=<s>`, `PROGRESS=<s>`,
   `ARTWORK=<local file path or http:// imageproxy URL>`, followed by
   `ACTION=SENDMETA` to push the set.
+
+`[STATUS] eof` means the stdin input ended — the whole feed is done, not just
+one track.
 
 Some receivers (notably Sonos) do not emit audio until they have received
 metadata; the binary pushes an initial metadata set at the first commanded
@@ -252,13 +265,14 @@ the server `dev` branch with both Dockerfile pins. That step requires the
 ## Architecture
 
 ```
-src/cliairplay.c      CLI entry, route dispatch, playback loops, input ring,
-                      cmdpipe, --pair-setup and --ptp-daemon modes
+src/cliairplay.c      CLI entry, route dispatch, playback loops, cmdpipe,
+                      --pair-setup and --ptp-daemon modes
 src/ap2_client.c      AP2 orchestrator: route resolution, RAOP-compat + native
                       flows, the realtime sender, anchor & pacing
-src/ap2_session.c     Protocol-neutral persistent generation engine used by
-                      legacy RAOP and both AirPlay 2 flows
-src/raop_session.c    Legacy RAOP generation commit/standby scheduling
+src/ap2_session.c     Protocol-neutral single-stdin flush-and-refill engine
+                      (persistent input reader + ring) used by legacy RAOP and
+                      both AirPlay 2 flows
+src/raop_session.c    Legacy RAOP commit / flush / standby scheduling
 src/ap2_hap.c         HAP pair-verify, transient and PIN pair-setup, encrypted
                       RTSP framing (ChaCha20-Poly1305)
 src/ap2_io.c          Absolute-deadline socket I/O shared by RTSP and MRP

--- a/TODO.md
+++ b/TODO.md
@@ -2,13 +2,6 @@
 
 Genuinely open work only. Completed work lives in git history.
 
-- [ ] **Persistent sessions (no mode flag).** Keep one connection per player
-      across seek/next/resume: numbered media generations over per-generation
-      input pipes, committed with RTSP `FLUSH` + a re-based frozen anchor line
-      (measured working down to a 150 ms warm lead on Sonos and Apple TV).
-      Every generation, including generation 0, arrives through `--cmdpipe`
-      PREPARE/START; the connection outlives it awaiting the next generation.
-      Replaces today's teardown-and-reconnect per `play_media`.
 - [ ] **Parse `audioLatencies` from GET /info.** The SETUP echo of
       `latencyMin`/`latencyMax` is receiver-optional (Sonos omits it); the
       /info table would populate the pacing window and the reported

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2036,26 +2036,19 @@ void ap2cl_standby(struct ap2cl_s *p)
     p->state = AP2_CONNECTED;
 }
 
-/* Warm-flush a LIVE session for a generation switch: discard receiver-buffered
- * audio and re-base the timeline so the next written frame is audible at the
- * requested instant. Native realtime sends the classic RTSP FLUSH with
- * RTP-Info and freezes a fresh anchor line (measured accepted down to a
- * 150 ms lead on Sonos and Apple TV); the RAOP paths use libraop's documented
- * flush + start-at seek flow. Sequence numbers (and thus audio nonces) are
- * never reset, so crypto state stays valid across the boundary. A start in
- * the past (or 0) is clamped to now + the minimum warm lead so the first
- * samples of the new generation can never be clipped. */
-bool ap2cl_warm_flush(struct ap2cl_s *p, uint64_t start_unix_ms)
+/* Discard the receiver's buffered audio in place for a warm seek, keeping the
+ * session and its timeline continuity. Native realtime sends the classic RTSP
+ * FLUSH with the current RTP-Info; the RAOP-compat path uses libraop's flush.
+ * The stream sends nothing until the next ap2cl_resume re-anchors it. Sequence
+ * numbers (and thus audio nonces) are never reset, so crypto state stays valid
+ * across the boundary (measured accepted down to a ~150 ms lead on Sonos and
+ * Apple TV once resumed). */
+bool ap2cl_flush(struct ap2cl_s *p)
 {
     if (!p || p->state == AP2_DOWN) return false;
 
-    uint64_t start_ntp = commanded_start_ntp(start_unix_ms);
-
-    if (p->flow != FLOW_NATIVE_AP2) {
-        if (!raop_session_commit(p->raopcl, start_unix_ms)) return false;
-        p->state = AP2_STREAMING;
-        return true;
-    }
+    if (p->flow != FLOW_NATIVE_AP2)
+        return raop_session_flush(p->raopcl);
 
     if (atomic_load(&p->rtsp_dead)) return false;
     char hdr[64];
@@ -2071,7 +2064,28 @@ bool ap2cl_warm_flush(struct ap2cl_s *p, uint64_t start_unix_ms)
     if (status != 200)
         LOG_WARN("[AP2] receiver did not accept FLUSH (%d); re-anchoring anyway",
                  status);
+    /* Drop the stale anchor; ap2cl_resume freezes a fresh line at START. */
+    p->rt_anchor_valid = false;
+    return true;
+}
 
+/* Re-base the frozen timeline so the next written frame is audible at
+ * start_unix_ms (unix epoch ms), resuming a stream that ap2cl_flush discarded
+ * (the START after a FLUSH). A start of 0 or one already in the past is clamped
+ * to now + the minimum warm lead so a new track's first samples can never be
+ * clipped. Sequence numbers and audio nonces are untouched. */
+bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms)
+{
+    if (!p || p->state == AP2_DOWN) return false;
+
+    if (p->flow != FLOW_NATIVE_AP2) {
+        if (!raop_session_start_at(p->raopcl, start_unix_ms)) return false;
+        p->state = AP2_STREAMING;
+        return true;
+    }
+
+    if (atomic_load(&p->rtsp_dead)) return false;
+    uint64_t start_ntp = commanded_start_ntp(start_unix_ms);
     /* Re-base the frozen line: head_ts moves in the scheduling domain, the
      * wire timestamp follows it plus the per-process offset, and the next
      * sync packet freezes the new line from start_ntp. */

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -70,10 +70,12 @@ extern log_level *loglevel;
 #define AP2_FEEDBACK_INTERVAL_MS     2000
 #define AP2_EVENT_POLL_INTERVAL_MS   100
 #define AP2_UDP_SEND_TIMEOUT_MS      20
-/* Minimum lead for a warm generation switch: receivers accepted re-anchors
- * down to 150 ms in the flush-ladder measurements; 350 ms leaves margin for
- * the commit round-trips and scheduling jitter. */
-#define AP2_MIN_WARM_LEAD_MS         350
+/* Minimum lead for a commanded start: receivers accepted re-anchors down to
+ * 150 ms in the flush-ladder measurements; 250 ms leaves margin for the
+ * commit round-trips and scheduling jitter. The caller only commands a start
+ * after the connection and the audio feed are both confirmed, so no setup
+ * slack is needed on top. */
+#define AP2_MIN_WARM_LEAD_MS         250
 
 typedef enum {
     FLOW_RAOP_COMPAT = 0,

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2041,7 +2041,8 @@ void ap2cl_standby(struct ap2cl_s *p)
 /* Discard the receiver's buffered audio in place for a warm seek, keeping the
  * session and its timeline continuity. Native realtime sends the classic RTSP
  * FLUSH with the current RTP-Info; the RAOP-compat path uses libraop's flush.
- * The stream sends nothing until the next ap2cl_resume re-anchors it. Sequence
+ * The send gate lives in the session engine: it is idle-primed after a FLUSH
+ * and calls no send until the next START commands ap2cl_resume. Sequence
  * numbers (and thus audio nonces) are never reset, so crypto state stays valid
  * across the boundary (measured accepted down to a ~150 ms lead on Sonos and
  * Apple TV once resumed). */

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -154,13 +154,19 @@ bool ap2cl_disconnect(struct ap2cl_s *p);
 bool ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms);
 
 /*
- * Warm-flush a live session for a generation switch (persistent session
- * mode): discard receiver-buffered audio and re-base the timeline so the next
- * written frame is audible at start_unix_ms (unix epoch milliseconds). A
- * start of 0 or one already in the past is clamped to now + the minimum warm
- * lead, so a new generation's first samples can never be clipped.
+ * Warm-seek a live session in place. FLUSH then START (below) are the two
+ * halves of the old combined warm flush:
+ *
+ * ap2cl_flush discards the receiver's buffered audio (RTSP FLUSH / libraop
+ * flush) and stops sending, keeping the session and its sequence/nonce state.
+ *
+ * ap2cl_resume re-bases the frozen timeline so the next written frame is
+ * audible at start_unix_ms (unix epoch milliseconds); a start of 0 or one in
+ * the past clamps to now + the minimum warm lead, so a new track's first
+ * samples can never be clipped.
  */
-bool ap2cl_warm_flush(struct ap2cl_s *p, uint64_t start_unix_ms);
+bool ap2cl_flush(struct ap2cl_s *p);
+bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms);
 
 /* Silence the receiver but keep the session warm: discard buffered audio,
  * publish the stopped state, drop to CONNECTED awaiting the next warm flush. */

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -1,17 +1,15 @@
 /*
- * Persistent session - generation state machine (see ap2_session.h)
+ * Persistent session - single-stream flush-and-refill engine (see ap2_session.h)
  *
- * Threading model: PREPARE spawns one reader thread per generation that
- * drains the generation's input into its own ring. The command-pipe thread
- * drives prepare/start/flush/standby; START performs the transport commit
- * (RTSP work is serialized inside the transport) and swaps the staged slot
- * in as active under the session lock. The audio loop only ever calls
- * ap2_session_read()/poll(), so a generation switch is invisible to it
- * beyond the data changing.
- *
- * Slots are heap objects with stable addresses for their reader threads;
- * generation switches swap pointers, never slot contents. A retired slot is
- * freed only after its reader has been joined.
+ * Threading model: one reader thread drains the persistent input fd into one
+ * ring for the whole session. The command-pipe thread drives start/flush/
+ * standby; the audio loop only ever calls ap2_session_read()/poll(). A FLUSH
+ * must drain the input fd without racing the reader on the same descriptor, so
+ * the cmdpipe thread parks the reader (drain_request -> reader_paused handshake)
+ * before it resets the ring and drains the fd, then releases it onto the empty
+ * ring to buffer the next track. The reader never blocks (the fd is
+ * non-blocking and poll uses a short timeout), so the handshake is bounded and
+ * the cmdpipe thread is never wedged.
  *
  * Copyright (C) 2024-2026 Music Assistant Contributors
  * See LICENSE
@@ -25,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -37,40 +34,37 @@ extern log_level *loglevel;
 
 #define SRING_MIN_BYTES   (1u << 20)   /* 1 MiB floor */
 #define SRING_SECONDS     4            /* ring depth in media time */
+#define READER_POLL_MS    30           /* input poll slice; bounds pause latency */
 
-/* One generation's input ring, filled by its reader thread. */
+/* The single input ring, filled by the reader thread. */
 typedef struct {
     uint8_t *data;
     size_t cap, rd, wr, fill;
-    bool eof;        /* writer closed (or read error) */
-    bool abort;      /* stop the reader and discard */
+    bool eof;        /* input closed (or read error): end of stream */
 } sring_t;
-
-typedef struct {
-    ap2_generation_t gen;
-    char *path_owned;         /* strdup'd audio_path (gen.audio_path aliases) */
-    sring_t ring;
-    pthread_t thread;
-    bool thread_started;
-    bool ready_sent;
-    bool primed_sent;
-} slot_t;
 
 struct ap2_session_s {
     ap2_session_ops_t ops;
     unsigned byte_rate;
-    size_t prefill_bytes;
     int idle_timeout_ms;
+    int input_fd;              /* owned dup of the caller's PCM descriptor */
 
     pthread_mutex_t lock;
-    pthread_cond_t can_read;   /* active ring gained data / state changed */
-    pthread_cond_t can_write;  /* a ring gained space / abort requested */
+    pthread_cond_t can_read;   /* ring gained data / state changed */
+    pthread_cond_t can_write;  /* ring gained space / abort / drain requested */
+    pthread_cond_t reader_paused_cond;  /* reader entered the paused state */
+    pthread_cond_t reader_resume_cond;  /* drain finished; reader may continue */
+
+    pthread_t reader;
+    bool reader_started;
+    bool reader_paused;        /* reader parked for a drain */
+    bool drain_request;        /* cmdpipe asked the reader to park */
+    bool abort;                /* tear the reader down */
 
     ap2_session_state_t state;
-    slot_t *active;
-    slot_t *staged;
-    uint64_t played_bytes;     /* consumed from the ACTIVE generation */
+    uint64_t epoch;            /* bumped on every START */
     uint64_t idle_since_ms;    /* monotonic ms when we last went idle */
+    sring_t ring;
 };
 
 /* ---- ring helpers (called with s->lock held) ---- */
@@ -84,6 +78,12 @@ static bool sring_init(sring_t *r, unsigned byte_rate)
     if (!r->data) return false;
     r->cap = cap;
     return true;
+}
+
+static void sring_reset(sring_t *r)
+{
+    r->rd = r->wr = r->fill = 0;
+    r->eof = false;
 }
 
 static size_t sring_pop(sring_t *r, uint8_t *buf, size_t want)
@@ -123,393 +123,254 @@ static void emit(struct ap2_session_s *s, const char *fmt, ...)
     s->ops.status(line);
 }
 
-/* ---- generation reader thread ---- */
+/* ---- input reader thread (single, persistent) ---- */
 
-typedef struct {
-    struct ap2_session_s *s;
-    slot_t *slot;
-} reader_arg_t;
+/* Read+discard from the fd until it would block. Called by the cmdpipe thread
+ * under s->lock with the reader parked, so it has exclusive fd access. */
+static void drain_input_fd(int fd)
+{
+    uint8_t scratch[16384];
+    /* Cap the loop so a misbehaving writer that never stops can never wedge the
+     * cmdpipe thread; MA stops writing old bytes before FLUSH, so a well-behaved
+     * drain terminates on EAGAIN long before this. */
+    for (int guard = 0; guard < 100000; guard++) {
+        ssize_t n = read(fd, scratch, sizeof(scratch));
+        if (n <= 0) return;   /* EAGAIN / EOF / error: nothing more to discard */
+    }
+}
 
 static void *reader_thread(void *arg)
 {
-    reader_arg_t a = *(reader_arg_t *)arg;
-    free(arg);
-    struct ap2_session_s *s = a.s;
-    slot_t *slot = a.slot;
-
-    int fd = strcmp(slot->path_owned, "-") == 0
-        ? dup(STDIN_FILENO)
-        : open(slot->path_owned, O_RDONLY | O_NONBLOCK);
-    if (fd < 0) {
-        pthread_mutex_lock(&s->lock);
-        slot->ring.eof = true;
-        pthread_cond_broadcast(&s->can_read);
-        pthread_mutex_unlock(&s->lock);
-        LOG_ERROR("[SESSION] cannot open %s: %s", slot->path_owned,
-                  strerror(errno));
-        return NULL;
-    }
-    /* The read loop below assumes a non-blocking fd: it polls for readiness and
-     * re-checks the abort flag on every poll timeout, so read() must never
-     * block. Named-pipe generations are opened O_NONBLOCK above, but generation
-     * 0 dup()s the process stdin, which is blocking and whose write end the
-     * caller keeps open for the whole process. Without this, once such a
-     * generation is superseded its read() blocks forever on the idle-but-open
-     * pipe, so retire_slot()'s join wedges the command-pipe thread and no
-     * further generation can be staged. Force non-blocking so read() yields
-     * EAGAIN and the loop can honour abort. */
-    int fl = fcntl(fd, F_GETFL, 0);
-    if (fl != -1)
-        (void)fcntl(fd, F_SETFL, fl | O_NONBLOCK);
-    struct stat input_stat;
-    if (fstat(fd, &input_stat) < 0) {
-        int open_errno = errno;
-        pthread_mutex_lock(&s->lock);
-        slot->ring.eof = true;
-        emit(s, "[STATUS] input_error generation=%llu errno=%d (%s)",
-             (unsigned long long)slot->gen.number, open_errno,
-             strerror(open_errno));
-        pthread_cond_broadcast(&s->can_read);
-        pthread_mutex_unlock(&s->lock);
-        close(fd);
-        return NULL;
-    }
-    bool writer_seen = !S_ISFIFO(input_stat.st_mode);
-
-    pthread_mutex_lock(&s->lock);
-    if (!slot->ring.abort && !slot->ready_sent) {
-        slot->ready_sent = true;
-        emit(s, "[STATUS] ready generation=%llu",
-             (unsigned long long)slot->gen.number);
-    }
-    pthread_mutex_unlock(&s->lock);
-
-    /* The read below unblocks when the writer closes its end (MA kills the
-     * generation's ffmpeg on replace), which is the normal retirement path;
-     * abort covers the never-started cases. */
+    struct ap2_session_s *s = arg;
     uint8_t buf[16384];
+
     for (;;) {
         pthread_mutex_lock(&s->lock);
-        bool abort = slot->ring.abort;
+        /* Park on a drain request: the cmdpipe thread needs exclusive fd access
+         * to drain it, so we release the lock and wait until the drain is done. */
+        while (s->drain_request && !s->abort) {
+            s->reader_paused = true;
+            pthread_cond_broadcast(&s->reader_paused_cond);
+            pthread_cond_wait(&s->reader_resume_cond, &s->lock);
+        }
+        s->reader_paused = false;
+        bool abort = s->abort;
+        bool at_eof = s->ring.eof;
         pthread_mutex_unlock(&s->lock);
         if (abort) break;
 
-        struct pollfd pfd = {.fd = fd, .events = POLLIN};
-        int polled = poll(&pfd, 1, 250);
-        if (polled < 0 && errno == EINTR) continue;
-        if (polled == 0) {
-            /* A timeout says nothing about FIFO writer presence: both a
-             * connected idle writer and a writerless FIFO can time out. */
-            if (!writer_seen) continue;
-            /* Once data proved that a writer existed, read to distinguish an
-             * idle writer (EAGAIN) from one that closed (EOF). */
-        }
-        if (!writer_seen && (pfd.revents & POLLHUP) &&
-            !(pfd.revents & POLLIN)) {
-            /* No writer has connected yet. Avoid treating that as input EOF. */
-            usleep(10000);
+        if (at_eof) {
+            /* Input closed (teardown): stay alive to honour pause/abort, but do
+             * not busy-poll a closed descriptor. */
+            usleep(20000);
             continue;
         }
-        if (pfd.revents & POLLIN) writer_seen = true;
 
-        ssize_t n = polled < 0 ? -1 : read(fd, buf, sizeof(buf));
-        if (n < 0 && errno == EINTR)
-            continue;  /* interrupted syscall, not an error — retry the read */
-        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
-            continue;
-        int read_errno = errno;
+        struct pollfd pfd = {.fd = s->input_fd, .events = POLLIN};
+        int polled = poll(&pfd, 1, READER_POLL_MS);
+        if (polled < 0 && errno == EINTR) continue;
+
+        /* A drain may have been requested while we polled; park before touching
+         * the fd so the cmdpipe thread keeps exclusive access. */
         pthread_mutex_lock(&s->lock);
-        if (slot->ring.abort) {
-            pthread_mutex_unlock(&s->lock);
-            break;
-        }
+        bool pause_now = s->drain_request;
+        pthread_mutex_unlock(&s->lock);
+        if (pause_now) continue;
+        if (polled <= 0) continue;   /* timeout: no data yet */
+
+        ssize_t n = read(s->input_fd, buf, sizeof(buf));
+        if (n < 0 && (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK))
+            continue;
         if (n <= 0) {
-            slot->ring.eof = true;
-            if (n == 0 && slot->ring.fill > 0 && !slot->primed_sent) {
-                slot->primed_sent = true;
-                emit(s, "[STATUS] primed generation=%llu prefill_ms=%llu",
-                     (unsigned long long)slot->gen.number,
-                     (unsigned long long)(slot->ring.fill * 1000ULL /
-                                          s->byte_rate));
-            }
-            /* A clean EOF (0) is the normal retirement path; a negative return
-             * is a real read error (e.g. a broken pipe) and is surfaced
-             * distinctly instead of being hidden as end-of-input. */
-            if (n < 0)
-                emit(s, "[STATUS] input_error generation=%llu errno=%d (%s)",
-                     (unsigned long long)slot->gen.number, read_errno,
-                     strerror(read_errno));
-            else
-                emit(s, "[STATUS] input_eof generation=%llu",
-                     (unsigned long long)slot->gen.number);
+            /* A clean EOF (0) is the normal teardown path; a negative return is
+             * a read error. Both end the stream. */
+            int read_errno = errno;
+            pthread_mutex_lock(&s->lock);
+            s->ring.eof = true;
             pthread_cond_broadcast(&s->can_read);
             pthread_mutex_unlock(&s->lock);
-            break;
+            if (n < 0)
+                LOG_ERROR("[SESSION] input read error: %s", strerror(read_errno));
+            continue;
         }
+
         size_t off = 0;
-        while (off < (size_t)n && !slot->ring.abort) {
-            size_t pushed = sring_push(&slot->ring, buf + off, (size_t)n - off);
+        pthread_mutex_lock(&s->lock);
+        while (off < (size_t)n && !s->abort && !s->drain_request) {
+            size_t pushed = sring_push(&s->ring, buf + off, (size_t)n - off);
             off += pushed;
             if (pushed) pthread_cond_broadcast(&s->can_read);
-            if (!slot->primed_sent && slot->ring.fill >= s->prefill_bytes) {
-                slot->primed_sent = true;
-                emit(s, "[STATUS] primed generation=%llu prefill_ms=%llu",
-                     (unsigned long long)slot->gen.number,
-                     (unsigned long long)(slot->ring.fill * 1000ULL /
-                                          s->byte_rate));
-            }
             if (off < (size_t)n)
                 pthread_cond_wait(&s->can_write, &s->lock);
         }
         pthread_mutex_unlock(&s->lock);
+        /* If a drain interrupted the push, the unwritten tail is pre-flush audio
+         * and is dropped on purpose. */
     }
-    close(fd);
     return NULL;
-}
-
-/* Stop a detached slot's reader, join it and free the slot. The slot must
- * already be unlinked from the session. Lock must NOT be held. */
-static void retire_slot(struct ap2_session_s *s, slot_t *slot)
-{
-    if (!slot) return;
-    pthread_mutex_lock(&s->lock);
-    slot->ring.abort = true;
-    pthread_cond_broadcast(&s->can_write);
-    bool started = slot->thread_started;
-    pthread_mutex_unlock(&s->lock);
-
-    if (started) {
-        pthread_join(slot->thread, NULL);
-    }
-    free(slot->ring.data);
-    free(slot->path_owned);
-    free(slot);
-}
-
-/* Detach a slot pointer from the session under the lock. */
-static slot_t *detach(struct ap2_session_s *s, slot_t **ref)
-{
-    pthread_mutex_lock(&s->lock);
-    slot_t *slot = *ref;
-    *ref = NULL;
-    pthread_mutex_unlock(&s->lock);
-    return slot;
 }
 
 /* ---- public API ---- */
 
 struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
-                                         unsigned byte_rate, int prefill_ms,
-                                         int idle_timeout_ms)
+                                         unsigned byte_rate, int idle_timeout_ms,
+                                         int input_fd)
 {
-    if (!ops || !ops->quiesce || !ops->commit || !ops->resume ||
-        !ops->stop || !ops->status || !byte_rate)
+    if (!ops || !ops->quiesce || !ops->flush || !ops->commit || !ops->resume ||
+        !ops->stop || !ops->status || !byte_rate || input_fd < 0)
         return NULL;
     struct ap2_session_s *s = calloc(1, sizeof(*s));
     if (!s) return NULL;
     s->ops = *ops;
     s->byte_rate = byte_rate;
-    s->prefill_bytes = (size_t)byte_rate * (prefill_ms > 0 ? prefill_ms : 1)
-                       / 1000;
     s->idle_timeout_ms = idle_timeout_ms;
+    s->input_fd = -1;
     pthread_mutex_init(&s->lock, NULL);
     pthread_cond_init(&s->can_read, NULL);
     pthread_cond_init(&s->can_write, NULL);
+    pthread_cond_init(&s->reader_paused_cond, NULL);
+    pthread_cond_init(&s->reader_resume_cond, NULL);
     s->state = AP2_SESSION_IDLE;
     s->idle_since_ms = ap2_io_monotonic_ms();
+    if (!sring_init(&s->ring, byte_rate)) {
+        ap2_session_destroy(s);
+        return NULL;
+    }
+
+    /* Own a private, non-blocking dup of the caller's descriptor: the reader
+     * polls for readiness and must never block, and the caller keeps its own
+     * reference (killing the per-seek transcoder must not close our input). */
+    s->input_fd = dup(input_fd);
+    if (s->input_fd < 0) {
+        LOG_ERROR("[SESSION] cannot dup input fd: %s", strerror(errno));
+        ap2_session_destroy(s);
+        return NULL;
+    }
+    int fl = fcntl(s->input_fd, F_GETFL, 0);
+    if (fl != -1)
+        (void)fcntl(s->input_fd, F_SETFL, fl | O_NONBLOCK);
+
+    if (pthread_create(&s->reader, NULL, reader_thread, s) != 0) {
+        LOG_ERROR("[SESSION] cannot start input reader");
+        ap2_session_destroy(s);
+        return NULL;
+    }
+    s->reader_started = true;
     return s;
 }
 
 void ap2_session_destroy(struct ap2_session_s *s)
 {
     if (!s) return;
-    ap2_session_end(s);
-    retire_slot(s, detach(s, &s->staged));
-    retire_slot(s, detach(s, &s->active));
+    pthread_mutex_lock(&s->lock);
+    s->state = AP2_SESSION_ENDED;
+    s->abort = true;
+    /* Wake the reader out of any wait (ring-full, paused, or state change). */
+    pthread_cond_broadcast(&s->can_read);
+    pthread_cond_broadcast(&s->can_write);
+    pthread_cond_broadcast(&s->reader_resume_cond);
+    pthread_mutex_unlock(&s->lock);
+    if (s->reader_started)
+        pthread_join(s->reader, NULL);
+    if (s->input_fd >= 0) close(s->input_fd);
     pthread_cond_destroy(&s->can_read);
     pthread_cond_destroy(&s->can_write);
+    pthread_cond_destroy(&s->reader_paused_cond);
+    pthread_cond_destroy(&s->reader_resume_cond);
     pthread_mutex_destroy(&s->lock);
+    free(s->ring.data);
     free(s);
 }
 
-bool ap2_session_prepare(struct ap2_session_s *s, const ap2_generation_t *gen)
-{
-    if (!s || !gen || !gen->audio_path) return false;
-    if (strcmp(gen->audio_path, "-") == 0) {
-        pthread_mutex_lock(&s->lock);
-        bool stdin_active =
-            s->active && strcmp(s->active->path_owned, "-") == 0;
-        pthread_mutex_unlock(&s->lock);
-        if (stdin_active) {
-            LOG_ERROR("[SESSION] cannot stage AUDIO=- while another stdin "
-                      "generation is active; use a named FIFO");
-            return false;
-        }
-    }
-    /* A superseded staged generation is discarded: the caller only ever wants
-     * the newest one (rapid seek/seek/seek collapses naturally). */
-    retire_slot(s, detach(s, &s->staged));
-
-    slot_t *slot = calloc(1, sizeof(*slot));
-    if (!slot) return false;
-    slot->gen = *gen;
-    slot->path_owned = gen->audio_path ? strdup(gen->audio_path) : NULL;
-    slot->gen.audio_path = slot->path_owned;
-    if (!sring_init(&slot->ring, s->byte_rate)) {
-        free(slot->path_owned);
-        free(slot);
-        return false;
-    }
-
-    pthread_mutex_lock(&s->lock);
-    if (s->state == AP2_SESSION_ENDED) {
-        pthread_mutex_unlock(&s->lock);
-        free(slot->ring.data);
-        free(slot->path_owned);
-        free(slot);
-        return false;
-    }
-    s->staged = slot;
-    if (s->state == AP2_SESSION_IDLE || s->state == AP2_SESSION_STANDBY)
-        s->state = AP2_SESSION_PREPARING;
-    pthread_mutex_unlock(&s->lock);
-
-    reader_arg_t *arg = malloc(sizeof(*arg));
-    if (!arg) {
-        retire_slot(s, detach(s, &s->staged));
-        return false;
-    }
-    arg->s = s;
-    arg->slot = slot;
-    if (pthread_create(&slot->thread, NULL, reader_thread, arg) != 0) {
-        free(arg);
-        retire_slot(s, detach(s, &s->staged));
-        return false;
-    }
-    pthread_mutex_lock(&s->lock);
-    slot->thread_started = true;
-    pthread_mutex_unlock(&s->lock);
-    return true;
-}
-
-bool ap2_session_start(struct ap2_session_s *s, uint64_t generation,
-                       uint64_t start_unix_ms)
+bool ap2_session_start(struct ap2_session_s *s, uint64_t start_unix_ms)
 {
     if (!s) return false;
     pthread_mutex_lock(&s->lock);
-    bool ok = s->staged && s->staged->gen.number == generation &&
-              s->state != AP2_SESSION_ENDED;
+    bool ended = s->state == AP2_SESSION_ENDED;
     pthread_mutex_unlock(&s->lock);
-    if (!ok) {
-        LOG_ERROR("[SESSION] START for generation %llu does not match the "
-                  "staged generation",
-                  (unsigned long long)generation);
-        return false;
-    }
+    if (ended) return false;
 
-    /* Stop the audio loop between its current chunk and the transport FLUSH;
-     * keep it stopped until the staged slot is active. */
+    /* Stop the audio loop between chunks, do the transport work, then swap to
+     * PLAYING. On the first start commit begins the session; after a FLUSH it
+     * re-bases the frozen anchor. */
     s->ops.quiesce(s->ops.transport);
-    pthread_mutex_lock(&s->lock);
-    ok = s->staged && s->staged->gen.number == generation &&
-         s->state != AP2_SESSION_ENDED;
-    pthread_mutex_unlock(&s->lock);
-    if (!ok) {
-        s->ops.resume(s->ops.transport);
-        return false;
-    }
-
-    /* Transport commit outside the lock: it does RTSP round-trips. The staged
-     * reader keeps filling meanwhile; audio sends remain quiesced. */
     if (!s->ops.commit(s->ops.transport, start_unix_ms)) {
         s->ops.resume(s->ops.transport);
-        LOG_ERROR("[SESSION] transport commit failed for generation %llu",
-                  (unsigned long long)generation);
+        LOG_ERROR("[SESSION] transport commit failed");
         return false;
     }
-
     pthread_mutex_lock(&s->lock);
-    /* Command actions are serialized by the cmdpipe thread. Re-validate after
-     * the unlocked transport round-trip as a defensive API invariant. */
-    if (!s->staged || s->staged->gen.number != generation ||
-        s->state == AP2_SESSION_ENDED) {
+    if (s->state == AP2_SESSION_ENDED) {
         pthread_mutex_unlock(&s->lock);
         s->ops.resume(s->ops.transport);
-        LOG_WARN("[SESSION] generation %llu superseded before activation",
-                 (unsigned long long)generation);
         return false;
     }
-    slot_t *old = s->active;
-    s->active = s->staged;
-    s->staged = NULL;
-    s->played_bytes = 0;
+    s->ring.eof = false;   /* a fresh START clears any stale end-of-stream */
+    s->epoch++;
     s->state = AP2_SESSION_PLAYING;
     pthread_cond_broadcast(&s->can_read);
     pthread_cond_broadcast(&s->can_write);
     pthread_mutex_unlock(&s->lock);
     s->ops.resume(s->ops.transport);
-
-    retire_slot(s, old);
     return true;
 }
 
-bool ap2_session_flush(struct ap2_session_s *s, uint64_t generation)
+bool ap2_session_flush(struct ap2_session_s *s)
 {
     if (!s) return false;
     pthread_mutex_lock(&s->lock);
-    bool is_staged = s->staged && s->staged->gen.number == generation;
-    bool is_active = s->active && s->active->gen.number == generation;
+    bool ended = s->state == AP2_SESSION_ENDED;
+    pthread_mutex_unlock(&s->lock);
+    if (ended) return false;
+
+    /* Stop sending, then discard the receiver's buffered audio in place. */
+    s->ops.quiesce(s->ops.transport);
+    s->ops.flush(s->ops.transport);
+
+    pthread_mutex_lock(&s->lock);
+    /* Park the reader so we can drain the input fd without racing it, then
+     * discard our own ring and drain the fd to EAGAIN. MA has already stopped
+     * writing old bytes, so this removes exactly the pre-flush audio. */
+    s->drain_request = true;
+    pthread_cond_broadcast(&s->can_write);
+    while (s->reader_started && !s->reader_paused && !s->abort)
+        pthread_cond_wait(&s->reader_paused_cond, &s->lock);
+    sring_reset(&s->ring);
+    drain_input_fd(s->input_fd);
+    /* Release the reader onto the now-empty ring: it buffers the next track
+     * while we send nothing until the next START (idle-primed). */
+    s->drain_request = false;
+    if (s->state != AP2_SESSION_ENDED) {
+        s->state = AP2_SESSION_IDLE;
+        s->idle_since_ms = ap2_io_monotonic_ms();
+    }
+    pthread_cond_broadcast(&s->reader_resume_cond);
+    pthread_cond_broadcast(&s->can_read);
     pthread_mutex_unlock(&s->lock);
 
-    if (is_staged) {
-        retire_slot(s, detach(s, &s->staged));
-        pthread_mutex_lock(&s->lock);
-        if (s->state != AP2_SESSION_ENDED) {
-            if (s->active &&
-                (!s->active->ring.eof || s->active->ring.fill > 0)) {
-                s->state = AP2_SESSION_PLAYING;
-            } else {
-                s->state = AP2_SESSION_IDLE;
-                s->idle_since_ms = ap2_io_monotonic_ms();
-            }
-        }
-        pthread_cond_broadcast(&s->can_read);
-        pthread_mutex_unlock(&s->lock);
-        return true;
-    }
-    if (is_active) {
-        s->ops.quiesce(s->ops.transport);
-        s->ops.stop(s->ops.transport);
-        slot_t *old = detach(s, &s->active);
-        pthread_mutex_lock(&s->lock);
-        if (s->state != AP2_SESSION_ENDED) {
-            s->state = s->staged ? AP2_SESSION_PREPARING : AP2_SESSION_IDLE;
-            s->idle_since_ms = ap2_io_monotonic_ms();
-        }
-        pthread_cond_broadcast(&s->can_read);
-        pthread_mutex_unlock(&s->lock);
-        s->ops.resume(s->ops.transport);
-        retire_slot(s, old);
-        return true;
-    }
-    return false;
+    s->ops.resume(s->ops.transport);
+    emit(s, "[STATUS] flushed");
+    return true;
 }
 
 bool ap2_session_standby(struct ap2_session_s *s)
 {
     if (!s) return false;
+    pthread_mutex_lock(&s->lock);
+    bool ended = s->state == AP2_SESSION_ENDED;
+    pthread_mutex_unlock(&s->lock);
+    if (ended) return false;
+
     s->ops.quiesce(s->ops.transport);
     s->ops.stop(s->ops.transport);
-    slot_t *old = detach(s, &s->active);
     pthread_mutex_lock(&s->lock);
     if (s->state != AP2_SESSION_ENDED) {
-        s->state = s->staged ? AP2_SESSION_PREPARING : AP2_SESSION_STANDBY;
+        s->state = AP2_SESSION_STANDBY;
         s->idle_since_ms = ap2_io_monotonic_ms();
     }
     pthread_cond_broadcast(&s->can_read);
     pthread_mutex_unlock(&s->lock);
     s->ops.resume(s->ops.transport);
-    retire_slot(s, old);
     return true;
 }
 
@@ -520,6 +381,7 @@ void ap2_session_end(struct ap2_session_s *s)
     s->state = AP2_SESSION_ENDED;
     pthread_cond_broadcast(&s->can_read);
     pthread_cond_broadcast(&s->can_write);
+    pthread_cond_broadcast(&s->reader_resume_cond);
     pthread_mutex_unlock(&s->lock);
 }
 
@@ -536,22 +398,17 @@ int ap2_session_read(struct ap2_session_s *s, uint8_t *buf, int len,
             pthread_mutex_unlock(&s->lock);
             return -2;
         }
-        if (s->active && s->active->ring.fill > 0) {
-            size_t n = sring_pop(&s->active->ring, buf, (size_t)len);
-            s->played_bytes += n;
-            pthread_cond_broadcast(&s->can_write);
-            pthread_mutex_unlock(&s->lock);
-            return (int)n;
-        }
-        if (s->active && s->active->ring.eof) {
-            if (s->state == AP2_SESSION_PLAYING) {
-                s->state = s->staged
-                    ? AP2_SESSION_PREPARING : AP2_SESSION_IDLE;
-                if (s->state == AP2_SESSION_IDLE)
-                    s->idle_since_ms = ap2_io_monotonic_ms();
+        if (s->state == AP2_SESSION_PLAYING) {
+            if (s->ring.fill > 0) {
+                size_t n = sring_pop(&s->ring, buf, (size_t)len);
+                pthread_cond_broadcast(&s->can_write);
+                pthread_mutex_unlock(&s->lock);
+                return (int)n;
             }
-            pthread_mutex_unlock(&s->lock);
-            return -1;   /* generation fully consumed */
+            if (s->ring.eof) {
+                pthread_mutex_unlock(&s->lock);
+                return -1;   /* input stream fully consumed */
+            }
         }
         uint64_t now = ap2_io_monotonic_ms();
         if (now >= deadline) {
@@ -582,6 +439,7 @@ void ap2_session_poll(struct ap2_session_s *s)
         emit(s, "[STATUS] idle_timeout");
         pthread_cond_broadcast(&s->can_read);
         pthread_cond_broadcast(&s->can_write);
+        pthread_cond_broadcast(&s->reader_resume_cond);
     }
     pthread_mutex_unlock(&s->lock);
 }
@@ -595,23 +453,11 @@ ap2_session_state_t ap2_session_state(struct ap2_session_s *s)
     return st;
 }
 
-uint64_t ap2_session_active_generation(struct ap2_session_s *s)
+uint64_t ap2_session_epoch(struct ap2_session_s *s)
 {
     if (!s) return 0;
     pthread_mutex_lock(&s->lock);
-    uint64_t g = s->active ? s->active->gen.number : 0;
+    uint64_t e = s->epoch;
     pthread_mutex_unlock(&s->lock);
-    return g;
-}
-
-uint64_t ap2_session_position_ms(struct ap2_session_s *s)
-{
-    if (!s) return 0;
-    pthread_mutex_lock(&s->lock);
-    uint64_t pos = 0;
-    if (s->active)
-        pos = s->active->gen.position_ms +
-              s->played_bytes * 1000ULL / s->byte_rate;
-    pthread_mutex_unlock(&s->lock);
-    return pos;
+    return e;
 }

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -64,6 +64,7 @@ struct ap2_session_s {
     ap2_session_state_t state;
     uint64_t epoch;            /* bumped on every START */
     uint64_t idle_since_ms;    /* monotonic ms when we last went idle */
+    bool audio_seen;           /* first input bytes since create/FLUSH arrived */
     sring_t ring;
 };
 
@@ -199,7 +200,19 @@ static void *reader_thread(void *arg)
         while (off < (size_t)n && !s->abort && !s->drain_request) {
             size_t pushed = sring_push(&s->ring, buf + off, (size_t)n - off);
             off += pushed;
-            if (pushed) pthread_cond_broadcast(&s->can_read);
+            if (pushed) {
+                pthread_cond_broadcast(&s->can_read);
+                if (!s->audio_seen) {
+                    /* One-shot per start cycle: the caller uses this to know
+                     * the new track's audio is flowing before it commands a
+                     * START, so it can anchor with a short lead instead of
+                     * blind margin for source/transcoder spin-up. */
+                    s->audio_seen = true;
+                    emit(s, "[STATUS] audio buffered_ms=%llu",
+                         (unsigned long long)(s->ring.fill * 1000ULL /
+                                              s->byte_rate));
+                }
+            }
             if (off < (size_t)n)
                 pthread_cond_wait(&s->can_write, &s->lock);
         }
@@ -337,6 +350,9 @@ bool ap2_session_flush(struct ap2_session_s *s)
         pthread_cond_wait(&s->reader_paused_cond, &s->lock);
     sring_reset(&s->ring);
     drain_input_fd(s->input_fd);
+    /* Re-arm the one-shot audio signal: the next bytes to arrive belong to
+     * the new track and announce that its feed is flowing. */
+    s->audio_seen = false;
     /* Release the reader onto the now-empty ring: it buffers the next track
      * while we send nothing until the next START (idle-primed). */
     s->drain_request = false;

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -149,6 +149,18 @@ static void *reader_thread(void *arg)
                   strerror(errno));
         return NULL;
     }
+    /* The read loop below assumes a non-blocking fd: it polls for readiness and
+     * re-checks the abort flag on every poll timeout, so read() must never
+     * block. Named-pipe generations are opened O_NONBLOCK above, but generation
+     * 0 dup()s the process stdin, which is blocking and whose write end the
+     * caller keeps open for the whole process. Without this, once such a
+     * generation is superseded its read() blocks forever on the idle-but-open
+     * pipe, so retire_slot()'s join wedges the command-pipe thread and no
+     * further generation can be staged. Force non-blocking so read() yields
+     * EAGAIN and the loop can honour abort. */
+    int fl = fcntl(fd, F_GETFL, 0);
+    if (fl != -1)
+        (void)fcntl(fd, F_SETFL, fl | O_NONBLOCK);
     struct stat input_stat;
     if (fstat(fd, &input_stat) < 0) {
         int open_errno = errno;

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -136,6 +136,7 @@ static void drain_input_fd(int fd)
      * drain terminates on EAGAIN long before this. */
     for (int guard = 0; guard < 100000; guard++) {
         ssize_t n = read(fd, scratch, sizeof(scratch));
+        if (n < 0 && errno == EINTR) continue;   /* retry: bytes may remain */
         if (n <= 0) return;   /* EAGAIN / EOF / error: nothing more to discard */
     }
 }
@@ -259,9 +260,17 @@ struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
         ap2_session_destroy(s);
         return NULL;
     }
+    /* The reader's poll loop and the FLUSH drain (which runs on the cmdpipe
+     * thread under the session lock) both rely on reads never blocking, so a
+     * blocking input fd is not survivable — refuse to start rather than risk
+     * wedging the command thread later. */
     int fl = fcntl(s->input_fd, F_GETFL, 0);
-    if (fl != -1)
-        (void)fcntl(s->input_fd, F_SETFL, fl | O_NONBLOCK);
+    if (fl == -1 || fcntl(s->input_fd, F_SETFL, fl | O_NONBLOCK) == -1) {
+        LOG_ERROR("[SESSION] cannot make the input fd non-blocking: %s",
+                  strerror(errno));
+        ap2_session_destroy(s);
+        return NULL;
+    }
 
     if (pthread_create(&s->reader, NULL, reader_thread, s) != 0) {
         LOG_ERROR("[SESSION] cannot start input reader");

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -1,47 +1,43 @@
 /*
- * Persistent session - generation state machine
+ * Persistent session - single-stream flush-and-refill engine
  *
  * Separates connection lifetime from media lifetime: the binary connects once
- * and plays a sequence of numbered media GENERATIONS over that connection, so
- * seek/next/resume never pay the protocol setup cost again. Every generation is
- * supplied through the command pipe, including generation 0; the connection
- * outlives each generation (bounded by the idle timeout) awaiting PREPARE.
+ * and streams a single, persistent PCM input (the process stdin) over that
+ * connection for the whole process lifetime. Seek/next never re-connect and
+ * never re-open the input; instead the LIVE stream is flushed and refilled in
+ * place. The connection outlives each track (bounded by the idle timeout).
  *
- * Start times are COMMANDED, not configured: every generation (including
- * generation 0) starts on an explicit START, which the caller sends after
- * seeing `connected` and `primed`. The caller therefore never has to guess a
- * safe setup lead in advance - it picks the start once the expensive work has
- * already succeeded, and a group start is simply the same START_UNIX_MS sent
- * to every primed member. Starts of 0 or in the past clamp to now + the
- * minimum warm lead.
+ * One reader thread drains the input fd into one ring buffer for the whole
+ * session. The audio loop only ever calls ap2_session_read()/poll(). Start
+ * times are COMMANDED: playback (and each warm re-anchor) begins on an explicit
+ * START, so the caller picks the audible instant once the expensive work has
+ * already succeeded, and a group start is simply the same START_UNIX_MS sent to
+ * every member. Starts of 0 or in the past clamp to now + the minimum warm
+ * lead (enforced by the transport commit callback).
  *
- *   PREPARE(gen, audio pipe, position)  ->  ready  ->  primed
- *   START(gen, start time)              ->  flush old + swap + anchor -> playing
- *   STANDBY                             ->  stop playback, keep the connection warm
- *   DISCONNECT                          ->  real teardown
+ *   START(start time)  -> first call: full session start; a call after a FLUSH
+ *                         re-bases the frozen anchor and resumes from the ring
+ *   FLUSH              -> stop sending, RTSP-FLUSH the receiver, discard the
+ *                         ring, drain the input to EAGAIN; stream goes
+ *                         idle-primed (keeps buffering, sends nothing) until the
+ *                         next START. Emits `[STATUS] flushed`.
+ *   STANDBY            -> stop playback, keep the connection warm
+ *   END                -> real teardown (DISCONNECT / idle timeout)
  *
- * The next generation's audio arrives on its OWN pipe and is drained into a
- * staging ring while the current generation keeps playing, so source and DSP
- * preparation cost no audible time. The commit is the measured-fast warm
- * flush: RTSP FLUSH (+/- 5 ms) plus a re-based frozen anchor line, working
- * down to a 150 ms lead on tested receivers. Sequence numbers and audio
- * nonces are never reset within the connection; the media timeline re-bases
- * per generation.
+ * The input is never re-opened across a FLUSH: the caller (MA) restarts only
+ * the per-seek transcoder feeding the same persistent fd, so sequence numbers
+ * and audio nonces are never reset within the connection and crypto state stays
+ * valid across the boundary. The media timeline re-bases per START.
  *
  * Command pipe verbs (newline-terminated KEY=VALUE, existing verbs unchanged):
- *   GENERATION=<n>            select the generation the next ACTION applies to
- *   AUDIO=<path>              FIFO carrying this generation's PCM (PREPARE)
- *   POSITION_MS=<ms>          media position of the pipe's first byte
  *   START_UNIX_MS=<ms|0>      audible start instant; 0 = ASAP at the minimum
  *                             warm lead
- *   ACTION=PREPARE|START|FLUSH|STANDBY|DISCONNECT
+ *   ACTION=START|FLUSH|STANDBY|DISCONNECT
  *
- * Status lines (stderr, generation-tagged):
- *   [STATUS] ready generation=<n>
- *   [STATUS] primed generation=<n> prefill_ms=<ms>
- *   [STATUS] playing generation=<n> elapsed_ms=<ms>
- *   [STATUS] input_eof generation=<n>
- *   [STATUS] eof generation=<n>
+ * Status lines (stderr):
+ *   [STATUS] playing elapsed_ms=<ms>   (elapsed since the current START anchor)
+ *   [STATUS] flushed                   (FLUSH completed; stream idle-primed)
+ *   [STATUS] eof                       (input stream ended)
  *   [STATUS] idle_timeout
  *
  * Copyright (C) 2024-2026 Music Assistant Contributors
@@ -56,75 +52,69 @@
 
 /* Overall session-mode state. */
 typedef enum {
-    AP2_SESSION_IDLE = 0,     /* connected; no generation playing or staged */
-    AP2_SESSION_PREPARING,    /* staging ring filling for the next generation */
-    AP2_SESSION_PLAYING,      /* a generation is streaming */
+    AP2_SESSION_IDLE = 0,     /* connected; not sending (pre-start/post-flush) */
+    AP2_SESSION_PLAYING,      /* streaming the ring to the device */
     AP2_SESSION_STANDBY,      /* stopped on request; connection kept warm */
     AP2_SESSION_ENDED,        /* DISCONNECT requested or idle timeout hit */
 } ap2_session_state_t;
 
-/* One staged/active generation. Audio comes from opening `audio_path`, normally
- * a FIFO created by the caller; "-" duplicates process stdin and is limited to
- * one active generation because duplicated descriptors share the same stream. */
-typedef struct {
-    uint64_t number;          /* caller-assigned generation number */
-    const char *audio_path;   /* FIFO delivering this generation's PCM */
-    uint64_t position_ms;     /* media position of byte zero (progress base) */
-} ap2_generation_t;
-
 struct ap2_session_s;
 
 /*
- * Callbacks the session engine invokes from its own threads. All are
- * required. `commit` performs the transport work of a generation switch on a
- * LIVE connection: discard receiver-buffered audio and re-base the timeline
- * so the next written frame is audible at `start_unix_ms` (or now + the
- * minimum warm lead when 0). Returns false when the transport failed
- * terminally (the caller then ends the session so MA can fall back cold).
+ * Callbacks the session engine invokes from its own threads. All are required.
+ * `commit` performs the START transport work on a LIVE connection: on the first
+ * start it begins the session; after a FLUSH it re-bases the timeline so the
+ * next written frame is audible at `start_unix_ms` (or now + the minimum warm
+ * lead when 0). Returns false when the transport failed terminally (the caller
+ * then ends the session so MA can fall back cold). `flush` discards the
+ * receiver's buffered audio in place (RTSP FLUSH / libraop flush), keeping the
+ * session and timeline continuity; the re-anchor happens on the next `commit`.
  */
 typedef struct {
-    void (*quiesce)(void *transport);    /* pause audio sends across commit */
+    void (*quiesce)(void *transport);    /* pause audio sends across a command */
+    void (*flush)(void *transport);      /* RTSP-flush receiver, keep session */
     bool (*commit)(void *transport, uint64_t start_unix_ms);
-    void (*resume)(void *transport);     /* resume sends after active swap */
-    void (*stop)(void *transport);      /* silence the receiver, keep session */
-    void (*status)(const char *line);   /* emit one [STATUS] line */
+    void (*resume)(void *transport);     /* resume sends after the command */
+    void (*stop)(void *transport);       /* silence the receiver, keep session */
+    void (*status)(const char *line);    /* emit one [STATUS] line */
     void *transport;
 } ap2_session_ops_t;
 
 /*
- * Create the session engine.
+ * Create the session engine and start its single input reader.
  *
- * :param ops: transport quiesce/commit/resume + status emit callbacks.
+ * :param ops: transport quiesce/flush/commit/resume/stop + status callbacks.
  * :param byte_rate: PCM byte rate of the input format (ring sizing/timing).
- * :param prefill_ms: staging ring fill level that emits `primed`.
- * :param idle_timeout_ms: end the session after this long without a playing
- *                         or preparing generation (orphan safety net).
+ * :param idle_timeout_ms: end the session after this long idle (no playing
+ *                         stream), an orphan safety net; 0 disables it.
+ * :param input_fd: PCM input descriptor (normally the process stdin). The
+ *                  engine duplicates it, drives it non-blocking, and reads it
+ *                  for the whole session; the caller keeps ownership of its own
+ *                  descriptor.
  */
 struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
-                                         unsigned byte_rate, int prefill_ms,
-                                         int idle_timeout_ms);
+                                         unsigned byte_rate, int idle_timeout_ms,
+                                         int input_fd);
 void ap2_session_destroy(struct ap2_session_s *s);
 
 /* Command-pipe entry points, serialized by the single cmdpipe thread. Invalid
  * transitions are rejected with a [STATUS]/log line and return false. */
-bool ap2_session_prepare(struct ap2_session_s *s, const ap2_generation_t *gen);
-bool ap2_session_start(struct ap2_session_s *s, uint64_t generation,
-                       uint64_t start_unix_ms);
-bool ap2_session_flush(struct ap2_session_s *s, uint64_t generation);
+bool ap2_session_start(struct ap2_session_s *s, uint64_t start_unix_ms);
+bool ap2_session_flush(struct ap2_session_s *s);
 bool ap2_session_standby(struct ap2_session_s *s);
 void ap2_session_end(struct ap2_session_s *s);
 
-/* Audio-loop entry points. `read` returns PCM from the ACTIVE generation's
- * ring (blocking up to timeout_ms; 0 on generation boundary/underrun, -1 on
- * end-of-generation, -2 when the session ended). The loop calls `poll` once
- * per iteration so the engine can run timeouts and complete commits. */
+/* Audio-loop entry points. `read` returns PCM from the ring while PLAYING
+ * (blocking up to timeout_ms; 0 on underrun/not-yet-playing, -1 on end of the
+ * input stream, -2 when the session ended). The loop calls `poll` once per
+ * iteration so the engine can run the idle timeout. */
 int ap2_session_read(struct ap2_session_s *s, uint8_t *buf, int len,
                      int timeout_ms);
 void ap2_session_poll(struct ap2_session_s *s);
 
 ap2_session_state_t ap2_session_state(struct ap2_session_s *s);
-uint64_t ap2_session_active_generation(struct ap2_session_s *s);
-/* Media position of the active generation (position_ms + played ms). */
-uint64_t ap2_session_position_ms(struct ap2_session_s *s);
+/* Monotonic counter bumped on every START; the audio loop resets its
+ * per-track bookkeeping (elapsed, alignment) when it changes. */
+uint64_t ap2_session_epoch(struct ap2_session_s *s);
 
 #endif /* __AP2_SESSION_H_ */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -161,16 +161,12 @@ static void status_connected(void)
     status_print("[STATUS] connected");
 }
 
-/* Persistent-session engine: every generation is commanded through the
- * command pipe, including generation 0. */
-#define SESSION_PREFILL_MS        500     /* staging fill that emits `primed` */
+/* Persistent-session engine: one stdin-backed PCM stream, flushed and refilled
+ * in place across seeks; playback (and each warm re-anchor) begins on START. */
 #define SESSION_IDLE_TIMEOUT_MS   120000  /* orphan safety net */
 static struct ap2_session_s *g_session = NULL;
 static pthread_mutex_t g_audio_send_lock = PTHREAD_MUTEX_INITIALIZER;
 static bool g_first_start_done = false;
-static uint64_t g_pend_generation = 0;
-static char g_pend_audio[512];
-static uint64_t g_pend_position_ms = 0;
 static uint64_t g_pend_start_unix_ms = 0;
 
 static void session_quiesce(void *transport)
@@ -374,40 +370,14 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
             ap2cl_set_volume(g_ap2cl, vol);
         }
-    } else if (strcmp(key, "GENERATION") == 0) {
-        g_pend_generation = strtoull(value, NULL, 10);
-    } else if (strcmp(key, "AUDIO") == 0) {
-        int written = snprintf(g_pend_audio, sizeof(g_pend_audio), "%s", value);
-        if (written < 0 || (size_t)written >= sizeof(g_pend_audio)) {
-            /* A truncated path would fail to open later at PREPARE with an
-             * opaque error; reject it here where the cause is clear. */
-            LOG_ERROR("AUDIO path too long (%zu bytes, max %zu)",
-                      strlen(value), sizeof(g_pend_audio) - 1);
-            g_pend_audio[0] = '\0';
-            status_error("AUDIO path too long");
-        }
-    } else if (strcmp(key, "POSITION_MS") == 0) {
-        g_pend_position_ms = strtoull(value, NULL, 10);
     } else if (strcmp(key, "START_UNIX_MS") == 0) {
         g_pend_start_unix_ms = strtoull(value, NULL, 10);
-    } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "PREPARE") == 0) {
-        ap2_generation_t gen = {
-            .number = g_pend_generation,
-            .audio_path = g_pend_audio[0] ? g_pend_audio : NULL,
-            .position_ms = g_pend_position_ms,
-        };
-        if (!g_session || !ap2_session_prepare(g_session, &gen))
-            status_error("PREPARE failed");
-        g_pend_audio[0] = '\0';
-        g_pend_position_ms = 0;
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "START") == 0) {
-        if (!g_session ||
-            !ap2_session_start(g_session, g_pend_generation,
-                               g_pend_start_unix_ms))
+        if (!g_session || !ap2_session_start(g_session, g_pend_start_unix_ms))
             status_error("START failed");
         g_pend_start_unix_ms = 0;
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "FLUSH") == 0) {
-        if (!g_session || !ap2_session_flush(g_session, g_pend_generation))
+        if (!g_session || !ap2_session_flush(g_session))
             status_error("FLUSH failed");
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "STANDBY") == 0) {
         if (g_session) ap2_session_standby(g_session);
@@ -495,15 +465,20 @@ static bool session_commit(void *transport, uint64_t start_unix_ms)
 {
     cli_config_t *cfg = transport;
     bool committed;
+    /* The first START begins the session; a START after a FLUSH re-anchors the
+     * flushed stream (no second receiver flush, no crypto/sequence reset). */
     if (cfg->protocol == PROTO_RAOP) {
         struct raopcl_s *client = g_raopcl;
-        committed = client && raop_session_commit(client, start_unix_ms);
+        if (!client) return false;
+        committed = !g_first_start_done
+            ? raop_session_commit(client, start_unix_ms)
+            : raop_session_start_at(client, start_unix_ms);
     } else {
         struct ap2cl_s *client = g_ap2cl;
         if (!client) return false;
         committed = !g_first_start_done
             ? ap2cl_start(client, start_unix_ms)
-            : ap2cl_warm_flush(client, start_unix_ms);
+            : ap2cl_resume(client, start_unix_ms);
     }
     if (!committed) return false;
 
@@ -512,6 +487,20 @@ static bool session_commit(void *transport, uint64_t start_unix_ms)
     g_first_start_done = true;
     g_status = STATUS_PLAYING;
     return true;
+}
+
+/* Discard the receiver's buffered audio in place for a warm seek and mark the
+ * stream not-playing; the next START re-anchors and resumes sending. */
+static void session_flush_op(void *transport)
+{
+    cli_config_t *cfg = transport;
+    if (cfg->protocol == PROTO_RAOP) {
+        if (g_raopcl && !raop_session_flush(g_raopcl))
+            status_error("RAOP flush failed");
+    } else if (g_ap2cl) {
+        ap2cl_flush(g_ap2cl);
+    }
+    if (g_status == STATUS_PLAYING) g_status = STATUS_PAUSED;
 }
 
 static void session_stop_op(void *transport)
@@ -638,6 +627,7 @@ static bool start_stream_session(cli_config_t *cfg, int input_bpf)
 {
     ap2_session_ops_t ops = {
         .quiesce = session_quiesce,
+        .flush = session_flush_op,
         .commit = session_commit,
         .resume = session_resume,
         .stop = session_stop_op,
@@ -646,7 +636,7 @@ static bool start_stream_session(cli_config_t *cfg, int input_bpf)
     };
     g_session = ap2_session_create(
         &ops, (unsigned)cfg->sample_rate * (unsigned)input_bpf,
-        SESSION_PREFILL_MS, SESSION_IDLE_TIMEOUT_MS);
+        SESSION_IDLE_TIMEOUT_MS, STDIN_FILENO);
     if (!g_session) {
         status_error("Cannot create session engine");
         return false;
@@ -771,9 +761,9 @@ static int run_raop(cli_config_t *cfg)
     }
 
     uint64_t last = 0, frames = 0;
-    uint64_t current_gen = ap2_session_active_generation(g_session);
+    uint64_t current_epoch = ap2_session_epoch(g_session);
     bool playback_failed = false;
-    bool gen_eof = false;
+    bool input_ended = false;
     bool eof_reported = false;
     uint64_t eof_time = 0;
     int pcm_carry = 0;
@@ -791,11 +781,13 @@ static int run_raop(cli_config_t *cfg)
             break;
         }
 
-        uint64_t active = ap2_session_active_generation(g_session);
-        if (active != current_gen) {
-            current_gen = active;
+        /* Each START bumps the epoch; reset the per-track bookkeeping so
+         * elapsed and frame alignment restart at the new anchor. */
+        uint64_t epoch = ap2_session_epoch(g_session);
+        if (epoch != current_epoch) {
+            current_epoch = epoch;
             frames = 0;
-            gen_eof = false;
+            input_ended = false;
             eof_reported = false;
             eof_time = 0;
             pcm_carry = 0;
@@ -803,7 +795,7 @@ static int run_raop(cli_config_t *cfg)
 
         /* Periodic status reporting (only while playing, so a pause does not keep
            emitting a "playing" status that would revive the sender's play state) */
-        if (g_status == STATUS_PLAYING && !gen_eof &&
+        if (g_status == STATUS_PLAYING && !input_ended &&
             now - last > MS2NTP(1000)) {
             last = now;
             if (frames > (uint64_t)raopcl_latency(g_raopcl)) {
@@ -812,15 +804,13 @@ static int run_raop(cli_config_t *cfg)
             }
         }
 
-        if (gen_eof) {
+        if (input_ended) {
             bool drained = !raopcl_is_playing(g_raopcl) ||
                            now - eof_time > MS2NTP(
                                TS2MS(raopcl_latency(g_raopcl),
                                      raopcl_sample_rate(g_raopcl)) + 2000);
             if (drained && !eof_reported) {
                 eof_reported = true;
-                status_print("[STATUS] eof generation=%llu",
-                             (unsigned long long)current_gen);
                 status_eof();
             }
             usleep(drained ? 50000 : 10000);
@@ -836,11 +826,11 @@ static int run_raop(cli_config_t *cfg)
                 usleep(1000);
                 continue;
             }
-            active = ap2_session_active_generation(g_session);
-            if (active != current_gen) {
-                current_gen = active;
+            epoch = ap2_session_epoch(g_session);
+            if (epoch != current_epoch) {
+                current_epoch = epoch;
                 frames = 0;
-                gen_eof = false;
+                input_ended = false;
                 eof_reported = false;
                 eof_time = 0;
                 pcm_carry = 0;
@@ -862,9 +852,8 @@ static int run_raop(cli_config_t *cfg)
                 break;
             }
             if (n == -1) {
-                LOG_INFO("End of RAOP generation %llu input, draining...",
-                         (unsigned long long)current_gen);
-                gen_eof = true;
+                LOG_INFO("End of RAOP input stream, draining...");
+                input_ended = true;
                 eof_time = raopcl_get_ntp(NULL);
                 pthread_mutex_unlock(&g_audio_send_lock);
                 continue;
@@ -1005,21 +994,21 @@ static int run_airplay2(cli_config_t *cfg)
         ap2cl_set_volume(g_ap2cl, cfg->volume);
     }
 
-    /* The session starts empty. Every generation, including generation 0, is
-     * prepared and started by the command-pipe thread after connection setup. */
+    /* The reader begins draining stdin into the ring immediately; the command
+     * pipe thread anchors playback on the first START after connection setup. */
     int ap2_input_bpf = (cfg->bit_depth <= 16 ? 2 : 4) * cfg->channels;
     int ap2_alac_bpf = (cfg->bit_depth <= 16 ? 2 : 3) * cfg->channels;
     if (!start_stream_session(cfg, ap2_input_bpf)) return 1;
     status_connected();
 
     uint64_t last = 0, frames = 0;
-    uint64_t current_gen = ap2_session_active_generation(g_session);
+    uint64_t current_epoch = ap2_session_epoch(g_session);
     uint8_t *buf = malloc(AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
     uint8_t *ap2_alac_buf = (cfg->bit_depth > 16) ? malloc(AP2_FRAMES_PER_CHUNK * ap2_alac_bpf) : NULL;
     bool playback_failed = false;
     bool starving = false;
     uint64_t starvation_started = 0;
-    bool gen_eof = false;         /* active generation's input fully consumed */
+    bool input_ended = false;     /* the input stream was fully consumed */
     bool eof_reported = false;
     uint64_t eof_time = 0;
     int pcm_carry = 0;            /* sub-frame remainder between ring reads */
@@ -1038,12 +1027,13 @@ static int run_airplay2(cli_config_t *cfg)
             break;
         }
 
-        /* A generation switch resets the per-generation bookkeeping. */
-        uint64_t active = ap2_session_active_generation(g_session);
-        if (active != current_gen) {
-            current_gen = active;
+        /* Each START bumps the epoch; reset the per-track bookkeeping so
+         * elapsed and frame alignment restart at the new anchor. */
+        uint64_t epoch = ap2_session_epoch(g_session);
+        if (epoch != current_epoch) {
+            current_epoch = epoch;
             frames = 0;
-            gen_eof = false;
+            input_ended = false;
             eof_reported = false;
             eof_time = 0;
             pcm_carry = 0;
@@ -1051,7 +1041,7 @@ static int run_airplay2(cli_config_t *cfg)
 
         /* Periodic status reporting (only while playing, so a pause does not keep
            emitting a "playing" status that would revive the sender's play state) */
-        if (g_status == STATUS_PLAYING && !gen_eof && now - last > MS2NTP(1000)) {
+        if (g_status == STATUS_PLAYING && !input_ended && now - last > MS2NTP(1000)) {
             last = now;
             uint32_t latency_frames = MS2TS(cfg->latency_ms, cfg->sample_rate);
             if (frames > latency_frames) {
@@ -1060,15 +1050,13 @@ static int run_airplay2(cli_config_t *cfg)
             }
         }
 
-        if (gen_eof) {
+        if (input_ended) {
             /* Input consumed: let the receiver drain, report once, then idle
-             * awaiting the next commanded generation or idle timeout. */
+             * awaiting the next START or the idle timeout. */
             bool drained = !ap2cl_is_playing(g_ap2cl) ||
                            now - eof_time > MS2NTP(cfg->latency_ms + 2000);
             if (drained && !eof_reported) {
                 eof_reported = true;
-                status_print("[STATUS] eof generation=%llu",
-                             (unsigned long long)current_gen);
                 status_eof();
             }
             usleep(drained ? 50000 : 10000);
@@ -1084,11 +1072,11 @@ static int run_airplay2(cli_config_t *cfg)
                 usleep(1000);
                 continue;
             }
-            active = ap2_session_active_generation(g_session);
-            if (active != current_gen) {
-                current_gen = active;
+            epoch = ap2_session_epoch(g_session);
+            if (epoch != current_epoch) {
+                current_epoch = epoch;
                 frames = 0;
-                gen_eof = false;
+                input_ended = false;
                 eof_reported = false;
                 eof_time = 0;
                 pcm_carry = 0;
@@ -1112,9 +1100,8 @@ static int run_airplay2(cli_config_t *cfg)
                 break;
             }
             if (n == -1) {
-                LOG_INFO("End of generation %llu input, draining buffer...",
-                         (unsigned long long)current_gen);
-                gen_eof = true;
+                LOG_INFO("End of AirPlay 2 input stream, draining buffer...");
+                input_ended = true;
                 eof_time = raopcl_get_ntp(NULL);
                 pthread_mutex_unlock(&g_audio_send_lock);
                 continue;
@@ -1533,7 +1520,7 @@ int main(int argc, char *argv[])
     }
     if (optind < argc) {
         status_error(
-            "Streaming audio must be provided by cmdpipe PREPARE, not argv");
+            "Streaming audio must be provided on stdin, not argv");
         return 1;
     }
 

--- a/src/raop_session.c
+++ b/src/raop_session.c
@@ -34,7 +34,19 @@ bool raop_session_commit(struct raopcl_s *client, uint64_t start_unix_ms)
     return raopcl_start_at(client, audible_ntp - latency_ntp);
 }
 
-bool raop_session_standby(struct raopcl_s *client)
+bool raop_session_start_at(struct raopcl_s *client, uint64_t start_unix_ms)
+{
+    if (!client) return false;
+    raop_state_t state = raopcl_state(client);
+    if (state != RAOP_STREAMING && state != RAOP_FLUSHED) return false;
+
+    uint64_t audible_ntp = commanded_audible_ntp(start_unix_ms);
+    uint64_t latency_ntp =
+        TS2NTP(raopcl_latency(client), raopcl_sample_rate(client));
+    return raopcl_start_at(client, audible_ntp - latency_ntp);
+}
+
+bool raop_session_flush(struct raopcl_s *client)
 {
     if (!client) return false;
     raop_state_t state = raopcl_state(client);
@@ -42,6 +54,11 @@ bool raop_session_standby(struct raopcl_s *client)
     raopcl_stop(client);
     if (state == RAOP_FLUSHED) return true;
     return raopcl_flush(client);
+}
+
+bool raop_session_standby(struct raopcl_s *client)
+{
+    return raop_session_flush(client);
 }
 
 bool raop_session_pause(struct raopcl_s *client)

--- a/src/raop_session.c
+++ b/src/raop_session.c
@@ -21,8 +21,8 @@ bool raop_session_commit(struct raopcl_s *client, uint64_t start_unix_ms)
 
     raop_state_t state = raopcl_state(client);
     if (state != RAOP_STREAMING && state != RAOP_FLUSHED) return false;
-    /* Generation switches discard old backlog. pause() would preserve one
-     * latency window and replay it before the new generation. */
+    /* A commanded (re)start discards the old backlog. pause() would preserve
+     * one latency window and replay it before the new track. */
     raopcl_stop(client);
     if (state == RAOP_STREAMING) {
         if (!raopcl_flush(client)) return false;

--- a/src/raop_session.c
+++ b/src/raop_session.c
@@ -37,8 +37,11 @@ bool raop_session_commit(struct raopcl_s *client, uint64_t start_unix_ms)
 bool raop_session_start_at(struct raopcl_s *client, uint64_t start_unix_ms)
 {
     if (!client) return false;
+    /* Only valid after a flush (seek/standby): re-anchoring a live stream
+     * would replay the receiver's retained backlog against the new timeline.
+     * Rejecting STREAMING makes a START without a preceding FLUSH fail fast. */
     raop_state_t state = raopcl_state(client);
-    if (state != RAOP_STREAMING && state != RAOP_FLUSHED) return false;
+    if (state != RAOP_FLUSHED) return false;
 
     uint64_t audible_ntp = commanded_audible_ntp(start_unix_ms);
     uint64_t latency_ntp =

--- a/src/raop_session.h
+++ b/src/raop_session.h
@@ -23,10 +23,10 @@ bool raop_session_flush(struct raopcl_s *client);
 /* Silence playback while preserving the RAOP connection for a later START. */
 bool raop_session_standby(struct raopcl_s *client);
 
-/* Pause and retain the current generation's backlog for ACTION=PLAY. */
+/* Pause and retain the current stream's backlog for ACTION=PLAY. */
 bool raop_session_pause(struct raopcl_s *client);
 
-/* Resume a paused generation without discarding libraop's retained backlog. */
+/* Resume a paused stream without discarding libraop's retained backlog. */
 bool raop_session_resume(struct raopcl_s *client);
 
 #endif /* RAOP_SESSION_H */

--- a/src/raop_session.h
+++ b/src/raop_session.h
@@ -6,10 +6,19 @@
 
 struct raopcl_s;
 
-/* Commit a commanded generation on an existing RAOP connection. The command
- * carries the audible first-sample unix time; 0 or stale values use a safe
- * ASAP lead. A currently streaming generation is flushed before re-anchoring. */
+/* Commit the first START on an existing RAOP connection. The command carries
+ * the audible first-sample unix time; 0 or stale values use a safe ASAP lead. A
+ * currently streaming stream is flushed before re-anchoring. */
 bool raop_session_commit(struct raopcl_s *client, uint64_t start_unix_ms);
+
+/* Re-anchor a flushed stream to a new audible start (the START after a FLUSH).
+ * Unlike commit it does not stop/flush again — the receiver buffer was already
+ * discarded by raop_session_flush — so no crypto/sequence state is reset. */
+bool raop_session_start_at(struct raopcl_s *client, uint64_t start_unix_ms);
+
+/* Discard the receiver's buffered audio in place for a warm seek, keeping the
+ * connection; the next START re-anchors via raop_session_start_at. */
+bool raop_session_flush(struct raopcl_s *client);
 
 /* Silence playback while preserving the RAOP connection for a later START. */
 bool raop_session_standby(struct raopcl_s *client);

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -13,7 +13,6 @@
 #include "ap2_bplist.h"
 #include "ap2_client.h"
 #include "ap2_io.h"
-#include "ap2_session.h"
 #include "cross_log.h"
 
 static log_level test_log_level = lSILENCE;
@@ -25,302 +24,6 @@ void ap2cl_test_lock_mrp(struct ap2cl_s *p);
 void ap2cl_test_unlock_mrp(struct ap2cl_s *p);
 void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd);
 void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p);
-
-typedef struct {
-    atomic_bool ready;
-    atomic_bool primed;
-    int commit_count;
-    int stop_count;
-    uint64_t start_unix_ms;
-} session_test_state_t;
-
-static session_test_state_t *session_status_state;
-
-static bool session_test_commit(void *transport, uint64_t start_unix_ms)
-{
-    session_test_state_t *state = transport;
-    state->commit_count++;
-    state->start_unix_ms = start_unix_ms;
-    return true;
-}
-
-static void session_test_quiesce(void *transport)
-{
-    (void)transport;
-}
-
-static void session_test_resume(void *transport)
-{
-    (void)transport;
-}
-
-static void session_test_stop(void *transport)
-{
-    session_test_state_t *state = transport;
-    state->stop_count++;
-}
-
-static void session_test_status(const char *line)
-{
-    if (strstr(line, "[STATUS] ready generation=0"))
-        atomic_store(&session_status_state->ready, true);
-    if (strstr(line, "[STATUS] primed generation=0"))
-        atomic_store(&session_status_state->primed, true);
-}
-
-static void test_generation_zero_requires_prepare_then_start(void)
-{
-    static const uint8_t audio[] = {
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-    };
-    char path[] = "/tmp/cliairplay-session-test.XXXXXX";
-    int fd = mkstemp(path);
-    assert(fd >= 0);
-    assert(write(fd, audio, sizeof(audio)) == (ssize_t)sizeof(audio));
-    assert(close(fd) == 0);
-
-    session_test_state_t state = {0};
-    atomic_init(&state.ready, false);
-    atomic_init(&state.primed, false);
-    session_status_state = &state;
-    ap2_session_ops_t ops = {
-        .quiesce = session_test_quiesce,
-        .commit = session_test_commit,
-        .resume = session_test_resume,
-        .stop = session_test_stop,
-        .status = session_test_status,
-        .transport = &state,
-    };
-    struct ap2_session_s *session =
-        ap2_session_create(&ops, 1000, 500, 20);
-    assert(session);
-
-    ap2_generation_t generation = {
-        .number = 0,
-        .audio_path = path,
-        .position_ms = 0,
-    };
-    assert(ap2_session_prepare(session, &generation));
-    for (int i = 0;
-         i < 200 && (!atomic_load(&state.ready) ||
-                     !atomic_load(&state.primed));
-         i++)
-        usleep(5000);
-    assert(atomic_load(&state.ready));
-    assert(atomic_load(&state.primed));
-    assert(state.commit_count == 0);
-    assert(ap2_session_state(session) == AP2_SESSION_PREPARING);
-
-    uint8_t received[sizeof(audio)] = {0};
-    assert(ap2_session_read(
-               session, received, sizeof(received), 10) == 0);
-    const uint64_t audible_start = 1770000000123ULL;
-    assert(ap2_session_start(session, 0, audible_start));
-    assert(state.commit_count == 1);
-    assert(state.start_unix_ms == audible_start);
-    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
-
-    char staged_path[] = "/tmp/cliairplay-staged-fifo.XXXXXX";
-    int staged_placeholder = mkstemp(staged_path);
-    assert(staged_placeholder >= 0);
-    assert(close(staged_placeholder) == 0);
-    assert(unlink(staged_path) == 0);
-    assert(mkfifo(staged_path, 0600) == 0);
-    ap2_generation_t staged_generation = {
-        .number = 1,
-        .audio_path = staged_path,
-    };
-    assert(ap2_session_prepare(session, &staged_generation));
-    assert(ap2_session_flush(session, 1));
-    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
-    assert(unlink(staged_path) == 0);
-
-    assert(ap2_session_read(
-               session, received, sizeof(received), 10) ==
-           (int)sizeof(received));
-    assert(memcmp(received, audio, sizeof(audio)) == 0);
-    assert(ap2_session_read(
-               session, received, sizeof(received), 100) == -1);
-    assert(ap2_session_state(session) == AP2_SESSION_IDLE);
-    usleep(30000);
-    ap2_session_poll(session);
-    assert(ap2_session_state(session) == AP2_SESSION_ENDED);
-
-    ap2_session_destroy(session);
-    session_status_state = NULL;
-    assert(unlink(path) == 0);
-}
-
-static void test_idle_fifo_does_not_block_shutdown(void)
-{
-    char path[] = "/tmp/cliairplay-session-fifo.XXXXXX";
-    int placeholder = mkstemp(path);
-    assert(placeholder >= 0);
-    assert(close(placeholder) == 0);
-    assert(unlink(path) == 0);
-    assert(mkfifo(path, 0600) == 0);
-
-    session_test_state_t state = {0};
-    atomic_init(&state.ready, false);
-    atomic_init(&state.primed, false);
-    session_status_state = &state;
-    ap2_session_ops_t ops = {
-        .quiesce = session_test_quiesce,
-        .commit = session_test_commit,
-        .resume = session_test_resume,
-        .stop = session_test_stop,
-        .status = session_test_status,
-        .transport = &state,
-    };
-    struct ap2_session_s *session =
-        ap2_session_create(&ops, 1000, 500, 0);
-    assert(session);
-    ap2_generation_t generation = {
-        .number = 0,
-        .audio_path = path,
-    };
-    assert(ap2_session_prepare(session, &generation));
-
-    uint64_t started = ap2_io_monotonic_ms();
-    assert(ap2_session_flush(session, 0));
-    assert(ap2_io_monotonic_ms() - started < 1000);
-    assert(ap2_session_state(session) == AP2_SESSION_IDLE);
-    ap2_session_destroy(session);
-
-    atomic_store(&state.ready, false);
-    session = ap2_session_create(&ops, 1000, 500, 0);
-    assert(session);
-    assert(ap2_session_prepare(session, &generation));
-    int writer = open(path, O_WRONLY);
-    assert(writer >= 0);
-    for (int i = 0; i < 200 && !atomic_load(&state.ready); i++)
-        usleep(5000);
-    assert(atomic_load(&state.ready));
-
-    started = ap2_io_monotonic_ms();
-    ap2_session_destroy(session);
-    assert(ap2_io_monotonic_ms() - started < 1000);
-    session_status_state = NULL;
-    assert(close(writer) == 0);
-    assert(unlink(path) == 0);
-}
-
-static void test_stdin_generation_uses_command_path(void)
-{
-    static const uint8_t audio[] = {
-        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
-    };
-    int input[2];
-    assert(pipe(input) == 0);
-    int saved_stdin = dup(STDIN_FILENO);
-    assert(saved_stdin >= 0);
-    assert(dup2(input[0], STDIN_FILENO) == STDIN_FILENO);
-    assert(close(input[0]) == 0);
-
-    session_test_state_t state = {0};
-    atomic_init(&state.ready, false);
-    atomic_init(&state.primed, false);
-    session_status_state = &state;
-    ap2_session_ops_t ops = {
-        .quiesce = session_test_quiesce,
-        .commit = session_test_commit,
-        .resume = session_test_resume,
-        .stop = session_test_stop,
-        .status = session_test_status,
-        .transport = &state,
-    };
-    struct ap2_session_s *session =
-        ap2_session_create(&ops, 1000, 500, 0);
-    assert(session);
-    ap2_generation_t generation = {
-        .number = 0,
-        .audio_path = "-",
-    };
-    assert(ap2_session_prepare(session, &generation));
-    assert(write(input[1], audio, sizeof(audio)) == (ssize_t)sizeof(audio));
-    assert(close(input[1]) == 0);
-    for (int i = 0;
-         i < 200 && (!atomic_load(&state.ready) ||
-                     !atomic_load(&state.primed));
-         i++)
-        usleep(5000);
-    assert(atomic_load(&state.ready));
-    assert(atomic_load(&state.primed));
-    assert(state.commit_count == 0);
-    assert(ap2_session_start(session, 0, 1700000000000ULL));
-    ap2_generation_t overlapping_stdin = {
-        .number = 1,
-        .audio_path = "-",
-    };
-    assert(!ap2_session_prepare(session, &overlapping_stdin));
-
-    uint8_t received[sizeof(audio)] = {0};
-    assert(ap2_session_read(
-               session, received, sizeof(received), 100) ==
-           (int)sizeof(received));
-    assert(memcmp(received, audio, sizeof(audio)) == 0);
-    ap2_session_destroy(session);
-    session_status_state = NULL;
-
-    assert(dup2(saved_stdin, STDIN_FILENO) == STDIN_FILENO);
-    assert(close(saved_stdin) == 0);
-}
-
-static void test_standby_keeps_session_reusable(void)
-{
-    static const uint8_t audio[] = {0x20, 0x21, 0x22, 0x23};
-    char first_path[] = "/tmp/cliairplay-standby-first.XXXXXX";
-    char second_path[] = "/tmp/cliairplay-standby-second.XXXXXX";
-    int first_fd = mkstemp(first_path);
-    int second_fd = mkstemp(second_path);
-    assert(first_fd >= 0);
-    assert(second_fd >= 0);
-    assert(write(first_fd, audio, sizeof(audio)) == (ssize_t)sizeof(audio));
-    assert(write(second_fd, audio, sizeof(audio)) == (ssize_t)sizeof(audio));
-    assert(close(first_fd) == 0);
-    assert(close(second_fd) == 0);
-
-    session_test_state_t state = {0};
-    atomic_init(&state.ready, false);
-    atomic_init(&state.primed, false);
-    session_status_state = &state;
-    ap2_session_ops_t ops = {
-        .quiesce = session_test_quiesce,
-        .commit = session_test_commit,
-        .resume = session_test_resume,
-        .stop = session_test_stop,
-        .status = session_test_status,
-        .transport = &state,
-    };
-    struct ap2_session_s *session =
-        ap2_session_create(&ops, 1000, 1, 0);
-    assert(session);
-
-    ap2_generation_t first = {
-        .number = 0,
-        .audio_path = first_path,
-    };
-    assert(ap2_session_prepare(session, &first));
-    assert(ap2_session_start(session, 0, 1700000000000ULL));
-    assert(ap2_session_standby(session));
-    assert(state.stop_count == 1);
-    assert(ap2_session_state(session) == AP2_SESSION_STANDBY);
-
-    ap2_generation_t second = {
-        .number = 1,
-        .audio_path = second_path,
-    };
-    assert(ap2_session_prepare(session, &second));
-    assert(ap2_session_start(session, 1, 1700000005000ULL));
-    assert(state.commit_count == 2);
-    assert(ap2_session_active_generation(session) == 1);
-    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
-
-    ap2_session_destroy(session);
-    session_status_state = NULL;
-    assert(unlink(first_path) == 0);
-    assert(unlink(second_path) == 0);
-}
 
 typedef struct {
     int fd;
@@ -369,7 +72,9 @@ static void *run_rtsp_flush_peer(void *arg)
     return NULL;
 }
 
-static void test_native_standby_keeps_rtsp_session_reusable(void)
+/* A standby then a warm seek (ap2cl_flush + ap2cl_resume) each send exactly one
+ * RTSP FLUSH and reuse the same native session — no reconnect, no crypto reset. */
+static void test_native_flush_resume_reuses_rtsp_session(void)
 {
     int sockets[2];
     assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
@@ -399,7 +104,9 @@ static void test_native_standby_keeps_rtsp_session_reusable(void)
 
     ap2cl_standby(client);
     assert(ap2cl_state(client) == AP2_CONNECTED);
-    assert(ap2cl_warm_flush(client, 1700000005000ULL));
+    /* Warm seek: discard the receiver buffer, then re-anchor the timeline. */
+    assert(ap2cl_flush(client));
+    assert(ap2cl_resume(client, 1700000005000ULL));
     assert(ap2cl_state(client) == AP2_STREAMING);
 
     assert(pthread_join(peer_thread, NULL) == 0);
@@ -496,11 +203,7 @@ static void test_info_format_tables(void)
 int main(void)
 {
     test_info_format_tables();
-    test_generation_zero_requires_prepare_then_start();
-    test_idle_fifo_does_not_block_shutdown();
-    test_stdin_generation_uses_command_path();
-    test_standby_keeps_session_reusable();
-    test_native_standby_keeps_rtsp_session_reusable();
+    test_native_flush_resume_reuses_rtsp_session();
 
     ap2_device_info_t device = {
         .name = "test",

--- a/tests/test_ap2_raop_lifecycle.c
+++ b/tests/test_ap2_raop_lifecycle.c
@@ -300,7 +300,11 @@ static bool test_standby_reuses_raop_compatible_connection(void)
     CHECK(mock.disconnects == 0);
     CHECK(mock.destroys == 0);
 
-    CHECK(ap2cl_warm_flush(client, 1700000008000ULL));
+    /* A warm seek is now FLUSH (discard receiver buffer) + START (re-anchor):
+     * flush stops the flushed stream again, resume re-arms start-at. No extra
+     * receiver flush, so mock.flushes stays 1. */
+    CHECK(ap2cl_flush(client));
+    CHECK(ap2cl_resume(client, 1700000008000ULL));
     CHECK(ap2cl_state(client) == AP2_STREAMING);
     CHECK(mock.last_transport_client == transport_client);
     CHECK(mock.stops == 2);

--- a/tests/test_ap2_session.c
+++ b/tests/test_ap2_session.c
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include "ap2_io.h"
@@ -19,307 +18,289 @@
 static log_level test_log_level = lSILENCE;
 log_level *loglevel = &test_log_level;
 
-#define MAX_GENERATIONS 64
-
-typedef struct {
-    atomic_int ready[MAX_GENERATIONS];
-    atomic_int primed[MAX_GENERATIONS];
-    atomic_int eof[MAX_GENERATIONS];
-    atomic_int commits;
-    atomic_int quiesces;
-    atomic_int resumes;
-} test_state_t;
-
-static test_state_t *status_state;
-static atomic_int injected_poll_step;
-static atomic_bool inject_no_writer_events;
-
+/* ap2_session.c is compiled with -Dpoll=ap2_session_test_poll; the single-stream
+ * model no longer needs poll injection, so just delegate to the real poll. */
 int ap2_session_test_poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {
-    if (atomic_load(&inject_no_writer_events)) {
-        int step = atomic_fetch_add(&injected_poll_step, 1);
-        if (step == 0) {
-            usleep((useconds_t)timeout * 1000);
-            for (nfds_t i = 0; i < nfds; i++) fds[i].revents = 0;
-            return 0;
-        }
-        if (step == 1) {
-            for (nfds_t i = 0; i < nfds; i++) fds[i].revents = POLLHUP;
-            atomic_store(&inject_no_writer_events, false);
-            return 1;
-        }
-    }
     return poll(fds, nfds, timeout);
 }
 
+typedef struct {
+    atomic_int commits;
+    atomic_int flushes;
+    atomic_int quiesces;
+    atomic_int resumes;
+    atomic_int stops;
+    atomic_int flushed_status;
+    atomic_int idle_timeouts;
+    uint64_t last_start_unix_ms;
+} test_state_t;
+
+static test_state_t *status_state;
+
 static void quiesce(void *transport)
 {
-    test_state_t *state = transport;
-    atomic_fetch_add(&state->quiesces, 1);
+    atomic_fetch_add(&((test_state_t *)transport)->quiesces, 1);
+}
+
+static void flush(void *transport)
+{
+    atomic_fetch_add(&((test_state_t *)transport)->flushes, 1);
 }
 
 static bool commit(void *transport, uint64_t start_unix_ms)
 {
     test_state_t *state = transport;
-    (void)start_unix_ms;
+    state->last_start_unix_ms = start_unix_ms;
     atomic_fetch_add(&state->commits, 1);
     return true;
 }
 
 static void resume(void *transport)
 {
-    test_state_t *state = transport;
-    atomic_fetch_add(&state->resumes, 1);
+    atomic_fetch_add(&((test_state_t *)transport)->resumes, 1);
 }
 
 static void stop(void *transport)
 {
-    (void)transport;
+    atomic_fetch_add(&((test_state_t *)transport)->stops, 1);
 }
 
 static void status(const char *line)
 {
-    unsigned long long generation;
-    if (sscanf(line, "[STATUS] ready generation=%llu", &generation) == 1 &&
-        generation < MAX_GENERATIONS) {
-        atomic_fetch_add(&status_state->ready[generation], 1);
-    } else if (sscanf(line, "[STATUS] primed generation=%llu", &generation) ==
-                   1 &&
-               generation < MAX_GENERATIONS) {
-        atomic_fetch_add(&status_state->primed[generation], 1);
-    } else if (sscanf(line, "[STATUS] input_eof generation=%llu", &generation) ==
-                   1 &&
-               generation < MAX_GENERATIONS) {
-        atomic_fetch_add(&status_state->eof[generation], 1);
-    }
+    if (strcmp(line, "[STATUS] flushed") == 0)
+        atomic_fetch_add(&status_state->flushed_status, 1);
+    else if (strcmp(line, "[STATUS] idle_timeout") == 0)
+        atomic_fetch_add(&status_state->idle_timeouts, 1);
 }
 
-static struct ap2_session_s *create_session(test_state_t *state)
+static void state_init(test_state_t *state)
 {
-    for (size_t i = 0; i < MAX_GENERATIONS; i++) {
-        atomic_init(&state->ready[i], 0);
-        atomic_init(&state->primed[i], 0);
-        atomic_init(&state->eof[i], 0);
-    }
+    memset(state, 0, sizeof(*state));
     atomic_init(&state->commits, 0);
+    atomic_init(&state->flushes, 0);
     atomic_init(&state->quiesces, 0);
     atomic_init(&state->resumes, 0);
+    atomic_init(&state->stops, 0);
+    atomic_init(&state->flushed_status, 0);
+    atomic_init(&state->idle_timeouts, 0);
     status_state = state;
+}
+
+/* Create a pipe-backed session: the engine reads (a dup of) the pipe read end,
+ * the test writes the audio into the returned write end. */
+static struct ap2_session_s *create_session(test_state_t *state,
+                                            int idle_timeout_ms, int *write_fd)
+{
+    state_init(state);
     ap2_session_ops_t ops = {
         .quiesce = quiesce,
+        .flush = flush,
         .commit = commit,
         .resume = resume,
         .stop = stop,
         .status = status,
         .transport = state,
     };
-    return ap2_session_create(&ops, 1000, 1, 0);
-}
-
-static void make_fifo(char *path, size_t size, const char *name)
-{
-    int written = snprintf(path, size, "/tmp/%s.XXXXXX", name);
-    assert(written > 0 && (size_t)written < size);
-    int placeholder = mkstemp(path);
-    assert(placeholder >= 0);
-    assert(close(placeholder) == 0);
-    assert(unlink(path) == 0);
-    assert(mkfifo(path, 0600) == 0);
-}
-
-static bool wait_for_count(atomic_int *value, int expected, int timeout_ms)
-{
-    uint64_t deadline = ap2_io_monotonic_ms() + (uint64_t)timeout_ms;
-    while (atomic_load(value) < expected &&
-           ap2_io_monotonic_ms() < deadline) {
-        usleep(1000);
-    }
-    return atomic_load(value) >= expected;
-}
-
-typedef struct {
-    const char *path;
-    const uint8_t *data;
-    size_t size;
-    int delay_ms;
-    int open_errno;
-    bool ok;
-} writer_arg_t;
-
-static void *delayed_writer(void *opaque)
-{
-    writer_arg_t *arg = opaque;
-    usleep((useconds_t)arg->delay_ms * 1000);
-    int fd = open(arg->path, O_WRONLY | O_NONBLOCK);
-    if (fd < 0) {
-        arg->open_errno = errno;
-        return NULL;
-    }
-    arg->ok = write(fd, arg->data, arg->size) == (ssize_t)arg->size;
-    if (close(fd) != 0) arg->ok = false;
-    return NULL;
-}
-
-static void read_generation(struct ap2_session_s *session,
-                            const uint8_t *expected, size_t size)
-{
-    uint8_t received[256];
-    assert(size <= sizeof(received));
-    size_t offset = 0;
-    while (offset < size) {
-        int n = ap2_session_read(session, received + offset,
-                                 (int)(size - offset), 1000);
-        assert(n > 0);
-        offset += (size_t)n;
-    }
-    assert(memcmp(received, expected, size) == 0);
-    assert(ap2_session_read(session, received, sizeof(received), 1000) == -1);
-}
-
-static void test_timeout_then_hup_keeps_fifo_reader(void)
-{
-    static const uint8_t audio[] = {0x10, 0x20, 0x30, 0x40};
-    char path[128];
-    make_fifo(path, sizeof(path), "cliairplay-fifo-race");
-
-    test_state_t state;
-    struct ap2_session_s *session = create_session(&state);
+    int input[2];
+    assert(pipe(input) == 0);
+    struct ap2_session_s *session =
+        ap2_session_create(&ops, 1000, idle_timeout_ms, input[0]);
     assert(session);
-    atomic_store(&injected_poll_step, 0);
-    atomic_store(&inject_no_writer_events, true);
+    /* The engine owns its own dup of the read end. */
+    assert(close(input[0]) == 0);
+    *write_fd = input[1];
+    return session;
+}
 
-    ap2_generation_t generation = {
-        .number = 0,
-        .audio_path = path,
-    };
-    writer_arg_t writer = {
-        .path = path,
-        .data = audio,
-        .size = sizeof(audio),
-        .delay_ms = 1000,
-    };
-    pthread_t writer_thread;
-    assert(pthread_create(&writer_thread, NULL, delayed_writer, &writer) == 0);
+static void feed(int write_fd, const uint8_t *data, size_t size)
+{
+    assert(write(write_fd, data, size) == (ssize_t)size);
+}
 
-    uint64_t prepare_started = ap2_io_monotonic_ms();
-    assert(ap2_session_prepare(session, &generation));
-    assert(ap2_io_monotonic_ms() - prepare_started < 500);
-    assert(wait_for_count(&state.ready[0], 1, 500));
-    usleep(600000);
-    assert(atomic_load(&state.ready[0]) == 1);
-    assert(atomic_load(&state.eof[0]) == 0);
+static void read_exact(struct ap2_session_s *session, const uint8_t *expected,
+                       size_t size)
+{
+    uint8_t got[256];
+    assert(size <= sizeof(got));
+    size_t off = 0;
+    uint64_t deadline = ap2_io_monotonic_ms() + 2000;
+    while (off < size && ap2_io_monotonic_ms() < deadline) {
+        int n = ap2_session_read(session, got + off, (int)(size - off), 200);
+        assert(n >= 0);   /* -1 (input EOF) / -2 (ended) must not happen here */
+        off += (size_t)n;
+    }
+    assert(off == size);
+    assert(memcmp(got, expected, size) == 0);
+}
 
-    assert(pthread_join(writer_thread, NULL) == 0);
-    assert(writer.ok);
-    assert(wait_for_count(&state.primed[0], 1, 1000));
-    assert(wait_for_count(&state.eof[0], 1, 1000));
-    assert(atomic_load(&state.ready[0]) == 1);
-    assert(atomic_load(&state.primed[0]) == 1);
-    assert(atomic_load(&state.eof[0]) == 1);
+static void test_start_streams_the_input(void)
+{
+    static const uint8_t audio[] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60};
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 0, &write_fd);
 
-    assert(ap2_session_start(session, 0, 1700000000000ULL));
-    read_generation(session, audio, sizeof(audio));
-    assert(atomic_load(&state.quiesces) == 1);
+    /* Before START the engine is idle and sends nothing. */
+    assert(ap2_session_state(session) == AP2_SESSION_IDLE);
+    assert(ap2_session_epoch(session) == 0);
+    feed(write_fd, audio, sizeof(audio));
+
+    const uint64_t audible = 1770000000123ULL;
+    assert(ap2_session_start(session, audible));
+    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
+    assert(ap2_session_epoch(session) == 1);
     assert(atomic_load(&state.commits) == 1);
+    assert(atomic_load(&state.quiesces) == 1);
     assert(atomic_load(&state.resumes) == 1);
+    assert(state.last_start_unix_ms == audible);
+
+    read_exact(session, audio, sizeof(audio));
 
     ap2_session_destroy(session);
     status_state = NULL;
-    assert(unlink(path) == 0);
+    assert(close(write_fd) == 0);
 }
 
-static void test_repeated_delayed_fifo_generations(void)
+/* The headline test: FLUSH drains the ring AND any undelivered stdin bytes and
+ * acks with [STATUS] flushed; the next START re-anchors and resumes cleanly from
+ * only the post-flush audio. */
+static void test_flush_drains_and_reanchors(void)
 {
-    static const int delays_ms[] = {20, 300, 1000, 450, 30, 1100, 275, 800};
+    static const uint8_t old_audio[] = {0xA0, 0xA1, 0xA2, 0xA3};
+    static const uint8_t stale_audio[] = {0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5};
+    static const uint8_t new_audio[] = {0xC0, 0xC1, 0xC2, 0xC3, 0xC4};
     test_state_t state;
-    struct ap2_session_s *session = create_session(&state);
-    assert(session);
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 0, &write_fd);
 
-    for (size_t i = 0; i < sizeof(delays_ms) / sizeof(delays_ms[0]); i++) {
-        char path[128];
-        make_fifo(path, sizeof(path), "cliairplay-fifo-stress");
-        uint8_t audio[64];
-        size_t audio_size = i == 0 ? 1 : sizeof(audio);
-        memset(audio, (int)(i + 1), audio_size);
-        ap2_generation_t generation = {
-            .number = i,
-            .audio_path = path,
-            .position_ms = i * 1000,
-        };
-        writer_arg_t writer = {
-            .path = path,
-            .data = audio,
-            .size = audio_size,
-            .delay_ms = delays_ms[i],
-        };
-        pthread_t writer_thread;
-        assert(pthread_create(
-                   &writer_thread, NULL, delayed_writer, &writer) == 0);
-        assert(ap2_session_prepare(session, &generation));
-        assert(wait_for_count(&state.ready[i], 1, 200));
-        assert(pthread_join(writer_thread, NULL) == 0);
-        assert(writer.ok);
-        assert(wait_for_count(&state.primed[i], 1, 1000));
-        assert(wait_for_count(&state.eof[i], 1, 1000));
-        assert(ap2_session_start(
-            session, i, 1700000000000ULL + i * 5000));
-        read_generation(session, audio, audio_size);
-        assert(atomic_load(&state.ready[i]) == 1);
-        assert(atomic_load(&state.primed[i]) == 1);
-        assert(atomic_load(&state.eof[i]) == 1);
-        assert(unlink(path) == 0);
-    }
+    feed(write_fd, old_audio, sizeof(old_audio));
+    assert(ap2_session_start(session, 1700000000000ULL));
+    read_exact(session, old_audio, sizeof(old_audio));
 
-    assert(atomic_load(&state.commits) ==
-           (int)(sizeof(delays_ms) / sizeof(delays_ms[0])));
-    ap2_session_destroy(session);
-    status_state = NULL;
-}
+    /* Bytes fed but never delivered before FLUSH: they sit in the ring and/or
+     * the input pipe and must be discarded by the drain. */
+    feed(write_fd, stale_audio, sizeof(stale_audio));
 
-static void test_empty_regular_input_and_writerless_abort(void)
-{
-    char empty_path[] = "/tmp/cliairplay-empty.XXXXXX";
-    int empty_fd = mkstemp(empty_path);
-    assert(empty_fd >= 0);
-    assert(close(empty_fd) == 0);
-
-    test_state_t state;
-    struct ap2_session_s *session = create_session(&state);
-    assert(session);
-    ap2_generation_t empty = {
-        .number = 0,
-        .audio_path = empty_path,
-    };
-    assert(ap2_session_prepare(session, &empty));
-    assert(wait_for_count(&state.ready[0], 1, 200));
-    assert(wait_for_count(&state.eof[0], 1, 200));
-    assert(ap2_session_start(session, 0, 1700000000000ULL));
-    uint8_t byte;
-    assert(ap2_session_read(session, &byte, 1, 200) == -1);
-
-    char fifo_path[128];
-    make_fifo(fifo_path, sizeof(fifo_path), "cliairplay-fifo-abort");
-    ap2_generation_t waiting = {
-        .number = 1,
-        .audio_path = fifo_path,
-    };
-    assert(ap2_session_prepare(session, &waiting));
-    assert(wait_for_count(&state.ready[1], 1, 200));
     uint64_t flush_started = ap2_io_monotonic_ms();
-    assert(ap2_session_flush(session, 1));
-    assert(ap2_io_monotonic_ms() - flush_started < 500);
+    assert(ap2_session_flush(session));
+    assert(ap2_io_monotonic_ms() - flush_started < 1000);
+    assert(atomic_load(&state.flushes) == 1);
+    assert(atomic_load(&state.flushed_status) == 1);
+    assert(ap2_session_state(session) == AP2_SESSION_IDLE);
+    assert(ap2_session_epoch(session) == 1);   /* FLUSH does not bump the epoch */
+
+    /* The post-flush track: START must re-anchor and deliver ONLY this audio,
+     * proving the stale bytes were drained from both the ring and the input. */
+    feed(write_fd, new_audio, sizeof(new_audio));
+    assert(ap2_session_start(session, 1700000005000ULL));
+    assert(atomic_load(&state.commits) == 2);
+    assert(ap2_session_epoch(session) == 2);
+    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
+    read_exact(session, new_audio, sizeof(new_audio));
 
     ap2_session_destroy(session);
     status_state = NULL;
-    assert(unlink(fifo_path) == 0);
-    assert(unlink(empty_path) == 0);
+    assert(close(write_fd) == 0);
+}
+
+static void test_flush_while_idle_before_start(void)
+{
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 0, &write_fd);
+
+    /* A FLUSH before the first START is valid: no commit yet, still idle. */
+    assert(ap2_session_flush(session));
+    assert(atomic_load(&state.flushes) == 1);
+    assert(atomic_load(&state.flushed_status) == 1);
+    assert(atomic_load(&state.commits) == 0);
+    assert(ap2_session_state(session) == AP2_SESSION_IDLE);
+
+    static const uint8_t audio[] = {0x01, 0x02, 0x03, 0x04};
+    feed(write_fd, audio, sizeof(audio));
+    assert(ap2_session_start(session, 0));
+    read_exact(session, audio, sizeof(audio));
+
+    ap2_session_destroy(session);
+    status_state = NULL;
+    assert(close(write_fd) == 0);
+}
+
+static void test_standby_then_resume(void)
+{
+    static const uint8_t audio[] = {0x20, 0x21, 0x22, 0x23};
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 0, &write_fd);
+
+    feed(write_fd, audio, sizeof(audio));
+    assert(ap2_session_start(session, 1700000000000ULL));
+    read_exact(session, audio, sizeof(audio));
+
+    assert(ap2_session_standby(session));
+    assert(atomic_load(&state.stops) == 1);
+    assert(ap2_session_state(session) == AP2_SESSION_STANDBY);
+
+    static const uint8_t more[] = {0x30, 0x31, 0x32};
+    feed(write_fd, more, sizeof(more));
+    assert(ap2_session_start(session, 1700000005000ULL));
+    assert(atomic_load(&state.commits) == 2);
+    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
+    read_exact(session, more, sizeof(more));
+
+    ap2_session_destroy(session);
+    status_state = NULL;
+    assert(close(write_fd) == 0);
+}
+
+static void test_idle_timeout_ends_session(void)
+{
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 20, &write_fd);
+
+    usleep(60000);
+    ap2_session_poll(session);
+    assert(ap2_session_state(session) == AP2_SESSION_ENDED);
+    assert(atomic_load(&state.idle_timeouts) == 1);
+    /* A read on an ended session reports -2. */
+    uint8_t byte;
+    assert(ap2_session_read(session, &byte, 1, 50) == -2);
+
+    ap2_session_destroy(session);
+    status_state = NULL;
+    assert(close(write_fd) == 0);
+}
+
+/* The input pipe's writer stays open (as MA holds the CLI stdin open), so the
+ * reader never sees EOF; destroy must still tear it down promptly. */
+static void test_destroy_is_prompt_with_open_writer(void)
+{
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 0, &write_fd);
+
+    static const uint8_t audio[] = {0x40, 0x41};
+    feed(write_fd, audio, sizeof(audio));
+    assert(ap2_session_start(session, 1700000000000ULL));
+    read_exact(session, audio, sizeof(audio));
+
+    uint64_t started = ap2_io_monotonic_ms();
+    ap2_session_destroy(session);
+    assert(ap2_io_monotonic_ms() - started < 1000);
+    status_state = NULL;
+    assert(close(write_fd) == 0);
 }
 
 int main(void)
 {
-    test_timeout_then_hup_keeps_fifo_reader();
-    test_repeated_delayed_fifo_generations();
-    test_empty_regular_input_and_writerless_abort();
-    puts("AP2 session FIFO lifecycle tests passed");
+    test_start_streams_the_input();
+    test_flush_drains_and_reanchors();
+    test_flush_while_idle_before_start();
+    test_standby_then_resume();
+    test_idle_timeout_ends_session();
+    test_destroy_is_prompt_with_open_writer();
+    puts("AP2 session flush-and-refill tests passed");
     return 0;
 }

--- a/tests/test_ap2_session.c
+++ b/tests/test_ap2_session.c
@@ -32,6 +32,7 @@ typedef struct {
     atomic_int resumes;
     atomic_int stops;
     atomic_int flushed_status;
+    atomic_int audio_status;
     atomic_int idle_timeouts;
     uint64_t last_start_unix_ms;
 } test_state_t;
@@ -70,6 +71,8 @@ static void status(const char *line)
 {
     if (strcmp(line, "[STATUS] flushed") == 0)
         atomic_fetch_add(&status_state->flushed_status, 1);
+    else if (strncmp(line, "[STATUS] audio ", 15) == 0)
+        atomic_fetch_add(&status_state->audio_status, 1);
     else if (strcmp(line, "[STATUS] idle_timeout") == 0)
         atomic_fetch_add(&status_state->idle_timeouts, 1);
 }
@@ -83,6 +86,7 @@ static void state_init(test_state_t *state)
     atomic_init(&state->resumes, 0);
     atomic_init(&state->stops, 0);
     atomic_init(&state->flushed_status, 0);
+    atomic_init(&state->audio_status, 0);
     atomic_init(&state->idle_timeouts, 0);
     status_state = state;
 }
@@ -134,6 +138,17 @@ static void read_exact(struct ap2_session_s *session, const uint8_t *expected,
     assert(memcmp(got, expected, size) == 0);
 }
 
+/* The reader thread emits [STATUS] audio asynchronously; poll for the count. */
+static bool wait_for_count(atomic_int *counter, int want, int timeout_ms)
+{
+    uint64_t deadline = ap2_io_monotonic_ms() + (uint64_t)timeout_ms;
+    while (ap2_io_monotonic_ms() < deadline) {
+        if (atomic_load(counter) >= want) return true;
+        usleep(5000);
+    }
+    return atomic_load(counter) >= want;
+}
+
 static void test_start_streams_the_input(void)
 {
     static const uint8_t audio[] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60};
@@ -175,8 +190,11 @@ static void test_flush_drains_and_reanchors(void)
     struct ap2_session_s *session = create_session(&state, 0, &write_fd);
 
     feed(write_fd, old_audio, sizeof(old_audio));
+    /* The one-shot audio signal announces the feed is flowing (pre-START). */
+    assert(wait_for_count(&state.audio_status, 1, 1000));
     assert(ap2_session_start(session, 1700000000000ULL));
     read_exact(session, old_audio, sizeof(old_audio));
+    assert(atomic_load(&state.audio_status) == 1);
 
     /* Bytes fed but never delivered before FLUSH: they sit in the ring and/or
      * the input pipe and must be discarded by the drain. */
@@ -191,8 +209,11 @@ static void test_flush_drains_and_reanchors(void)
     assert(ap2_session_epoch(session) == 1);   /* FLUSH does not bump the epoch */
 
     /* The post-flush track: START must re-anchor and deliver ONLY this audio,
-     * proving the stale bytes were drained from both the ring and the input. */
+     * proving the stale bytes were drained from both the ring and the input.
+     * FLUSH re-armed the one-shot audio signal, so the new track's first bytes
+     * announce themselves again. */
     feed(write_fd, new_audio, sizeof(new_audio));
+    assert(wait_for_count(&state.audio_status, 2, 1000));
     assert(ap2_session_start(session, 1700000005000ULL));
     assert(atomic_load(&state.commits) == 2);
     assert(ap2_session_epoch(session) == 2);

--- a/tests/test_raop_session.c
+++ b/tests/test_raop_session.c
@@ -153,9 +153,35 @@ int main(void)
     assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
            mock_now + MS2NTP(200));
 
+    /* raop_session_flush discards the receiver buffer in place: stop, and flush
+     * only when currently streaming (a warm seek's FLUSH half). */
+    reset_mocks();
+    client.state = RAOP_STREAMING;
+    assert(raop_session_flush(&client));
+    assert(stop_calls == 1);
+    assert(flush_calls == 1);
+    assert(client.state == RAOP_FLUSHED);
+    assert(raop_session_flush(&client));   /* already flushed: stop only */
+    assert(stop_calls == 2);
+    assert(flush_calls == 1);
+
+    /* raop_session_start_at re-anchors a flushed stream without stopping or
+     * flushing again (the START half after a FLUSH). */
+    reset_mocks();
+    client.state = RAOP_FLUSHED;
+    const uint64_t resume_ms = 1700000123000ULL;
+    assert(raop_session_start_at(&client, resume_ms));
+    assert(stop_calls == 0);
+    assert(flush_calls == 0);
+    assert(start_calls == 1);
+    assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
+           unix_ms_to_ntp(resume_ms));
+
     client.state = RAOP_DOWN;
     assert(!raop_session_commit(&client, future_ms));
     assert(!raop_session_standby(&client));
+    assert(!raop_session_flush(&client));
+    assert(!raop_session_start_at(&client, future_ms));
     assert(!raop_session_pause(&client));
     assert(!raop_session_resume(&client));
 

--- a/tests/test_raop_session.c
+++ b/tests/test_raop_session.c
@@ -177,6 +177,13 @@ int main(void)
     assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
            unix_ms_to_ntp(resume_ms));
 
+    /* A START without a preceding FLUSH must fail fast: re-anchoring a live
+     * stream would replay the receiver backlog against the new timeline. */
+    reset_mocks();
+    client.state = RAOP_STREAMING;
+    assert(!raop_session_start_at(&client, resume_ms));
+    assert(start_calls == 0);
+
     client.state = RAOP_DOWN;
     assert(!raop_session_commit(&client, future_ms));
     assert(!raop_session_standby(&client));


### PR DESCRIPTION
## The problem

Warm seek/next staged each new track as its own numbered "generation" over a
per-generation input pipe (`PREPARE`/`AUDIO=`/`POSITION_MS`). Draining and
swapping those FIFOs on the command thread wedged it, and the second warm seek
in a row dropped the audio feed — the receiver kept its old buffer and playback
stalled.

## The new model

One persistent input: the process **stdin** is the single audio feed for the
whole process lifetime, drained by one reader thread into one ring. Seek/next no
longer re-open anything:

- **`ACTION=FLUSH`** quiesces the sends, flushes the receiver (RTSP FLUSH),
  parks the reader to take exclusive fd access, resets the ring, and drains
  stdin to `EAGAIN` — removing exactly the pre-flush audio — then acks
  `[STATUS] flushed` and goes idle-primed (keeps buffering the next track,
  sends nothing).
- **`ACTION=START`** begins the session on the first call and re-anchors the
  same live stream on every call after a FLUSH (frozen-anchor re-base, no
  reconnect, no crypto/sequence reset).
- The one-shot **`[STATUS] audio buffered_ms=`** signal (re-armed by each FLUSH)
  lets the caller confirm the new track's feed is flowing before it commands a
  start, so starts are readiness-confirmed with just a **250 ms** commanded-start
  floor (200 ms on RAOP) instead of a blind spin-up margin.

The reader is non-blocking and the drain is a bounded reader-park handshake, so
the command thread is never wedged.

## Validation

Live-verified working for solo, group, and late-join playback with sub-second
seeks. `make STATIC=1` and `make test STATIC=1` pass (the AP2 session
flush-and-refill suite included).

Docs (README/DESIGN/TODO) are updated to the new contract; the retired
per-generation staging model is removed from them.
