### PR TITLE
Fix audio noise after seeking

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -185,12 +185,13 @@ exactly T on every streaming protocol.** Legacy RAOP, RAOP-compatible AirPlay 2,
 and native AirPlay 2 members are handed the same T, then align by construction.
 The first `ACTION=START` begins the session; a `START` after an `ACTION=FLUSH`
 re-anchors the same live stream (§10) by re-basing the frozen anchor line below,
-with no reconnect and no crypto/sequence reset. The caller can gate the command
-on the one-shot `[STATUS] audio buffered_ms=` line — emitted once the current
-track's feed is flowing, and re-armed by each FLUSH — so it commits a start only
-after the feed is confirmed. A T of 0 or in the past clamps to now plus the
-minimum commanded-start lead (250 ms; 200 ms on RAOP), which covers only the
-commit round-trips since the connection and the feed are already up.
+with no reconnect and no crypto/sequence reset. The first packet carries a fresh
+restart marker and sync announcement for the new timeline. The caller can gate
+the command on the one-shot `[STATUS] audio buffered_ms=` line — emitted once a
+complete transport packet is buffered, and re-armed by each FLUSH — so it
+commits a start only after the feed is ready. A T of 0 or in the past clamps to
+now plus the minimum commanded-start lead (250 ms; 200 ms on RAOP), which covers
+only the commit round-trips since the connection and the feed are already up.
 
 **Downstream render-latency is informational, not applied.** A receiver whose
 audible output sits behind an external pipeline reports that delay in its
@@ -504,13 +505,15 @@ capture.
   network pacing. A warm seek/next is `ACTION=FLUSH`: it quiesces the audio
   sends, flushes the receiver (RTSP FLUSH), parks the reader to take exclusive
   fd access, resets the ring, and drains stdin to `EAGAIN` — removing exactly
-  the pre-flush audio the caller stopped writing — then acks `[STATUS] flushed`
-  and releases the reader onto the empty ring. The stream is then idle-primed:
-  it keeps buffering the next track but sends nothing until the next `START`,
-  which re-anchors it. The one-shot `[STATUS] audio` signal (§6) is re-armed by
-  the flush, so the caller learns when the next track's feed is flowing. The
-  sender waits in bounded intervals so control failures remain visible during
-  producer starvation.
+  the pre-flush audio the caller stopped writing — then, after the receiver
+  accepts the flush, acks `[STATUS] flushed` and releases the reader onto the
+  empty ring. The stream is then idle-primed: it keeps buffering the next track
+  but sends nothing until the next `START`, which re-anchors it. The one-shot
+  `[STATUS] audio` signal (§6) is re-armed by the flush and fires after one
+  complete transport packet is buffered. Partial PCM remains in the ring until
+  a full packet is available; only the final EOF packet is padded with silence.
+  The sender waits in bounded intervals so control failures remain visible
+  during producer starvation.
 - **Realtime send outcomes** — local UDP backpressure is a bounded transient
   drop that advances sequence, RTP, and scheduling timestamps. Encode,
   allocation, encryption, socket, and control failures are terminal and produce

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -188,10 +188,11 @@ re-anchors the same live stream (§10) by re-basing the frozen anchor line below
 with no reconnect and no crypto/sequence reset. The first packet carries a fresh
 restart marker and sync announcement for the new timeline. The caller can gate
 the command on the one-shot `[STATUS] audio buffered_ms=` line — emitted once a
-complete transport packet is buffered, and re-armed by each FLUSH — so it
-commits a start only after the feed is ready. A T of 0 or in the past clamps to
-now plus the minimum commanded-start lead (250 ms; 200 ms on RAOP), which covers
-only the commit round-trips since the connection and the feed are already up.
+complete transport packet is buffered (or the final short packet reaches EOF),
+and re-armed by each FLUSH — so it commits a start only after the feed is ready.
+A T of 0 or in the past clamps to now plus the minimum commanded-start lead
+(250 ms; 200 ms on RAOP), which covers only the commit round-trips since the
+connection and the feed are already up.
 
 **Downstream render-latency is informational, not applied.** A receiver whose
 audible output sits behind an external pipeline reports that delay in its
@@ -510,10 +511,10 @@ capture.
   empty ring. The stream is then idle-primed: it keeps buffering the next track
   but sends nothing until the next `START`, which re-anchors it. The one-shot
   `[STATUS] audio` signal (§6) is re-armed by the flush and fires after one
-  complete transport packet is buffered. Partial PCM remains in the ring until
-  a full packet is available; only the final EOF packet is padded with silence.
-  The sender waits in bounded intervals so control failures remain visible
-  during producer starvation.
+  complete transport packet is buffered, or when a final short packet reaches
+  EOF. Partial PCM remains in the ring until a full packet is available; only
+  the final EOF packet is padded with silence. The sender waits in bounded
+  intervals so control failures remain visible during producer starvation.
 - **Realtime send outcomes** — local UDP backpressure is a bounded transient
   drop that advances sequence, RTP, and scheduling timestamps. Encode,
   allocation, encryption, socket, and control failures are terminal and produce

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ AirPlay 2, and native AirPlay 2. The first `ACTION=START` begins the session; a
 `START` after an `ACTION=FLUSH` re-anchors the same live stream to a new instant
 without reconnecting. A caller can wait for the one-shot
 `[STATUS] audio buffered_ms=<ms>` line — emitted once the (new) track has a
-complete audio packet buffered — before it commands the start, then send the
-same start value to every member of a sync group. A `START_UNIX_MS` of 0 or in
-the past clamps to now plus the minimum commanded-start lead (250 ms, 200 ms on
-RAOP).
+complete audio packet buffered, or its final short packet reaches EOF — before
+it commands the start, then send the same start value to every member of a sync
+group. A `START_UNIX_MS` of 0 or in the past clamps to now plus the minimum
+commanded-start lead (250 ms, 200 ms on RAOP).
 
 Delivery is not gated on the start time: frames are released up to the
 receiver's buffer window ahead of each frame's deadline (the device-reported
@@ -197,7 +197,7 @@ stdin, the single persistent audio input for the whole process lifetime.
   accepts the flush, acks with `[STATUS] flushed` and keeps buffering the next
   track while sending nothing until the next `START` (idle-primed). The one-shot
   `[STATUS] audio buffered_ms=<ms>` line fires again when the next track's feed
-  has a complete packet buffered.
+  has a complete packet buffered, or its final short packet reaches EOF.
 - Session lifecycle: `ACTION=STANDBY` (silence the receiver, keep the connection
   warm), `ACTION=DISCONNECT` (end the session).
 - Transport: `ACTION=PLAY|PAUSE|STOP`.

--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ audible exactly at that unix-epoch instant** for legacy RAOP, RAOP-compatible
 AirPlay 2, and native AirPlay 2. The first `ACTION=START` begins the session; a
 `START` after an `ACTION=FLUSH` re-anchors the same live stream to a new instant
 without reconnecting. A caller can wait for the one-shot
-`[STATUS] audio buffered_ms=<ms>` line — emitted once the (new) track's feed is
-flowing — before it commands the start, then send the same start value to every
-member of a sync group. A `START_UNIX_MS` of 0 or in the past clamps to now plus
-the minimum commanded-start lead (250 ms, 200 ms on RAOP).
+`[STATUS] audio buffered_ms=<ms>` line — emitted once the (new) track has a
+complete audio packet buffered — before it commands the start, then send the
+same start value to every member of a sync group. A `START_UNIX_MS` of 0 or in
+the past clamps to now plus the minimum commanded-start lead (250 ms, 200 ms on
+RAOP).
 
 Delivery is not gated on the start time: frames are released up to the
 receiver's buffer window ahead of each frame's deadline (the device-reported
@@ -192,11 +193,11 @@ stdin, the single persistent audio input for the whole process lifetime.
   the same live stream (no reconnect). `START_UNIX_MS=0` (or a past instant)
   starts as soon as possible, at the minimum commanded-start lead.
 - `ACTION=FLUSH` — in-place warm flush for seek/next: flush the receiver (RTSP
-  FLUSH), discard the internal ring, and drain stdin to empty; acks with
-  `[STATUS] flushed` and then keeps buffering the next track while sending
-  nothing until the next `START` (idle-primed). The one-shot
+  FLUSH), discard the internal ring, and drain stdin to empty; after the receiver
+  accepts the flush, acks with `[STATUS] flushed` and keeps buffering the next
+  track while sending nothing until the next `START` (idle-primed). The one-shot
   `[STATUS] audio buffered_ms=<ms>` line fires again when the next track's feed
-  starts flowing.
+  has a complete packet buffered.
 - Session lifecycle: `ACTION=STANDBY` (silence the receiver, keep the connection
   warm), `ACTION=DISCONNECT` (end the session).
 - Transport: `ACTION=PLAY|PAUSE|STOP`.

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -1703,8 +1703,10 @@ static ap2_send_result_t ap2_native_send_chunk(
         return AP2_SEND_FATAL;
     }
     /* A transient local UDP drop exposes a sequence gap rather than retrying
-     * an old timestamp late, so the media timeline always advances. */
-    p->first_packet = false;
+     * an old timestamp late, so the media timeline always advances. Keep the
+     * restart marker armed until its sync and audio packet reach the receiver. */
+    if (result == AP2_SEND_SENT && sync_result == AP2_SEND_SENT)
+        p->first_packet = false;
     p->seq_number++;
     p->rtp_timestamp += frames;
     p->head_ts += frames;
@@ -2064,9 +2066,10 @@ bool ap2cl_flush(struct ap2cl_s *p)
     free(resp);
     LOG_INFO("[AP2] warm FLUSH (seq=%u rtptime=%u) -> %d",
              (unsigned)p->seq_number, (unsigned)p->rtp_timestamp, status);
-    if (status != 200)
-        LOG_WARN("[AP2] receiver did not accept FLUSH (%d); re-anchoring anyway",
-                 status);
+    if (status != 200) {
+        LOG_WARN("[AP2] receiver did not accept FLUSH (%d)", status);
+        return false;
+    }
     /* Drop the stale anchor; ap2cl_resume freezes a fresh line at START. */
     p->rt_anchor_valid = false;
     return true;
@@ -2096,6 +2099,9 @@ bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms)
     p->head_ts = NTP2TS(start_ntp, p->format.sample_rate);
     p->rtp_timestamp = (uint32_t)p->head_ts + atomic_load(&p->rtp_offset);
     p->rt_anchor_valid = false;
+    /* The first packet after a timeline discontinuity carries the RTP marker
+     * and sends a fresh sync packet before its audio payload. */
+    p->first_packet = true;
     p->state = AP2_STREAMING;
     atomic_store(&p->media_healthy, true);
 
@@ -2834,5 +2840,15 @@ void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p)
     p->sock_fd = -1;
     p->rtsp_established = false;
     p->state = AP2_DOWN;
+}
+
+bool ap2cl_test_first_packet(struct ap2cl_s *p)
+{
+    return p->first_packet;
+}
+
+void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet)
+{
+    p->first_packet = first_packet;
 }
 #endif

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -190,6 +190,13 @@ static void *reader_thread(void *arg)
             int read_errno = errno;
             pthread_mutex_lock(&s->lock);
             s->ring.eof = true;
+            if (n == 0 && !s->audio_seen && s->ring.fill > 0) {
+                /* A final short input can still form one silence-padded packet. */
+                s->audio_seen = true;
+                emit(s, "[STATUS] audio buffered_ms=%llu",
+                     (unsigned long long)(s->ring.fill * 1000ULL /
+                                          s->byte_rate));
+            }
             pthread_cond_broadcast(&s->can_read);
             pthread_mutex_unlock(&s->lock);
             if (n < 0)
@@ -334,7 +341,6 @@ bool ap2_session_start(struct ap2_session_s *s, uint64_t start_unix_ms)
         s->ops.resume(s->ops.transport);
         return false;
     }
-    s->ring.eof = false;   /* a fresh START clears any stale end-of-stream */
     s->epoch++;
     s->state = AP2_SESSION_PLAYING;
     pthread_cond_broadcast(&s->can_read);

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -46,6 +46,7 @@ typedef struct {
 struct ap2_session_s {
     ap2_session_ops_t ops;
     unsigned byte_rate;
+    unsigned ready_bytes;
     int idle_timeout_ms;
     int input_fd;              /* owned dup of the caller's PCM descriptor */
 
@@ -203,11 +204,10 @@ static void *reader_thread(void *arg)
             off += pushed;
             if (pushed) {
                 pthread_cond_broadcast(&s->can_read);
-                if (!s->audio_seen) {
+                if (!s->audio_seen && s->ring.fill >= s->ready_bytes) {
                     /* One-shot per start cycle: the caller uses this to know
-                     * the new track's audio is flowing before it commands a
-                     * START, so it can anchor with a short lead instead of
-                     * blind margin for source/transcoder spin-up. */
+                     * one complete transport packet is buffered before it
+                     * commands a START. */
                     s->audio_seen = true;
                     emit(s, "[STATUS] audio buffered_ms=%llu",
                          (unsigned long long)(s->ring.fill * 1000ULL /
@@ -227,16 +227,18 @@ static void *reader_thread(void *arg)
 /* ---- public API ---- */
 
 struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
-                                         unsigned byte_rate, int idle_timeout_ms,
-                                         int input_fd)
+                                         unsigned byte_rate,
+                                         unsigned ready_bytes,
+                                         int idle_timeout_ms, int input_fd)
 {
     if (!ops || !ops->quiesce || !ops->flush || !ops->commit || !ops->resume ||
-        !ops->stop || !ops->status || !byte_rate || input_fd < 0)
+        !ops->stop || !ops->status || !byte_rate || !ready_bytes || input_fd < 0)
         return NULL;
     struct ap2_session_s *s = calloc(1, sizeof(*s));
     if (!s) return NULL;
     s->ops = *ops;
     s->byte_rate = byte_rate;
+    s->ready_bytes = ready_bytes;
     s->idle_timeout_ms = idle_timeout_ms;
     s->input_fd = -1;
     pthread_mutex_init(&s->lock, NULL);
@@ -247,6 +249,11 @@ struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
     s->state = AP2_SESSION_IDLE;
     s->idle_since_ms = ap2_io_monotonic_ms();
     if (!sring_init(&s->ring, byte_rate)) {
+        ap2_session_destroy(s);
+        return NULL;
+    }
+    if (ready_bytes > s->ring.cap) {
+        LOG_ERROR("[SESSION] ready buffer exceeds ring capacity");
         ap2_session_destroy(s);
         return NULL;
     }
@@ -347,7 +354,11 @@ bool ap2_session_flush(struct ap2_session_s *s)
 
     /* Stop sending, then discard the receiver's buffered audio in place. */
     s->ops.quiesce(s->ops.transport);
-    s->ops.flush(s->ops.transport);
+    if (!s->ops.flush(s->ops.transport)) {
+        s->ops.resume(s->ops.transport);
+        LOG_ERROR("[SESSION] transport flush failed");
+        return false;
+    }
 
     pthread_mutex_lock(&s->lock);
     /* Park the reader so we can drain the input fd without racing it, then
@@ -359,8 +370,7 @@ bool ap2_session_flush(struct ap2_session_s *s)
         pthread_cond_wait(&s->reader_paused_cond, &s->lock);
     sring_reset(&s->ring);
     drain_input_fd(s->input_fd);
-    /* Re-arm the one-shot audio signal: the next bytes to arrive belong to
-     * the new track and announce that its feed is flowing. */
+    /* Re-arm the one-shot audio signal for the next complete packet. */
     s->audio_seen = false;
     /* Release the reader onto the now-empty ring: it buffers the next track
      * while we send nothing until the next START (idle-primed). */
@@ -424,7 +434,8 @@ int ap2_session_read(struct ap2_session_s *s, uint8_t *buf, int len,
             return -2;
         }
         if (s->state == AP2_SESSION_PLAYING) {
-            if (s->ring.fill > 0) {
+            if (s->ring.fill >= (size_t)len ||
+                (s->ring.eof && s->ring.fill > 0)) {
                 size_t n = sring_pop(&s->ring, buf, (size_t)len);
                 pthread_cond_broadcast(&s->can_write);
                 pthread_mutex_unlock(&s->lock);

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -68,11 +68,12 @@ struct ap2_session_s;
  * lead when 0). Returns false when the transport failed terminally (the caller
  * then ends the session so MA can fall back cold). `flush` discards the
  * receiver's buffered audio in place (RTSP FLUSH / libraop flush), keeping the
- * session and timeline continuity; the re-anchor happens on the next `commit`.
+ * session and timeline continuity; it returns false when the receiver did not
+ * accept the flush. The re-anchor happens on the next `commit`.
  */
 typedef struct {
     void (*quiesce)(void *transport);    /* pause audio sends across a command */
-    void (*flush)(void *transport);      /* RTSP-flush receiver, keep session */
+    bool (*flush)(void *transport);      /* RTSP-flush receiver, keep session */
     bool (*commit)(void *transport, uint64_t start_unix_ms);
     void (*resume)(void *transport);     /* resume sends after the command */
     void (*stop)(void *transport);       /* silence the receiver, keep session */
@@ -85,6 +86,7 @@ typedef struct {
  *
  * :param ops: transport quiesce/flush/commit/resume/stop + status callbacks.
  * :param byte_rate: PCM byte rate of the input format (ring sizing/timing).
+ * :param ready_bytes: buffered PCM required before the one-shot audio status.
  * :param idle_timeout_ms: end the session after this long idle (no playing
  *                         stream), an orphan safety net; 0 disables it.
  * :param input_fd: PCM input descriptor (normally the process stdin). The
@@ -93,8 +95,9 @@ typedef struct {
  *                  descriptor.
  */
 struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
-                                         unsigned byte_rate, int idle_timeout_ms,
-                                         int input_fd);
+                                         unsigned byte_rate,
+                                         unsigned ready_bytes,
+                                         int idle_timeout_ms, int input_fd);
 void ap2_session_destroy(struct ap2_session_s *s);
 
 /* Command-pipe entry points, serialized by the single cmdpipe thread. Invalid
@@ -104,17 +107,18 @@ bool ap2_session_flush(struct ap2_session_s *s);
 bool ap2_session_standby(struct ap2_session_s *s);
 void ap2_session_end(struct ap2_session_s *s);
 
-/* Audio-loop entry points. `read` returns PCM from the ring while PLAYING
- * (blocking up to timeout_ms; 0 on underrun/not-yet-playing, -1 on end of the
- * input stream, -2 when the session ended). The loop calls `poll` once per
- * iteration so the engine can run the idle timeout. */
+/* Audio-loop entry points. While the input remains open, `read` retains partial
+ * data in the ring until exactly len bytes are available. It blocks up to
+ * timeout_ms; returns 0 when that deadline passes, a final short read at EOF,
+ * -1 once the input is fully consumed, and -2 when the session ended. The loop
+ * calls `poll` once per iteration so the engine can run the idle timeout. */
 int ap2_session_read(struct ap2_session_s *s, uint8_t *buf, int len,
                      int timeout_ms);
 void ap2_session_poll(struct ap2_session_s *s);
 
 ap2_session_state_t ap2_session_state(struct ap2_session_s *s);
 /* Monotonic counter bumped on every START; the audio loop resets its
- * per-track bookkeeping (elapsed, alignment) when it changes. */
+ * per-track elapsed/EOF bookkeeping when it changes. */
 uint64_t ap2_session_epoch(struct ap2_session_s *s);
 
 #endif /* __AP2_SESSION_H_ */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -517,6 +517,8 @@ static bool session_flush_op(void *transport)
     } else if (g_ap2cl) {
         flushed = ap2cl_flush(g_ap2cl);
     }
+    /* A failed RTSP round-trip can leave the receiver partially flushed.
+     * Keep sends paused while the caller falls back to a cold restart. */
     if (g_status == STATUS_PLAYING) g_status = STATUS_PAUSED;
     return flushed;
 }

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -292,6 +292,19 @@ static int truncate_32to24(const uint8_t *in, int in_bytes, uint8_t *out)
     return samples * 3;
 }
 
+/* The session only returns a short read when stdin reaches EOF. Complete the
+ * final transport packet with silence, dropping any incomplete PCM frame. */
+static int pad_final_pcm_chunk(uint8_t *buf, int bytes, int chunk_bytes,
+                               int bytes_per_frame)
+{
+    if (bytes >= chunk_bytes) return bytes;
+    int aligned = bytes - bytes % bytes_per_frame;
+    if (aligned != bytes)
+        LOG_WARN("Discarding %d trailing incomplete PCM bytes", bytes - aligned);
+    memset(buf + aligned, 0, (size_t)(chunk_bytes - aligned));
+    return chunk_bytes;
+}
+
 /* ---- Command pipe handler ---- */
 
 static struct {
@@ -495,16 +508,17 @@ static bool session_commit(void *transport, uint64_t start_unix_ms)
 
 /* Discard the receiver's buffered audio in place for a warm seek and mark the
  * stream not-playing; the next START re-anchors and resumes sending. */
-static void session_flush_op(void *transport)
+static bool session_flush_op(void *transport)
 {
     cli_config_t *cfg = transport;
+    bool flushed = false;
     if (cfg->protocol == PROTO_RAOP) {
-        if (g_raopcl && !raop_session_flush(g_raopcl))
-            status_error("RAOP flush failed");
+        flushed = g_raopcl && raop_session_flush(g_raopcl);
     } else if (g_ap2cl) {
-        ap2cl_flush(g_ap2cl);
+        flushed = ap2cl_flush(g_ap2cl);
     }
     if (g_status == STATUS_PLAYING) g_status = STATUS_PAUSED;
+    return flushed;
 }
 
 static void session_stop_op(void *transport)
@@ -627,7 +641,8 @@ static bool start_command_thread(cli_config_t *cfg)
     return true;
 }
 
-static bool start_stream_session(cli_config_t *cfg, int input_bpf)
+static bool start_stream_session(cli_config_t *cfg, int input_bpf,
+                                 int frames_per_chunk)
 {
     ap2_session_ops_t ops = {
         .quiesce = session_quiesce,
@@ -640,6 +655,7 @@ static bool start_stream_session(cli_config_t *cfg, int input_bpf)
     };
     g_session = ap2_session_create(
         &ops, (unsigned)cfg->sample_rate * (unsigned)input_bpf,
+        (unsigned)frames_per_chunk * (unsigned)input_bpf,
         SESSION_IDLE_TIMEOUT_MS, STDIN_FILENO);
     if (!g_session) {
         status_error("Cannot create session engine");
@@ -742,7 +758,9 @@ static int run_raop(cli_config_t *cfg)
     latency = raopcl_latency(g_raopcl);
     int input_bpf = (cfg->bit_depth <= 16 ? 2 : 4) * cfg->channels;
     int alac_bpf = (cfg->bit_depth <= 16 ? 2 : 3) * cfg->channels;
-    if (!start_stream_session(cfg, input_bpf)) return 1;
+    if (!start_stream_session(
+            cfg, input_bpf, DEFAULT_FRAMES_PER_CHUNK))
+        return 1;
     status_connected_legacy(inet_ntoa(player_addr), cfg->port,
                             (int)TS2MS(latency, raopcl_sample_rate(g_raopcl)));
 
@@ -770,7 +788,6 @@ static int run_raop(cli_config_t *cfg)
     bool input_ended = false;
     bool eof_reported = false;
     uint64_t eof_time = 0;
-    int pcm_carry = 0;
 
     /* Main audio loop */
     while (g_status != STATUS_STOPPED) {
@@ -785,8 +802,7 @@ static int run_raop(cli_config_t *cfg)
             break;
         }
 
-        /* Each START bumps the epoch; reset the per-track bookkeeping so
-         * elapsed and frame alignment restart at the new anchor. */
+        /* Each START bumps the epoch; elapsed restarts at the new anchor. */
         uint64_t epoch = ap2_session_epoch(g_session);
         if (epoch != current_epoch) {
             current_epoch = epoch;
@@ -794,7 +810,6 @@ static int run_raop(cli_config_t *cfg)
             input_ended = false;
             eof_reported = false;
             eof_time = 0;
-            pcm_carry = 0;
         }
 
         /* Periodic status reporting (only while playing, so a pause does not keep
@@ -837,20 +852,9 @@ static int run_raop(cli_config_t *cfg)
                 input_ended = false;
                 eof_reported = false;
                 eof_time = 0;
-                pcm_carry = 0;
             }
             int n = ap2_session_read(
-                g_session, buf + pcm_carry,
-                DEFAULT_FRAMES_PER_CHUNK * input_bpf - pcm_carry, 250);
-            if (n > 0) {
-                n += pcm_carry;
-                pcm_carry = n % input_bpf;
-                n -= pcm_carry;
-                if (n == 0) {
-                    pthread_mutex_unlock(&g_audio_send_lock);
-                    continue;
-                }
-            }
+                g_session, buf, DEFAULT_FRAMES_PER_CHUNK * input_bpf, 250);
             if (n == -2) {
                 pthread_mutex_unlock(&g_audio_send_lock);
                 break;
@@ -866,6 +870,8 @@ static int run_raop(cli_config_t *cfg)
                 pthread_mutex_unlock(&g_audio_send_lock);
                 continue;
             }
+            n = pad_final_pcm_chunk(
+                buf, n, DEFAULT_FRAMES_PER_CHUNK * input_bpf, input_bpf);
 
             int audio_frames = n / input_bpf;
             uint8_t *send_buf = buf;
@@ -883,7 +889,6 @@ static int run_raop(cli_config_t *cfg)
                 break;
             }
             frames += audio_frames;
-            if (pcm_carry) memmove(buf, buf + n, (size_t)pcm_carry);
             pthread_mutex_unlock(&g_audio_send_lock);
         } else {
             usleep(1000);
@@ -1002,7 +1007,9 @@ static int run_airplay2(cli_config_t *cfg)
      * pipe thread anchors playback on the first START after connection setup. */
     int ap2_input_bpf = (cfg->bit_depth <= 16 ? 2 : 4) * cfg->channels;
     int ap2_alac_bpf = (cfg->bit_depth <= 16 ? 2 : 3) * cfg->channels;
-    if (!start_stream_session(cfg, ap2_input_bpf)) return 1;
+    if (!start_stream_session(
+            cfg, ap2_input_bpf, AP2_FRAMES_PER_CHUNK))
+        return 1;
     status_connected();
 
     uint64_t last = 0, frames = 0;
@@ -1015,7 +1022,6 @@ static int run_airplay2(cli_config_t *cfg)
     bool input_ended = false;     /* the input stream was fully consumed */
     bool eof_reported = false;
     uint64_t eof_time = 0;
-    int pcm_carry = 0;            /* sub-frame remainder between ring reads */
 
     /* Main audio loop */
     while (g_status != STATUS_STOPPED) {
@@ -1031,8 +1037,7 @@ static int run_airplay2(cli_config_t *cfg)
             break;
         }
 
-        /* Each START bumps the epoch; reset the per-track bookkeeping so
-         * elapsed and frame alignment restart at the new anchor. */
+        /* Each START bumps the epoch; elapsed restarts at the new anchor. */
         uint64_t epoch = ap2_session_epoch(g_session);
         if (epoch != current_epoch) {
             current_epoch = epoch;
@@ -1040,7 +1045,6 @@ static int run_airplay2(cli_config_t *cfg)
             input_ended = false;
             eof_reported = false;
             eof_time = 0;
-            pcm_carry = 0;
         }
 
         /* Periodic status reporting (only while playing, so a pause does not keep
@@ -1083,22 +1087,9 @@ static int run_airplay2(cli_config_t *cfg)
                 input_ended = false;
                 eof_reported = false;
                 eof_time = 0;
-                pcm_carry = 0;
             }
             int n = ap2_session_read(
-                g_session, buf + pcm_carry,
-                AP2_FRAMES_PER_CHUNK * ap2_input_bpf - pcm_carry, 250);
-            if (n > 0) {
-                /* Ring pops are byte-granular: carry any sub-frame remainder
-                 * into the next read so frame alignment never drifts. */
-                n += pcm_carry;
-                pcm_carry = n % ap2_input_bpf;
-                n -= pcm_carry;
-                if (n == 0) {
-                    pthread_mutex_unlock(&g_audio_send_lock);
-                    continue;   /* only a partial frame arrived so far */
-                }
-            }
+                g_session, buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf, 250);
             if (n == -2) {
                 pthread_mutex_unlock(&g_audio_send_lock);
                 break;
@@ -1121,6 +1112,8 @@ static int run_airplay2(cli_config_t *cfg)
                 pthread_mutex_unlock(&g_audio_send_lock);
                 continue;
             }
+            n = pad_final_pcm_chunk(
+                buf, n, AP2_FRAMES_PER_CHUNK * ap2_input_bpf, ap2_input_bpf);
             if (starving) {
                 uint32_t stalled_ms =
                     (uint32_t)NTP2MS(raopcl_get_ntp(NULL) -
@@ -1145,7 +1138,6 @@ static int run_airplay2(cli_config_t *cfg)
                 break;
             }
             frames += af;
-            if (pcm_carry) memmove(buf, buf + n, (size_t)pcm_carry);
             pthread_mutex_unlock(&g_audio_send_lock);
         } else {
             /* Paused, or connected and awaiting the commanded first START. */

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -24,10 +24,14 @@ void ap2cl_test_lock_mrp(struct ap2cl_s *p);
 void ap2cl_test_unlock_mrp(struct ap2cl_s *p);
 void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd);
 void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p);
+bool ap2cl_test_first_packet(struct ap2cl_s *p);
+void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet);
 
 typedef struct {
     int fd;
     int request_count;
+    int expected_requests;
+    int response_status;
     bool ok;
 } rtsp_peer_t;
 
@@ -35,7 +39,7 @@ static void *run_rtsp_flush_peer(void *arg)
 {
     rtsp_peer_t *peer = arg;
     peer->ok = true;
-    for (int request = 0; request < 2; request++) {
+    for (int request = 0; request < peer->expected_requests; request++) {
         char buffer[2048] = {0};
         size_t fill = 0;
         while (!strstr(buffer, "\r\n\r\n")) {
@@ -60,10 +64,11 @@ static void *run_rtsp_flush_peer(void *arg)
         }
         peer->request_count++;
         char response[96];
+        const char *reason = peer->response_status == 200 ? "OK" : "Error";
         int response_len = snprintf(
             response, sizeof(response),
-            "RTSP/1.0 200 OK\r\nCSeq: %d\r\nContent-Length: 0\r\n\r\n",
-            cseq);
+            "RTSP/1.0 %d %s\r\nCSeq: %d\r\nContent-Length: 0\r\n\r\n",
+            peer->response_status, reason, cseq);
         if (write(peer->fd, response, (size_t)response_len) != response_len) {
             peer->ok = false;
             return NULL;
@@ -80,6 +85,8 @@ static void test_native_flush_resume_reuses_rtsp_session(void)
     assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
     rtsp_peer_t peer = {
         .fd = sockets[1],
+        .expected_requests = 2,
+        .response_status = 200,
     };
     pthread_t peer_thread;
     assert(pthread_create(
@@ -101,6 +108,9 @@ static void test_native_flush_resume_reuses_rtsp_session(void)
     ap2cl_force_native(client);
     ap2cl_test_attach_rtsp_socket(client, sockets[0]);
     assert(ap2cl_start(client, 1700000000000ULL));
+    /* The test bypasses native connect, so model a completed first send before
+     * exercising the warm restart. */
+    ap2cl_test_set_first_packet(client, false);
 
     ap2cl_standby(client);
     assert(ap2cl_state(client) == AP2_CONNECTED);
@@ -108,10 +118,51 @@ static void test_native_flush_resume_reuses_rtsp_session(void)
     assert(ap2cl_flush(client));
     assert(ap2cl_resume(client, 1700000005000ULL));
     assert(ap2cl_state(client) == AP2_STREAMING);
+    assert(ap2cl_test_first_packet(client));
 
     assert(pthread_join(peer_thread, NULL) == 0);
     assert(peer.ok);
     assert(peer.request_count == 2);
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+}
+
+static void test_native_flush_rejects_receiver_error(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    rtsp_peer_t peer = {
+        .fd = sockets[1],
+        .expected_requests = 1,
+        .response_status = 500,
+    };
+    pthread_t peer_thread;
+    assert(pthread_create(
+               &peer_thread, NULL, run_rtsp_flush_peer, &peer) == 0);
+
+    ap2_device_info_t device = {
+        .name = "flush failure test",
+        .address = "127.0.0.1",
+        .port = 7000,
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+    assert(ap2cl_start(client, 1700000000000ULL));
+    assert(!ap2cl_flush(client));
+
+    assert(pthread_join(peer_thread, NULL) == 0);
+    assert(peer.ok);
+    assert(peer.request_count == 1);
     ap2cl_test_detach_rtsp_socket(client);
     assert(close(sockets[0]) == 0);
     assert(close(sockets[1]) == 0);
@@ -204,6 +255,7 @@ int main(void)
 {
     test_info_format_tables();
     test_native_flush_resume_reuses_rtsp_session();
+    test_native_flush_rejects_receiver_error();
 
     ap2_device_info_t device = {
         .name = "test",

--- a/tests/test_ap2_session.c
+++ b/tests/test_ap2_session.c
@@ -223,13 +223,15 @@ static void test_short_read_is_released_at_eof(void)
     static const uint8_t audio[] = {0x10, 0x20, 0x30};
     test_state_t state;
     int write_fd;
-    struct ap2_session_s *session = create_session(&state, 0, &write_fd);
+    struct ap2_session_s *session =
+        create_session_with_ready(&state, sizeof(audio) + 1, 0, &write_fd);
 
-    assert(ap2_session_start(session, 1700000000000ULL));
     feed(write_fd, audio, sizeof(audio));
-    uint8_t got[sizeof(audio) + 1];
-    assert(ap2_session_read(session, got, sizeof(got), 50) == 0);
     assert(close(write_fd) == 0);
+    assert(wait_for_count(&state.audio_status, 1, 1000));
+    assert(ap2_session_start(session, 1700000000000ULL));
+
+    uint8_t got[sizeof(audio) + 1];
     assert(ap2_session_read(session, got, sizeof(got), 1000) ==
            (int)sizeof(audio));
     assert(memcmp(got, audio, sizeof(audio)) == 0);

--- a/tests/test_ap2_session.c
+++ b/tests/test_ap2_session.c
@@ -35,6 +35,7 @@ typedef struct {
     atomic_int audio_status;
     atomic_int idle_timeouts;
     uint64_t last_start_unix_ms;
+    bool flush_succeeds;
 } test_state_t;
 
 static test_state_t *status_state;
@@ -44,9 +45,11 @@ static void quiesce(void *transport)
     atomic_fetch_add(&((test_state_t *)transport)->quiesces, 1);
 }
 
-static void flush(void *transport)
+static bool flush(void *transport)
 {
-    atomic_fetch_add(&((test_state_t *)transport)->flushes, 1);
+    test_state_t *state = transport;
+    atomic_fetch_add(&state->flushes, 1);
+    return state->flush_succeeds;
 }
 
 static bool commit(void *transport, uint64_t start_unix_ms)
@@ -88,13 +91,15 @@ static void state_init(test_state_t *state)
     atomic_init(&state->flushed_status, 0);
     atomic_init(&state->audio_status, 0);
     atomic_init(&state->idle_timeouts, 0);
+    state->flush_succeeds = true;
     status_state = state;
 }
 
 /* Create a pipe-backed session: the engine reads (a dup of) the pipe read end,
  * the test writes the audio into the returned write end. */
-static struct ap2_session_s *create_session(test_state_t *state,
-                                            int idle_timeout_ms, int *write_fd)
+static struct ap2_session_s *create_session_with_ready(
+    test_state_t *state, unsigned ready_bytes, int idle_timeout_ms,
+    int *write_fd)
 {
     state_init(state);
     ap2_session_ops_t ops = {
@@ -109,12 +114,19 @@ static struct ap2_session_s *create_session(test_state_t *state,
     int input[2];
     assert(pipe(input) == 0);
     struct ap2_session_s *session =
-        ap2_session_create(&ops, 1000, idle_timeout_ms, input[0]);
+        ap2_session_create(
+            &ops, 1000, ready_bytes, idle_timeout_ms, input[0]);
     assert(session);
     /* The engine owns its own dup of the read end. */
     assert(close(input[0]) == 0);
     *write_fd = input[1];
     return session;
+}
+
+static struct ap2_session_s *create_session(test_state_t *state,
+                                             int idle_timeout_ms, int *write_fd)
+{
+    return create_session_with_ready(state, 1, idle_timeout_ms, write_fd);
 }
 
 static void feed(int write_fd, const uint8_t *data, size_t size)
@@ -175,6 +187,56 @@ static void test_start_streams_the_input(void)
     ap2_session_destroy(session);
     status_state = NULL;
     assert(close(write_fd) == 0);
+}
+
+static void test_ready_and_reads_wait_for_a_complete_packet(void)
+{
+    static const uint8_t first[] = {0x10, 0x20, 0x30, 0x40};
+    static const uint8_t second[] = {0x50, 0x60, 0x70, 0x80};
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session =
+        create_session_with_ready(&state, sizeof(first), 0, &write_fd);
+
+    feed(write_fd, first, sizeof(first) - 1);
+    usleep(50000);
+    assert(atomic_load(&state.audio_status) == 0);
+    feed(write_fd, first + sizeof(first) - 1, 1);
+    assert(wait_for_count(&state.audio_status, 1, 1000));
+
+    assert(ap2_session_start(session, 1700000000000ULL));
+    read_exact(session, first, sizeof(first));
+
+    feed(write_fd, second, sizeof(second) - 1);
+    uint8_t got[sizeof(second)];
+    assert(ap2_session_read(session, got, sizeof(got), 50) == 0);
+    feed(write_fd, second + sizeof(second) - 1, 1);
+    read_exact(session, second, sizeof(second));
+
+    ap2_session_destroy(session);
+    status_state = NULL;
+    assert(close(write_fd) == 0);
+}
+
+static void test_short_read_is_released_at_eof(void)
+{
+    static const uint8_t audio[] = {0x10, 0x20, 0x30};
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 0, &write_fd);
+
+    assert(ap2_session_start(session, 1700000000000ULL));
+    feed(write_fd, audio, sizeof(audio));
+    uint8_t got[sizeof(audio) + 1];
+    assert(ap2_session_read(session, got, sizeof(got), 50) == 0);
+    assert(close(write_fd) == 0);
+    assert(ap2_session_read(session, got, sizeof(got), 1000) ==
+           (int)sizeof(audio));
+    assert(memcmp(got, audio, sizeof(audio)) == 0);
+    assert(ap2_session_read(session, got, sizeof(got), 50) == -1);
+
+    ap2_session_destroy(session);
+    status_state = NULL;
 }
 
 /* The headline test: FLUSH drains the ring AND any undelivered stdin bytes and
@@ -241,6 +303,31 @@ static void test_flush_while_idle_before_start(void)
     static const uint8_t audio[] = {0x01, 0x02, 0x03, 0x04};
     feed(write_fd, audio, sizeof(audio));
     assert(ap2_session_start(session, 0));
+    read_exact(session, audio, sizeof(audio));
+
+    ap2_session_destroy(session);
+    status_state = NULL;
+    assert(close(write_fd) == 0);
+}
+
+static void test_failed_flush_preserves_pending_audio(void)
+{
+    static const uint8_t audio[] = {0x10, 0x20, 0x30, 0x40};
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 0, &write_fd);
+
+    feed(write_fd, audio, sizeof(audio));
+    assert(wait_for_count(&state.audio_status, 1, 1000));
+    assert(ap2_session_start(session, 1700000000000ULL));
+    state.flush_succeeds = false;
+
+    assert(!ap2_session_flush(session));
+    assert(atomic_load(&state.flushes) == 1);
+    assert(atomic_load(&state.flushed_status) == 0);
+    assert(atomic_load(&state.quiesces) == 2);
+    assert(atomic_load(&state.resumes) == 2);
+    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
     read_exact(session, audio, sizeof(audio));
 
     ap2_session_destroy(session);
@@ -317,8 +404,11 @@ static void test_destroy_is_prompt_with_open_writer(void)
 int main(void)
 {
     test_start_streams_the_input();
+    test_ready_and_reads_wait_for_a_complete_packet();
+    test_short_read_is_released_at_eof();
     test_flush_drains_and_reanchors();
     test_flush_while_idle_before_start();
+    test_failed_flush_preserves_pending_audio();
     test_standby_then_resume();
     test_idle_timeout_ends_session();
     test_destroy_is_prompt_with_open_writer();


### PR DESCRIPTION
## Problem
Some AirPlay devices could play a short burst of noise or struggle to resume after seeking.

## Changes
- Restart AirPlay 2 playback with a fresh sync marker
- Send only complete audio packets after a seek
- Fall back cleanly when a device rejects a stream flush