### PR TITLE
Sign downstream server pin-update commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,6 +370,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.server-token.outputs.token }}
+          sign-commits: true
           path: server
           commit-message: Update airplay-cli to ${{ env.RELEASE_TAG }}
           # This branch deliberately avoids the server's auto-merge prefixes.


### PR DESCRIPTION
## Summary
- enable bot commit signing for the downstream server pin-update PR step
- keep existing short-lived GitHub App token flow unchanged

## Change
- add `sign-commits: true` to `peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1` in `server-repo-pr`
