### PR TITLE
Tolerate brief network dropouts instead of ending the session

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -488,8 +488,8 @@ capture.
   keepalive thread and the streaming path can never interleave frames on the
   encrypted channel.
 - **Socket deadlines** — established RTSP request/response cycles use cumulative
-  absolute deadlines appropriate to the request: 1.5 seconds for feedback,
-  2 seconds for control, 5 seconds for metadata, and 15 seconds for artwork.
+  absolute deadlines appropriate to the request: 2 seconds for feedback and
+  control, 5 seconds for metadata, and 15 seconds for artwork.
   The deadline also bounds waiting for the RTSP serialization lock, so a long
   artwork transaction cannot silently extend a feedback request's budget. A
   feedback tick that exhausts its budget before acquiring that lock is skipped:
@@ -497,6 +497,15 @@ capture.
   Event/DataStream writes have a one-second deadline, while realtime RTP/control
   UDP sends are nonblocking with a short bounded retry. A dead encrypted channel
   is fail-closed and terminal so an advanced nonce is never reused.
+- **Keepalive miss tolerance** — a timeout-shaped `/feedback` failure (the
+  device riding out a short local network blackout with its buffered audio
+  intact) does not kill the channel: up to three consecutive missed beats are
+  tolerated (the third kills), while hard peer errors (reset/EOF/protocol)
+  stay immediately fatal. Responses to abandoned beats arrive late once the
+  device recovers, so the response reader skips complete stale responses by
+  CSeq, and bytes of a response that was mid-flight at an abandoned deadline
+  carry over into the next exchange to keep the byte stream and the HAP
+  read-nonce sequence intact. A succeeded beat resets the miss count.
 - **Reverse event channel** — pair-verified sessions derive independent
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -64,11 +64,18 @@ extern log_level *loglevel;
 #define AP2_FMT_ALAC_48000_24_2 (1ULL << 21)
 #define AP2_RTSP_SETUP_TIMEOUT_MS    8000
 #define AP2_RTSP_CONTROL_TIMEOUT_MS  2000
-#define AP2_RTSP_FEEDBACK_TIMEOUT_MS 1500
+#define AP2_RTSP_FEEDBACK_TIMEOUT_MS 2000
 #define AP2_RTSP_METADATA_TIMEOUT_MS 5000
 #define AP2_RTSP_ARTWORK_TIMEOUT_MS  15000
 #define AP2_FEEDBACK_INTERVAL_MS     2000
+/* A single missed keepalive beat must not kill an otherwise healthy session:
+ * receivers ride out multi-second local network blackouts (wifi roams, DFS
+ * scans) with their buffered audio intact. Consecutive timeout-shaped misses
+ * are tolerated up to this count (the final one kills), so a genuinely dead
+ * channel is still detected within roughly misses x (interval + timeout). */
+#define AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES 3
 #define AP2_EVENT_POLL_INTERVAL_MS   100
+#define AP2_RTSP_RX_BUF_SIZE         16384
 #define AP2_UDP_SEND_TIMEOUT_MS      20
 /* Minimum lead for a commanded start: receivers accepted re-anchors down to
  * 150 ms in the flush-ladder measurements; 250 ms leaves margin for the
@@ -121,6 +128,13 @@ struct ap2cl_s {
     atomic_bool rtsp_dead;
     atomic_bool media_healthy;
     bool rtsp_established;
+    /* Raw bytes received for a response whose exchange was abandoned by a
+     * tolerated /feedback miss. Re-seeded into the next exchange's read so
+     * the TCP byte stream (and the HAP read-nonce sequence) stays intact
+     * when that response was mid-flight at the deadline. Only touched under
+     * rtsp_lock (the exchange serializer). */
+    uint8_t rtsp_carry[AP2_RTSP_RX_BUF_SIZE];
+    int rtsp_carry_len;
     pthread_t feedback_thread;
     atomic_bool feedback_stop;
     bool feedback_thread_started;
@@ -219,6 +233,20 @@ static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
                                uint64_t elapsed_ms)
 {
     int saved_errno = errno;
+    unsigned prior_misses = atomic_load(&p->feedback_failures);
+    if (ap2_io_feedback_miss_tolerated(uri, saved_errno, prior_misses,
+                                       AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES)) {
+        /* The device may just be riding out a short local network blackout
+         * with its buffered audio intact. Leave the channel open — the next
+         * exchange skips this beat's late response by CSeq — and only give
+         * up after the consecutive-miss budget is spent. */
+        LOG_WARN("[AP2] POST /feedback keepalive miss %u/%d (%s after %" PRIu64
+                 "ms: %s); tolerating transient failure",
+                 prior_misses + 1, AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES, phase,
+                 elapsed_ms, strerror(saved_errno));
+        errno = saved_errno;
+        return;
+    }
     if ((p->rtsp_established || p->hap) &&
         !atomic_exchange(&p->rtsp_dead, true)) {
         LOG_ERROR("[AP2] RTSP channel failed during %s %s %s after %" PRIu64
@@ -316,18 +344,29 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
               cseq, method, uri, body_len, msg_len,
               (int)(deadline_ms - started_ms));
     if (!ap2_io_write_all_deadline(p->sock_fd, msg, msg_len, deadline_ms)) {
-        free(msg);
+        /* mark first: it keys off errno from the failed write, which a
+         * free() in between is not guaranteed to preserve */
         ap2_mark_rtsp_dead(p, method, uri, "write",
                            ap2_io_monotonic_ms() - started_ms);
+        free(msg);
         return 0;
     }
     free(msg);
 
     /* Read encrypted response.
      * HAP framing: [2-byte LE length][encrypted chunk + 16-byte tag]
-     * We accumulate raw bytes, then decrypt complete frames. */
-    uint8_t buf[16384] = {0};
+     * We accumulate raw bytes, then decrypt complete frames.
+     * The accumulation is seeded with bytes carried over from an exchange
+     * abandoned by a tolerated /feedback miss, so a response that was
+     * mid-flight at that deadline keeps the byte stream intact; responses
+     * to such abandoned requests are then skipped by CSeq below. */
+    uint8_t buf[AP2_RTSP_RX_BUF_SIZE] = {0};
     int total = 0;
+    if (p->rtsp_carry_len > 0) {
+        memcpy(buf, p->rtsp_carry, (size_t)p->rtsp_carry_len);
+        total = p->rtsp_carry_len;
+        p->rtsp_carry_len = 0;
+    }
     if (!p->hap) {
         while (total < (int)sizeof(buf)) {
             int n = (int)ap2_io_read_deadline(
@@ -336,18 +375,19 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
             if (n <= 0) break;
             total += n;
             ap2_rtsp_response_t parsed;
-            int parse_status = ap2_io_parse_rtsp_response(
-                buf, (size_t)total, &parsed);
-            if (parse_status < 0) {
+            size_t match_offset = 0;
+            unsigned discarded = 0;
+            int match_status = ap2_io_match_rtsp_response(
+                buf, (size_t)total, cseq, &parsed, &match_offset, &discarded);
+            if (match_status < 0) {
                 errno = EPROTO;
                 break;
             }
-            if (parse_status > 0) {
-                if (parsed.message_len != (size_t)total ||
-                    parsed.cseq != cseq) {
-                    errno = EPROTO;
-                    break;
-                }
+            if (match_status > 0) {
+                if (discarded)
+                    LOG_INFO("[AP2] %s %s: discarded %u stale response(s) "
+                             "from tolerated keepalive misses",
+                             method, uri, discarded);
                 *resp_len = (int)parsed.body_len;
                 *resp_body = parsed.body_len ? malloc(parsed.body_len) : NULL;
                 if (parsed.body_len && !*resp_body) {
@@ -355,12 +395,18 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
                     break;
                 }
                 if (*resp_body)
-                    memcpy(*resp_body, buf + parsed.header_len, parsed.body_len);
+                    memcpy(*resp_body, buf + match_offset + parsed.header_len,
+                           parsed.body_len);
                 return parsed.status;
             }
         }
+        if (total >= (int)sizeof(buf)) errno = EMSGSIZE;
         ap2_mark_rtsp_dead(p, method, uri, "read",
                            ap2_io_monotonic_ms() - started_ms);
+        if (!atomic_load(&p->rtsp_dead) && total > 0) {
+            memcpy(p->rtsp_carry, buf, (size_t)total);
+            p->rtsp_carry_len = total;
+        }
         *resp_body = NULL;
         *resp_len = 0;
         return 0;
@@ -382,20 +428,21 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         int dec_len = ap2_hap_decrypt(p->hap, buf, total, &dec);
         if (dec_len > 0 && dec) {
             ap2_rtsp_response_t parsed;
-            int parse_status = ap2_io_parse_rtsp_response(
-                dec, (size_t)dec_len, &parsed);
-            if (parse_status < 0) {
+            size_t match_offset = 0;
+            unsigned discarded = 0;
+            int match_status = ap2_io_match_rtsp_response(
+                dec, (size_t)dec_len, cseq, &parsed, &match_offset,
+                &discarded);
+            if (match_status < 0) {
                 free(dec);
                 errno = EPROTO;
                 break;
             }
-            if (parse_status > 0) {
-                if (parsed.message_len != (size_t)dec_len ||
-                    parsed.cseq != cseq) {
-                    free(dec);
-                    errno = EPROTO;
-                    break;
-                }
+            if (match_status > 0) {
+                if (discarded)
+                    LOG_INFO("[AP2] %s %s: discarded %u stale response(s) "
+                             "from tolerated keepalive misses",
+                             method, uri, discarded);
                 *resp_len = (int)parsed.body_len;
                 *resp_body = parsed.body_len ? malloc(parsed.body_len) : NULL;
                 if (parsed.body_len && !*resp_body) {
@@ -404,7 +451,7 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
                     break;
                 }
                 if (*resp_body)
-                    memcpy(*resp_body, dec + parsed.header_len,
+                    memcpy(*resp_body, dec + match_offset + parsed.header_len,
                            parsed.body_len);
                 int status = parsed.status;
                 free(dec);
@@ -418,8 +465,13 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         }
     }
 
+    if (total >= (int)sizeof(buf)) errno = EMSGSIZE;
     ap2_mark_rtsp_dead(p, method, uri, "read",
                        ap2_io_monotonic_ms() - started_ms);
+    if (!atomic_load(&p->rtsp_dead) && total > 0) {
+        memcpy(p->rtsp_carry, buf, (size_t)total);
+        p->rtsp_carry_len = total;
+    }
     *resp_body = NULL;
     *resp_len = 0;
     return 0;
@@ -889,6 +941,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     }
 
     if (getaddrinfo(p->device.address, port_str, &hints, &res) != 0) return false;
+    p->rtsp_carry_len = 0;
     p->sock_fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
     if (p->sock_fd >= 0 && p->bind_addr.s_addr != INADDR_ANY) {
         struct sockaddr_in la = {.sin_family = AF_INET, .sin_addr = p->bind_addr};
@@ -2326,7 +2379,10 @@ bool ap2cl_feedback(struct ap2cl_s *p)
         }
     }
     if (result == AP2_FEEDBACK_SUCCEEDED) {
-        atomic_store(&p->feedback_failures, 0);
+        unsigned prior_misses = atomic_exchange(&p->feedback_failures, 0);
+        if (prior_misses)
+            LOG_INFO("[AP2] /feedback keepalive recovered after %u missed "
+                     "beat(s)", prior_misses);
     } else if (result == AP2_FEEDBACK_FAILED) {
         atomic_fetch_add(&p->feedback_failures, 1);
     }
@@ -2338,7 +2394,7 @@ bool ap2cl_control_healthy(struct ap2cl_s *p)
     if (!p || p->flow != FLOW_NATIVE_AP2) return true;
     if (atomic_load(&p->rtsp_dead) ||
         !atomic_load(&p->media_healthy) ||
-        atomic_load(&p->feedback_failures) >= 3)
+        atomic_load(&p->feedback_failures) >= AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES)
         return false;
     return atomic_load(&p->mrp_event_health) != 0;
 }
@@ -2844,6 +2900,7 @@ void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd)
 {
     p->sock_fd = fd;
     p->rtsp_established = true;
+    p->rtsp_carry_len = 0;
     atomic_store(&p->rtsp_dead, false);
     snprintf(p->session_url, sizeof(p->session_url), "rtsp://test/session");
 }

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -177,6 +177,15 @@ ap2_feedback_result_t ap2_io_feedback_result(int rtsp_status,
     return AP2_FEEDBACK_FAILED;
 }
 
+bool ap2_io_feedback_miss_tolerated(const char *uri, int err,
+                                    unsigned prior_misses,
+                                    unsigned max_misses)
+{
+    if (!uri || strcmp(uri, "/feedback") != 0) return false;
+    if (err != ETIMEDOUT) return false;
+    return prior_misses + 1 < max_misses;
+}
+
 static size_t ap2_find_header_end(const uint8_t *data, size_t len)
 {
     for (size_t i = 0; i + 3 < len; i++) {
@@ -273,4 +282,27 @@ int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
     response->body_len = body_len;
     response->message_len = message_len;
     return 1;
+}
+
+int ap2_io_match_rtsp_response(const uint8_t *data, size_t len,
+                               int expect_cseq,
+                               ap2_rtsp_response_t *response,
+                               size_t *match_offset, unsigned *discarded)
+{
+    if (discarded) *discarded = 0;
+    size_t offset = 0;
+    while (offset < len) {
+        int parse_status =
+            ap2_io_parse_rtsp_response(data + offset, len - offset, response);
+        if (parse_status <= 0) return parse_status;
+        if (response->cseq == expect_cseq) {
+            if (offset + response->message_len != len) return -1;
+            if (match_offset) *match_offset = offset;
+            return 1;
+        }
+        if (response->cseq > expect_cseq) return -1;
+        if (discarded) (*discarded)++;
+        offset += response->message_len;
+    }
+    return 0;
 }

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -43,9 +43,30 @@ ap2_send_result_t ap2_io_send_datagram_deadline(
 ap2_feedback_result_t ap2_io_feedback_result(int rtsp_status,
                                              bool request_started);
 
+/* Returns true when a failed RTSP exchange may be survived as a keepalive
+ * miss instead of killing the channel: only POST /feedback, only a
+ * timeout-shaped error (a hard peer error means the connection is gone), and
+ * only while fewer than max_misses consecutive beats have been missed
+ * (prior_misses counts the misses before this one). */
+bool ap2_io_feedback_miss_tolerated(const char *uri, int err,
+                                    unsigned prior_misses,
+                                    unsigned max_misses);
+
 /* Returns 1 for a complete response, 0 for incomplete input, and -1 for
  * malformed input. */
 int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
                                ap2_rtsp_response_t *response);
+
+/* Locate the response with expect_cseq in a buffer that may start with
+ * complete responses left over from abandoned (timed-out) requests; those
+ * stale responses (lower CSeq) are skipped and counted in *discarded.
+ * Returns 1 with *response and *match_offset set when the expected response is
+ * found (it must end the buffer: with one outstanding request nothing may
+ * trail it), 0 when more data is needed, and -1 for malformed input, a
+ * response from the future or trailing bytes after the match. */
+int ap2_io_match_rtsp_response(const uint8_t *data, size_t len,
+                               int expect_cseq,
+                               ap2_rtsp_response_t *response,
+                               size_t *match_offset, unsigned *discarded);
 
 #endif

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -169,6 +169,104 @@ static void test_native_flush_rejects_receiver_error(void)
     assert(ap2cl_destroy(client));
 }
 
+static bool read_rtsp_request_cseq(int fd, const char *method, int *cseq)
+{
+    char buffer[2048] = {0};
+    size_t fill = 0;
+    while (!strstr(buffer, "\r\n\r\n")) {
+        ssize_t n = read(fd, buffer + fill, sizeof(buffer) - fill - 1);
+        if (n <= 0) return false;
+        fill += (size_t)n;
+        if (fill >= sizeof(buffer) - 1) return false;
+    }
+    char *cseq_header = strstr(buffer, "\r\nCSeq: ");
+    if (strncmp(buffer, method, strlen(method)) != 0 || !cseq_header ||
+        sscanf(cseq_header, "\r\nCSeq: %d", cseq) != 1)
+        return false;
+    return true;
+}
+
+typedef struct {
+    int fd;
+    bool ok;
+} feedback_peer_t;
+
+static void *run_feedback_miss_peer(void *arg)
+{
+    feedback_peer_t *peer = arg;
+    peer->ok = false;
+    /* Beat 1: swallow the request so the sender's read budget expires. */
+    int missed_cseq = 0;
+    if (!read_rtsp_request_cseq(peer->fd, "POST /feedback ", &missed_cseq))
+        return NULL;
+    /* Beat 2: answer the missed beat late, then the current one — the
+     * sender must skip the stale response and accept the fresh one. */
+    int current_cseq = 0;
+    if (!read_rtsp_request_cseq(peer->fd, "POST /feedback ", &current_cseq) ||
+        current_cseq != missed_cseq + 1)
+        return NULL;
+    char responses[192];
+    int responses_len = snprintf(
+        responses, sizeof(responses),
+        "RTSP/1.0 200 OK\r\nCSeq: %d\r\nContent-Length: 0\r\n\r\n"
+        "RTSP/1.0 200 OK\r\nCSeq: %d\r\nContent-Length: 0\r\n\r\n",
+        missed_cseq, current_cseq);
+    if (write(peer->fd, responses, (size_t)responses_len) != responses_len)
+        return NULL;
+    peer->ok = true;
+    return NULL;
+}
+
+/* One missed keepalive beat is tolerated (the channel stays alive) and the
+ * next successful beat — whose read must first skip the missed beat's late
+ * response — resets the consecutive-miss counter. */
+static void test_feedback_miss_tolerated_then_recovered(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    feedback_peer_t peer = {
+        .fd = sockets[1],
+    };
+    pthread_t peer_thread;
+    assert(pthread_create(
+               &peer_thread, NULL, run_feedback_miss_peer, &peer) == 0);
+
+    ap2_device_info_t device = {
+        .name = "feedback test",
+        .address = "127.0.0.1",
+        .port = 7000,
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+
+    /* The unanswered beat fails after its read budget but must not kill the
+     * channel (single-strike behaviour would report unhealthy here). */
+    assert(!ap2cl_feedback(client));
+    assert(ap2cl_control_healthy(client));
+
+    /* The next beat rides over the stale response and resets the counter:
+     * were the miss still counted, two more misses would flip health, so a
+     * succeeded beat proving health is the observable reset. */
+    assert(ap2cl_feedback(client));
+    assert(ap2cl_control_healthy(client));
+
+    assert(pthread_join(peer_thread, NULL) == 0);
+    assert(peer.ok);
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+    puts("ap2_client feedback miss tolerance test passed");
+}
+
 typedef struct {
     struct ap2cl_s *client;
     atomic_bool done;
@@ -256,6 +354,7 @@ int main(void)
     test_info_format_tables();
     test_native_flush_resume_reuses_rtsp_session();
     test_native_flush_rejects_receiver_error();
+    test_feedback_miss_tolerated_then_recovered();
 
     ap2_device_info_t device = {
         .name = "test",

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -59,6 +59,83 @@ static bool test_rtsp_parser(void)
     return true;
 }
 
+static bool test_feedback_miss_policy(void)
+{
+    /* Only /feedback, only timeout-shaped errors, only under the budget. */
+    CHECK(ap2_io_feedback_miss_tolerated("/feedback", ETIMEDOUT, 0, 3));
+    CHECK(ap2_io_feedback_miss_tolerated("/feedback", ETIMEDOUT, 1, 3));
+    /* The final miss of the budget kills the channel. */
+    CHECK(!ap2_io_feedback_miss_tolerated("/feedback", ETIMEDOUT, 2, 3));
+    CHECK(!ap2_io_feedback_miss_tolerated("/feedback", ETIMEDOUT, 7, 3));
+    /* Hard peer errors are never survivable. */
+    CHECK(!ap2_io_feedback_miss_tolerated("/feedback", ECONNRESET, 0, 3));
+    CHECK(!ap2_io_feedback_miss_tolerated("/feedback", EPIPE, 0, 3));
+    CHECK(!ap2_io_feedback_miss_tolerated("/feedback", EPROTO, 0, 3));
+    /* Other requests keep their single-strike behaviour. */
+    CHECK(!ap2_io_feedback_miss_tolerated("/command", ETIMEDOUT, 0, 3));
+    CHECK(!ap2_io_feedback_miss_tolerated("rtsp://x/session", ETIMEDOUT, 0, 3));
+    CHECK(!ap2_io_feedback_miss_tolerated(NULL, ETIMEDOUT, 0, 3));
+    /* A budget of one means no tolerance at all. */
+    CHECK(!ap2_io_feedback_miss_tolerated("/feedback", ETIMEDOUT, 0, 1));
+    return true;
+}
+
+static bool test_match_rtsp_response_skips_stale(void)
+{
+    static const uint8_t stream[] =
+        "RTSP/1.0 200 OK\r\nCSeq: 5\r\nContent-Length: 0\r\n\r\n"
+        "RTSP/1.0 500 Internal Server Error\r\nCSeq: 6\r\n"
+        "Content-Length: 2\r\n\r\nxy"
+        "RTSP/1.0 200 OK\r\nCSeq: 7\r\nContent-Length: 4\r\n\r\nbody";
+    const size_t len = sizeof(stream) - 1;
+    ap2_rtsp_response_t parsed;
+    size_t match_offset = 0;
+    unsigned discarded = 0;
+
+    /* An exact single response still matches with nothing discarded. */
+    static const uint8_t single[] =
+        "RTSP/1.0 200 OK\r\nCSeq: 7\r\nContent-Length: 4\r\n\r\nbody";
+    CHECK(ap2_io_match_rtsp_response(single, sizeof(single) - 1, 7, &parsed,
+                                     &match_offset, &discarded) == 1);
+    CHECK(discarded == 0);
+    CHECK(match_offset == 0);
+    CHECK(parsed.status == 200 && parsed.body_len == 4);
+
+    /* Two stale responses ahead of the expected one are skipped. */
+    CHECK(ap2_io_match_rtsp_response(stream, len, 7, &parsed,
+                                     &match_offset, &discarded) == 1);
+    CHECK(discarded == 2);
+    CHECK(parsed.status == 200);
+    CHECK(parsed.cseq == 7);
+    CHECK(parsed.body_len == 4);
+    CHECK(memcmp(stream + match_offset + parsed.header_len, "body", 4) == 0);
+
+    /* Only stale data so far: consumed entirely, more data needed. */
+    CHECK(ap2_io_match_rtsp_response(stream, len, 9, &parsed,
+                                     &match_offset, &discarded) == 0);
+    CHECK(discarded == 3);
+
+    /* Truncated tail after a stale prefix: more data needed. */
+    CHECK(ap2_io_match_rtsp_response(stream, len - 2, 7, &parsed,
+                                     &match_offset, &discarded) == 0);
+    CHECK(discarded == 2);
+
+    /* A response from the future means protocol desync. */
+    CHECK(ap2_io_match_rtsp_response(stream, len, 4, &parsed,
+                                     &match_offset, &discarded) == -1);
+
+    /* Trailing bytes after the matched response are not allowed. */
+    CHECK(ap2_io_match_rtsp_response(stream, len, 5, &parsed,
+                                     &match_offset, &discarded) == -1);
+
+    /* Malformed input propagates as -1. */
+    static const uint8_t malformed[] =
+        "RTSP/1.0 200 OK\r\nCSeq: nope\r\nContent-Length: 0\r\n\r\n";
+    CHECK(ap2_io_match_rtsp_response(malformed, sizeof(malformed) - 1, 5,
+                                     &parsed, &match_offset, &discarded) == -1);
+    return true;
+}
+
 static bool test_read_timeout_is_bounded(void)
 {
     int pair[2];
@@ -250,6 +327,10 @@ int main(void)
     fprintf(stderr, "fake peer response passed\n");
     if (!test_rtsp_parser()) return 1;
     fprintf(stderr, "RTSP parser passed\n");
+    if (!test_feedback_miss_policy()) return 1;
+    fprintf(stderr, "feedback miss policy passed\n");
+    if (!test_match_rtsp_response_skips_stale()) return 1;
+    fprintf(stderr, "stale response matcher passed\n");
     if (!test_read_timeout_is_bounded()) return 1;
     fprintf(stderr, "read timeout passed\n");
     if (!test_stalled_write_is_bounded()) return 1;


### PR DESCRIPTION
A single missed keepalive beat (one POST /feedback timing out, e.g. while the receiver rides out a short wifi dropout) immediately ended the whole native AirPlay 2 session — dropping the speaker from its group while it still had audio buffered and would have recovered on its own.

- Tolerate up to 3 consecutive timed-out keepalive beats before ending the session; hard connection errors (reset/EOF/protocol) still end it immediately. Per-beat read budget raised from 1.5s to 2s.
- Skip late responses of missed beats by CSeq and carry partially received bytes over into the next exchange, so the channel (and the HAP nonce sequence) recovers cleanly once the receiver is back.
- Reset the miss counter on the first successful beat; log each miss and the recovery.
- RAOP needs no change: its keepalive result was already ignored.
