### PR TITLE
Support password-protected receivers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -53,8 +53,9 @@ Decision order:
    `--ap2-native` forces AirPlay 2 regardless.
 2. **Native vs RAOP-compat** — stored credentials (`--auth`) ⇒ native with
    pair-verify. `--ap2-native` ⇒ native with transient pairing.
-   In `auto`, a device that advertises pairing (bit 46 or 48) with no PIN, no
-   legacy flag, and no password ⇒ native with transient pairing. Otherwise
+   In `auto`, a device that advertises pairing (bit 46 or 48) with no PIN and
+   no legacy flag ⇒ native with transient pairing, provided it either does not
+   require a password or one was supplied with `--password` (§3a). Otherwise
    the RAOP-compat flow. An explicit `--protocol airplay2` without
    credentials keeps RAOP-compat unless `--ap2-native` is given.
 3. **Timing** — `--ptp` forces PTP; otherwise the SupportsPTP feature bit
@@ -81,8 +82,9 @@ Connect sequence (`ap2_native_connect()`):
 3. **HAP pairing** — with `--auth`: pair-verify (`X-Apple-HKP: 3`) using the
    stored Ed25519/X25519 credentials, client identity = uppercased DACP ID
    (must match the one used at `--pair-setup` time). Without: transient
-   pair-setup (`X-Apple-HKP: 4`) — SRP-6a (SHA-512, 3072-bit group, fixed PIN
-   `3939`), M1–M4 only, nothing stored, shared secret = SRP session key.
+   pair-setup (`X-Apple-HKP: 4`) — SRP-6a (SHA-512, 3072-bit group, secret =
+   the fixed PIN `3939` or the device password, §3a), M1–M4 only, nothing
+   stored, shared secret = SRP session key.
    From here the RTSP channel is encrypted with HAP framing:
    `[2-byte LE length][ChaCha20-Poly1305 ciphertext + 16-byte tag]`, max 1024
    plaintext bytes per frame, nonce = 4 zero bytes + 8-byte LE per-direction
@@ -124,6 +126,62 @@ advertised ClockID.
 advertise in `timingPeerInfo`/SETPEERS when the reachable address differs
 from the bound one (Docker bridge, NAT). Default advertised address: the
 bind address, else the RTSP socket's local address.
+
+## 3a. Device passwords and the error contract
+
+A receiver with "Require Password" enabled advertises `pw=true` in its mDNS
+TXT. What that password means depends on the protocol:
+
+- **RAOP** — classic RTSP Digest (RFC 2069 shape, realm `raop`, username
+  `iTunes`; `AirPlay` for any other realm). libraop discovers the challenge on
+  a probe ANNOUNCE and then signs every request. The password is handed to
+  `raopcl_create()` whenever `--password` is non-empty: the `pw` flag only says
+  the device advertises one, and the digest is only used if the device actually
+  challenges.
+- **AirPlay 2** — there is no agreed mechanism. Reference receivers substitute
+  the password for the fixed `3939` transient SRP secret, and others disable
+  transient pairing entirely once a password is set, expecting full HomeKit
+  pairing (`--auth` credentials) instead. Real HomePods additionally answer
+  `401` on the session SETUP after a handshake that itself succeeded.
+
+Because the receiver decides, the native flow is self-selecting
+(`ap2_native_pair()`). Without `--password` it is exactly one leg and unchanged:
+credentials ⇒ pair-verify, otherwise transient pairing with the fixed PIN. With
+`--password`:
+
+1. transient pair-setup using the password as the SRP secret;
+2. if that is *rejected* (non-200 on a pair POST, or a TLV error), retry on a
+   fresh connection — with `--auth` credentials that is pair-verify, without
+   them it is transient pairing with the fixed PIN, which recovers the case of
+   a password configured on a device that does not require one.
+
+Each leg needs its own connection: a receiver that rejected a pairing attempt
+keeps its state machine wedged on that socket. A leg that dies on the wire
+(rather than being rejected) ends the attempt — there is nothing to retry.
+
+**Diagnostics.** Every non-200 on the native path (`/info`, pair-setup,
+pair-verify, session SETUP, stream SETUP) is logged at error level as the
+status line, all headers and a bounded hex dump of the body
+(`ap2_io_format_response_dump()`), which is what tells whether a receiver's
+`401` carries a `WWW-Authenticate` challenge and what its TLV/plist body says.
+
+**Error contract.** Before the human-readable `[ERROR]` line, a fatal
+connect/auth failure emits exactly one machine-readable line on stderr that
+Music Assistant parses:
+
+```
+[STATUS] error code=<slug> http=<int> detail="<single line>"
+```
+
+| slug | meaning |
+|---|---|
+| `auth_required` | a password is needed and none was supplied: reported before connecting when the TXT says so (and no credentials are stored), and on a `401`/`403` from a device we presented no password to |
+| `auth_failed` | the password we did present was rejected, on any exchange |
+| `connect_failed` | every other connect-path failure |
+
+`http` is the most informative HTTP status seen, `0` when none applies (a
+TLV-level rejection is an HTTP 200). The detail is squeezed onto one line and
+its double quotes replaced, so the shape holds for device-supplied text.
 
 ## 4. PTP engine
 

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,12 @@ test: directory $(EXECUTABLE) $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(CLIENT
 		/tmp/cliairplay-test-unused 127.0.0.1 - 2>&1 || true)"; \
 		printf '%s\n' "$$argv_audio" | \
 		grep -q "Streaming audio must be provided on stdin, not argv"
+	@auth_required="$$($(EXECUTABLE) --protocol raop --pw true \
+		127.0.0.1 2>&1 || true)"; \
+		printf '%s\n' "$$auth_required" | \
+		grep -q '^\[STATUS\] error code=auth_required http=0 detail="[^"]*"$$'; \
+		printf '%s\n' "$$auth_required" | \
+		grep -q "Password required but not supplied"
 
 $(RAOP_SESSION_TEST): tests/test_raop_session.c src/raop_session.c \
 		src/raop_session.h Makefile

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ cliairplay [options] --cmdpipe <path> <host_ip>
 |--------|-------------|
 | `--raw` | Force uncompressed ALAC frames. Default is compressed ALAC; the binary also falls back to uncompressed when the device's `cn` field lacks ALAC. |
 | `--encrypt` | Enable RAOP audio-payload encryption (default: clear). |
-| `--password <pw>` | Device password, if the receiver requires one. |
+| `--password <pw>` | Device password, if the receiver requires one. Used for RAOP digest authentication and as the AirPlay 2 transient pairing secret (DESIGN.md §3a). |
 | `--secret <secret>` | Legacy Apple TV pairing secret (from `--pair`). |
 | `--et <v>` `--md <v>` `--am <v>` `--pk <v>` `--pw <v>` `--cn <v>` | mDNS TXT fields from the receiver's `_raop._tcp` record (encryption types, metadata types, model, public key, password flag, codec types). |
 

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <poll.h>
+#include <stdarg.h>
 #include <stdatomic.h>
 #include <inttypes.h>
 
@@ -83,6 +84,10 @@ extern log_level *loglevel;
  * after the connection and the audio feed are both confirmed, so no setup
  * slack is needed on top. */
 #define AP2_MIN_WARM_LEAD_MS         250
+/* Raw bytes kept from a failed exchange for the auth diagnostics dump: enough
+ * for a full header block plus the start of a TLV/plist body. */
+#define AP2_DIAG_RESPONSE_MAX        1536
+#define AP2_DIAG_BODY_MAX            512
 
 typedef enum {
     FLOW_RAOP_COMPAT = 0,
@@ -202,6 +207,17 @@ struct ap2cl_s {
     uint32_t session_id;
     int cseq;
 
+    /* Outcome of the last connect attempt, surfaced through
+     * ap2cl_connect_error() so the caller can report why it failed. */
+    ap2_connect_error_t connect_error;
+    int connect_http_status;
+    char connect_detail[192];
+    /* Raw bytes of the most recent non-200 RTSP response, kept for the auth
+     * diagnostics dump. Written only from inside an RTSP exchange, which the
+     * rtsp_lock serializes. */
+    uint8_t last_error_response[AP2_DIAG_RESPONSE_MAX];
+    int last_error_response_len;
+
     /* PTP timing selection */
     bool use_ptp;      /* resolved: PTP grandmaster timing active this session */
     bool ptp_forced;   /* ap2cl_set_ptp() was called (overrides auto-detect) */
@@ -224,6 +240,93 @@ static void ap2_remote_command_received(
     struct ap2cl_s *p = userdata;
     if (p && p->remote_command_cb)
         p->remote_command_cb(command, p->remote_command_userdata);
+}
+
+/* ---- Native AP2 failure reporting ---- */
+
+/* True for the statuses a receiver uses to refuse an unauthenticated or
+ * wrongly-authenticated request. */
+static bool ap2_status_is_auth(int status)
+{
+    return status == 401 || status == 403;
+}
+
+/* An auth-shaped rejection means "supply a password" when we presented none,
+ * and "this password is wrong" when we did. */
+static ap2_connect_error_t ap2_auth_error_kind(struct ap2cl_s *p)
+{
+    return (p->password && *p->password) ? AP2_CONNECT_ERROR_AUTH_FAILED
+                                         : AP2_CONNECT_ERROR_AUTH_REQUIRED;
+}
+
+static void ap2_set_connect_error(struct ap2cl_s *p, ap2_connect_error_t kind,
+                                  int http_status, const char *fmt, ...)
+    __attribute__((format(printf, 4, 5)));
+
+static void ap2_set_connect_error(struct ap2cl_s *p, ap2_connect_error_t kind,
+                                  int http_status, const char *fmt, ...)
+{
+    p->connect_error = kind;
+    p->connect_http_status = http_status;
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(p->connect_detail, sizeof(p->connect_detail), fmt, args);
+    va_end(args);
+}
+
+/* Keep the raw bytes of a non-200 response for the diagnostics dump; a 200
+ * clears them so a later failure can never dump a stale exchange. */
+static void ap2_capture_response(struct ap2cl_s *p, const uint8_t *msg,
+                                 size_t len, int status)
+{
+    if (status == 200) {
+        p->last_error_response_len = 0;
+        return;
+    }
+    size_t keep = len < sizeof(p->last_error_response)
+                      ? len : sizeof(p->last_error_response);
+    memcpy(p->last_error_response, msg, keep);
+    p->last_error_response_len = (int)keep;
+}
+
+/*
+ * Log what the receiver answered on a failed native exchange: the status line,
+ * every header and a bounded body dump. For a 401 the questions that matter
+ * are whether a WWW-Authenticate challenge came with it and what the body
+ * carries, so the challenge is also returned for the caller's error detail.
+ */
+static void ap2_log_failed_response(struct ap2cl_s *p, const char *label,
+                                    int status, char *challenge,
+                                    size_t challenge_size)
+{
+    if (challenge && challenge_size) snprintf(challenge, challenge_size, "%s", "(absent)");
+    if (p->last_error_response_len <= 0) {
+        LOG_ERROR("[AP2] %s -> %d (no response body captured)", label, status);
+        return;
+    }
+    size_t len = (size_t)p->last_error_response_len;
+    char dump[1600];
+    ap2_io_format_response_dump(p->last_error_response, len,
+                                AP2_DIAG_BODY_MAX, dump, sizeof(dump));
+    LOG_ERROR("[AP2] %s -> %d response: %s", label, status, dump);
+    if (challenge && challenge_size)
+        ap2_io_header_value(p->last_error_response, len, "WWW-Authenticate",
+                            challenge, challenge_size);
+}
+
+/* Report a non-200 on the native connect path: dump the exchange and classify
+ * it, so the caller can tell a rejected password from a broken device. */
+static void ap2_report_failed_exchange(struct ap2cl_s *p, const char *label,
+                                       int status)
+{
+    char challenge[96];
+    ap2_log_failed_response(p, label, status, challenge, sizeof(challenge));
+    ap2_set_connect_error(p,
+                          ap2_status_is_auth(status)
+                              ? ap2_auth_error_kind(p)
+                              : AP2_CONNECT_ERROR_GENERIC,
+                          status, "%s -> %d; WWW-Authenticate: %s", label,
+                          status, challenge);
 }
 
 /* ---- Native AP2 RTSP I/O ---- */
@@ -388,6 +491,8 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
                     LOG_INFO("[AP2] %s %s: discarded %u stale response(s) "
                              "from tolerated keepalive misses",
                              method, uri, discarded);
+                ap2_capture_response(p, buf + match_offset, parsed.message_len,
+                                     parsed.status);
                 *resp_len = (int)parsed.body_len;
                 *resp_body = parsed.body_len ? malloc(parsed.body_len) : NULL;
                 if (parsed.body_len && !*resp_body) {
@@ -443,6 +548,8 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
                     LOG_INFO("[AP2] %s %s: discarded %u stale response(s) "
                              "from tolerated keepalive misses",
                              method, uri, discarded);
+                ap2_capture_response(p, dec + match_offset, parsed.message_len,
+                                     parsed.status);
                 *resp_len = (int)parsed.body_len;
                 *resp_body = parsed.body_len ? malloc(parsed.body_len) : NULL;
                 if (parsed.body_len && !*resp_body) {
@@ -707,8 +814,8 @@ static bool ap2_features_has_ptp(const char *txt)
 }
 
 ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char *pw,
-                              bool have_credentials, int bit_depth,
-                              bool force_native,
+                              bool have_credentials, bool have_password,
+                              int bit_depth, bool force_native,
                               bool ptp_forced, bool ptp_enabled)
 {
     ap2_route_t r = {0};
@@ -737,8 +844,11 @@ ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char
 
     /* 2. Native AP2 vs RAOP-compatible flow. Stored credentials or an explicit
      * override select native; in AUTO, transient-pairable devices (pairing bits,
-     * no PIN/legacy flag, no password) go native too. Explicit --protocol
-     * airplay2 keeps the proven RAOP-compat default unless native is forced. */
+     * no PIN/legacy flag, and either no password required or one supplied) go
+     * native too — the device password doubles as the transient SRP secret, so a
+     * password-protected receiver no longer has to drop to RAOP-compat. Explicit
+     * --protocol airplay2 keeps the proven RAOP-compat default unless native is
+     * forced. */
     bool native, transient = false;
     if (have_credentials) {
         native = true;            /* pair-verify with stored keys (Apple TV/HomePod) */
@@ -748,7 +858,8 @@ ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char
     } else if (pref == AP2_PROTO_AUTO &&
                (AP2_FEAT(r.features, AP2_FEAT_HK_PAIRING) ||
                 AP2_FEAT(r.features, AP2_FEAT_COREUTILS)) &&
-               !(r.flags & (AP2_SF_PIN_REQUIRED | AP2_SF_LEGACY_PAIRING)) && !has_pw) {
+               !(r.flags & (AP2_SF_PIN_REQUIRED | AP2_SF_LEGACY_PAIRING)) &&
+               (!has_pw || have_password)) {
         native = true;
         transient = true;
     } else {
@@ -774,8 +885,11 @@ ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char
      * removed: see DESIGN.md for the findings and rationale. */
     (void)bit_depth;
 
-    r.reason = transient ? "native AP2, transient, realtime"
-                         : "native AP2, pair-verify, realtime";
+    if (transient)
+        r.reason = have_password ? "native AP2, password, realtime"
+                                 : "native AP2, transient, realtime";
+    else
+        r.reason = "native AP2, pair-verify, realtime";
     return r;
 }
 
@@ -922,23 +1036,15 @@ static void ap2_native_setup_mrp(struct ap2cl_s *p)
 
 /* ---- Native AP2 connect sequence ---- */
 
-static bool ap2_native_connect(struct ap2cl_s *p)
+/* Open the RTSP control connection to the device (bound to the configured
+ * interface on multi-homed hosts). */
+static bool ap2_native_open_socket(struct ap2cl_s *p)
 {
     struct addrinfo hints = {0}, *res;
     hints.ai_family = AF_INET;
     hints.ai_socktype = SOCK_STREAM;
     char port_str[8];
     snprintf(port_str, sizeof(port_str), "%d", p->device.port);
-
-    /* Resolve the local bind address once (multi-homed hosts): used for the
-     * RTSP TCP socket and the RTP data/control UDP sockets below. */
-    p->bind_addr.s_addr = INADDR_ANY;
-    if (p->iface) {
-        char *ifname = NULL;
-        uint32_t netmask;
-        p->bind_addr = get_interface(p->iface, &ifname, &netmask);
-        NFREE(ifname);
-    }
 
     if (getaddrinfo(p->device.address, port_str, &hints, &res) != 0) return false;
     p->rtsp_carry_len = 0;
@@ -954,6 +1060,227 @@ static bool ap2_native_connect(struct ap2cl_s *p)
         return false;
     }
     freeaddrinfo(res);
+    return true;
+}
+
+/* GET /info on the (still unencrypted) control connection and read the
+ * advertised per-stream format tables from the reply. */
+static bool ap2_native_get_info(struct ap2cl_s *p)
+{
+    uint8_t *resp = NULL; int resp_len = 0;
+    int status = ap2_rtsp_send(p, "GET", "/info", NULL, 0, NULL, &resp, &resp_len);
+    if (status != 200) {
+        LOG_ERROR("[AP2] /info failed: %d", status);
+        ap2_report_failed_exchange(p, "GET /info", status);
+        free(resp);
+        return false;
+    }
+    p->audio_format = ap2_audio_format_code(&p->format);
+    if (resp && resp_len > 0) {
+        ap2_parse_format_capability(resp, (size_t)resp_len, "audioStream",
+                                    &p->realtime_formats,
+                                    &p->realtime_formats_known,
+                                    &p->realtime_formats_extended);
+        ap2_parse_format_capability(resp, (size_t)resp_len, "bufferStream",
+                                    &p->buffered_formats,
+                                    &p->buffered_formats_known,
+                                    &p->buffered_formats_extended);
+    }
+    LOG_INFO("[AP2] Formats requested=0x%" PRIx64
+             " realtime=%s0x%" PRIx64 " buffered=%s0x%" PRIx64,
+             p->audio_format,
+             p->realtime_formats_known
+                 ? (p->realtime_formats_extended ? "extended:" : "mask:")
+                 : "unknown:",
+             p->realtime_formats,
+             p->buffered_formats_known
+                 ? (p->buffered_formats_extended ? "extended:" : "mask:")
+                 : "unknown:",
+             p->buffered_formats);
+    free(resp);
+    return true;
+}
+
+/* Start the next pairing attempt from a clean connection: a receiver that
+ * rejected one pairing leg leaves its state machine wedged on that socket. */
+static bool ap2_native_reset_connection(struct ap2cl_s *p)
+{
+    if (p->sock_fd >= 0) { close(p->sock_fd); p->sock_fd = -1; }
+    if (!ap2_native_open_socket(p)) {
+        LOG_ERROR("[AP2] Cannot reopen the control connection for the next "
+                  "pairing attempt");
+        return false;
+    }
+    return ap2_native_get_info(p);
+}
+
+/* One transient pair-setup leg; secret NULL selects the fixed transient PIN. */
+static bool ap2_native_transient(struct ap2cl_s *p, const char *secret,
+                                 ap2_hap_error_t *err)
+{
+    p->hap = ap2_hap_create(NULL);
+    if (!p->hap) {
+        LOG_ERROR("[AP2] Cannot create HAP context");
+        return false;
+    }
+    LOG_INFO("[AP2] Performing HAP transient pair-setup...");
+    if (ap2_hap_pair_setup_transient(p->hap, p->sock_fd, secret, err))
+        return true;
+    LOG_ERROR("[AP2] HAP transient pair-setup failed");
+    ap2_hap_destroy(p->hap);
+    p->hap = NULL;
+    return false;
+}
+
+/* One pair-verify leg with the stored HAP credentials. */
+static bool ap2_native_pair_verify(struct ap2cl_s *p, ap2_hap_error_t *err)
+{
+    p->hap = ap2_hap_create(p->auth_credentials);
+    if (!p->hap) {
+        LOG_ERROR("[AP2] Invalid credentials");
+        return false;
+    }
+
+    /* Set client_id from DACP ID as UPPERCASE ASCII string.
+     * Must match what was sent during pair-setup. MA's pair-setup uses the
+     * DACP ID as a 16-char uppercase hex string encoded as bytes. */
+    if (p->dacp_id) {
+        /* Uppercase the string */
+        char upper_dacp[32];
+        int len = strlen(p->dacp_id);
+        if (len > 30) len = 30;
+        for (int i = 0; i < len; i++) {
+            char c = p->dacp_id[i];
+            upper_dacp[i] = (c >= 'a' && c <= 'f') ? (c - 'a' + 'A') : c;
+        }
+        upper_dacp[len] = '\0';
+        ap2_hap_set_client_id(p->hap, (const uint8_t *)upper_dacp, len);
+    }
+
+    LOG_INFO("[AP2] Performing HAP pair-verify...");
+    if (ap2_hap_pair_verify(p->hap, p->sock_fd, err)) return true;
+    LOG_ERROR("[AP2] HAP pair-verify failed");
+    ap2_hap_destroy(p->hap);
+    p->hap = NULL;
+    return false;
+}
+
+/*
+ * HAP handshake for the native flow, leaving p->hap holding the session keys.
+ *
+ * Without a device password this is exactly one leg: pair-verify with stored
+ * credentials (Apple TV/HomePod), transient pair-setup with the fixed PIN
+ * otherwise (Sonos and most third-party receivers).
+ *
+ * A device password makes it a ladder, because receivers disagree on what a
+ * password means for AirPlay 2: some substitute it for the fixed PIN as the
+ * transient SRP secret, others disable transient pairing entirely once a
+ * password is set and expect the stored HomeKit credentials instead. The
+ * password leg goes first and each rejected leg is retried on a fresh
+ * connection; the reported status is the password leg's, which is the one
+ * that describes the device's password handling.
+ */
+static bool ap2_native_pair(struct ap2cl_s *p)
+{
+    ap2_hap_error_t err = {0};
+    const bool have_password = p->password && *p->password;
+
+    if (!have_password) {
+        if (p->auth_credentials) {
+            if (ap2_native_pair_verify(p, &err)) return true;
+            ap2_set_connect_error(p,
+                                  ap2_status_is_auth(err.http_status)
+                                      ? ap2_auth_error_kind(p)
+                                      : AP2_CONNECT_ERROR_GENERIC,
+                                  err.http_status, "HAP pair-verify failed");
+            return false;
+        }
+        if (ap2_native_transient(p, NULL, &err)) return true;
+        ap2_set_connect_error(p,
+                              ap2_status_is_auth(err.http_status)
+                                  ? ap2_auth_error_kind(p)
+                                  : AP2_CONNECT_ERROR_GENERIC,
+                              err.http_status, "HAP transient pair-setup failed");
+        return false;
+    }
+
+    LOG_INFO("[AP2] Pairing leg 1/2: transient pair-setup with the device password");
+    if (ap2_native_transient(p, p->password, &err)) {
+        LOG_INFO("[AP2] Device accepted the password as the transient secret");
+        return true;
+    }
+    int password_status = err.http_status;
+    LOG_WARN("[AP2] Password pair-setup rejected (cause=%d http=%d tlv=%d)",
+             (int)err.result, err.http_status, err.tlv_error);
+    if (err.result == AP2_HAP_ERR_TRANSPORT) {
+        /* Nothing was rejected — the connection died mid-handshake. */
+        ap2_set_connect_error(p, AP2_CONNECT_ERROR_GENERIC, password_status,
+                              "pair-setup with the device password failed on the wire");
+        return false;
+    }
+
+    if (p->auth_credentials) {
+        LOG_INFO("[AP2] Pairing leg 2/2: stored credentials (pair-verify)");
+        if (!ap2_native_reset_connection(p)) {
+            ap2_set_connect_error(p, AP2_CONNECT_ERROR_GENERIC, password_status,
+                                  "cannot reconnect for the pair-verify fallback");
+            return false;
+        }
+        ap2_hap_error_t verify_err = {0};
+        if (ap2_native_pair_verify(p, &verify_err)) {
+            LOG_INFO("[AP2] Stored credentials accepted after the password leg "
+                     "was rejected");
+            return true;
+        }
+        ap2_set_connect_error(p, AP2_CONNECT_ERROR_AUTH_FAILED,
+                              password_status ? password_status
+                                              : verify_err.http_status,
+                              "device rejected both the password and the stored "
+                              "credentials");
+        return false;
+    }
+
+    /* No credentials to fall back on. The password may simply not be this
+     * receiver's SRP secret (configured, but not actually required), so give
+     * the fixed transient PIN its normal chance before giving up. */
+    LOG_INFO("[AP2] Pairing leg 2/2: transient pair-setup with the fixed PIN");
+    if (!ap2_native_reset_connection(p)) {
+        ap2_set_connect_error(p, AP2_CONNECT_ERROR_AUTH_FAILED, password_status,
+                              "device rejected the password and the connection "
+                              "could not be retried");
+        return false;
+    }
+    ap2_hap_error_t pin_err = {0};
+    if (ap2_native_transient(p, NULL, &pin_err)) {
+        LOG_WARN("[AP2] Device paired with the fixed transient PIN; the "
+                 "configured password was not used");
+        return true;
+    }
+    ap2_set_connect_error(p, AP2_CONNECT_ERROR_AUTH_FAILED,
+                          password_status ? password_status : pin_err.http_status,
+                          "device rejected the supplied password");
+    return false;
+}
+
+static bool ap2_native_connect(struct ap2cl_s *p)
+{
+    /* Default outcome for every failure path below; the auth-aware sites
+     * refine it. Cleared once the session is up. */
+    ap2_set_connect_error(p, AP2_CONNECT_ERROR_GENERIC, 0,
+                          "native AirPlay 2 connect failed");
+    p->last_error_response_len = 0;
+
+    /* Resolve the local bind address once (multi-homed hosts): used for the
+     * RTSP TCP socket and the RTP data/control UDP sockets below. */
+    p->bind_addr.s_addr = INADDR_ANY;
+    if (p->iface) {
+        char *ifname = NULL;
+        uint32_t netmask;
+        p->bind_addr = get_interface(p->iface, &ifname, &netmask);
+        NFREE(ifname);
+    }
+
+    if (!ap2_native_open_socket(p)) return false;
 
     /* Get local address for session URL */
     struct sockaddr_in local;
@@ -987,78 +1314,10 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     ap2_gen_uuid(p->group_uuid);
 
     /* 1. GET /info */
-    uint8_t *resp = NULL; int resp_len = 0;
-    int status = ap2_rtsp_send(p, "GET", "/info", NULL, 0, NULL, &resp, &resp_len);
-    if (status != 200) {
-        LOG_ERROR("[AP2] /info failed: %d", status);
-        free(resp);
-        return false;
-    }
-    p->audio_format = ap2_audio_format_code(&p->format);
-    if (resp && resp_len > 0) {
-        ap2_parse_format_capability(resp, (size_t)resp_len, "audioStream",
-                                    &p->realtime_formats,
-                                    &p->realtime_formats_known,
-                                    &p->realtime_formats_extended);
-        ap2_parse_format_capability(resp, (size_t)resp_len, "bufferStream",
-                                    &p->buffered_formats,
-                                    &p->buffered_formats_known,
-                                    &p->buffered_formats_extended);
-    }
-    LOG_INFO("[AP2] Formats requested=0x%" PRIx64
-             " realtime=%s0x%" PRIx64 " buffered=%s0x%" PRIx64,
-             p->audio_format,
-             p->realtime_formats_known
-                 ? (p->realtime_formats_extended ? "extended:" : "mask:")
-                 : "unknown:",
-             p->realtime_formats,
-             p->buffered_formats_known
-                 ? (p->buffered_formats_extended ? "extended:" : "mask:")
-                 : "unknown:",
-             p->buffered_formats);
-    free(resp);
+    if (!ap2_native_get_info(p)) return false;
 
-    /* 2. HAP pairing: pair-verify with stored credentials (Apple TV/HomePod),
-     * transient pair-setup otherwise (Sonos and most third-party receivers) */
-    if (p->auth_credentials) {
-        p->hap = ap2_hap_create(p->auth_credentials);
-        if (!p->hap) { LOG_ERROR("[AP2] Invalid credentials"); return false; }
-
-        /* Set client_id from DACP ID as UPPERCASE ASCII string.
-         * Must match what was sent during pair-setup. MA's pair-setup uses the
-         * DACP ID as a 16-char uppercase hex string encoded as bytes. */
-        if (p->dacp_id) {
-            /* Uppercase the string */
-            char upper_dacp[32];
-            int len = strlen(p->dacp_id);
-            if (len > 30) len = 30;
-            for (int i = 0; i < len; i++) {
-                char c = p->dacp_id[i];
-                upper_dacp[i] = (c >= 'a' && c <= 'f') ? (c - 'a' + 'A') : c;
-            }
-            upper_dacp[len] = '\0';
-            ap2_hap_set_client_id(p->hap, (const uint8_t *)upper_dacp, len);
-        }
-
-        LOG_INFO("[AP2] Performing HAP pair-verify...");
-        if (!ap2_hap_pair_verify(p->hap, p->sock_fd)) {
-            LOG_ERROR("[AP2] HAP pair-verify failed");
-            ap2_hap_destroy(p->hap);
-            p->hap = NULL;
-            return false;
-        }
-    } else {
-        p->hap = ap2_hap_create(NULL);
-        if (!p->hap) { LOG_ERROR("[AP2] Cannot create HAP context"); return false; }
-
-        LOG_INFO("[AP2] Performing HAP transient pair-setup...");
-        if (!ap2_hap_pair_setup_transient(p->hap, p->sock_fd)) {
-            LOG_ERROR("[AP2] HAP transient pair-setup failed");
-            ap2_hap_destroy(p->hap);
-            p->hap = NULL;
-            return false;
-        }
-    }
+    /* 2. HAP pairing (see ap2_native_pair for the leg order). */
+    if (!ap2_native_pair(p)) return false;
     LOG_INFO("[AP2] Channel encrypted");
 
     /* Diagnostic: post-pairing /info — the encrypted-channel reply is the
@@ -1161,12 +1420,13 @@ static bool ap2_native_connect(struct ap2cl_s *p)
         ap2_plist_free(sp);
     }
 
-    resp = NULL; resp_len = 0;
-    status = ap2_rtsp_send(p, "SETUP", p->session_url, plist_data, plist_len,
+    uint8_t *resp = NULL; int resp_len = 0;
+    int status = ap2_rtsp_send(p, "SETUP", p->session_url, plist_data, plist_len,
                             "application/x-apple-binary-plist", &resp, &resp_len);
     free(plist_data);
     if (status != 200) {
         LOG_ERROR("[AP2] Session SETUP failed: %d", status);
+        ap2_report_failed_exchange(p, "session SETUP", status);
         free(resp);
         return false;
     }
@@ -1300,6 +1560,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
 
     if (status != 200) {
         LOG_ERROR("[AP2] Stream SETUP failed: %d", status);
+        ap2_report_failed_exchange(p, "stream SETUP", status);
         free(resp);
         return false;
     }
@@ -1437,6 +1698,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
         atomic_store(&p->rtsp_dead, true);
         return false;
     }
+    ap2_set_connect_error(p, AP2_CONNECT_ERROR_NONE, 0, "%s", "");
     LOG_INFO("[AP2] Native AP2 session ready");
     return true;
 }
@@ -1807,13 +2069,22 @@ static bool ap2_raop_compat_connect(struct ap2cl_s *p)
         p->format.sample_rate, p->format.bit_depth, p->format.channels,
         p->volume > 0 ? raopcl_float_volume(p->volume) : -144.0f);
 
-    if (!p->raopcl) return false;
+    if (!p->raopcl) {
+        ap2_set_connect_error(p, AP2_CONNECT_ERROR_GENERIC, 0,
+                              "cannot create the RAOP-compatible client");
+        return false;
+    }
 
     if (!raopcl_connect(p->raopcl, player_addr, p->device.port, p->volume > 0)) {
+        /* libraop does not expose the RTSP status of the failure, so a rejected
+         * password is not distinguishable from an unreachable device here. */
+        ap2_set_connect_error(p, AP2_CONNECT_ERROR_GENERIC, 0,
+                              "RAOP-compatible connect failed");
         ap2_raop_session_cleanup(p);
         return false;
     }
 
+    ap2_set_connect_error(p, AP2_CONNECT_ERROR_NONE, 0, "%s", "");
     p->state = AP2_CONNECTED;
     return true;
 }
@@ -1955,9 +2226,23 @@ void ap2cl_set_remote_command_callback(
     p->remote_command_userdata = userdata;
 }
 
+ap2_connect_error_t ap2cl_connect_error(struct ap2cl_s *p, int *http_status,
+                                        const char **detail)
+{
+    if (!p) {
+        if (http_status) *http_status = 0;
+        if (detail) *detail = "";
+        return AP2_CONNECT_ERROR_GENERIC;
+    }
+    if (http_status) *http_status = p->connect_http_status;
+    if (detail) *detail = p->connect_detail;
+    return p->connect_error;
+}
+
 bool ap2cl_connect(struct ap2cl_s *p)
 {
     if (!p) return false;
+    ap2_set_connect_error(p, AP2_CONNECT_ERROR_GENERIC, 0, "connect failed");
     if (p->flow == FLOW_NATIVE_AP2) {
         LOG_INFO("[AP2] Connecting via native AP2 flow to %s:%d",
                  p->device.address, p->device.port);

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -309,9 +309,11 @@ static void ap2_log_failed_response(struct ap2cl_s *p, const char *label,
     ap2_io_format_response_dump(p->last_error_response, len,
                                 AP2_DIAG_BODY_MAX, dump, sizeof(dump));
     LOG_ERROR("[AP2] %s -> %d response: %s", label, status, dump);
-    if (challenge && challenge_size)
-        ap2_io_header_value(p->last_error_response, len, "WWW-Authenticate",
-                            challenge, challenge_size);
+    /* the lookup clears the buffer on a miss, so restore the sentinel then */
+    if (challenge && challenge_size &&
+        !ap2_io_header_value(p->last_error_response, len, "WWW-Authenticate",
+                             challenge, challenge_size))
+        snprintf(challenge, challenge_size, "%s", "(absent)");
 }
 
 /* Report a non-200 on the native connect path: dump the exchange and classify
@@ -1186,10 +1188,13 @@ static bool ap2_native_pair(struct ap2cl_s *p)
     const bool have_password = p->password && *p->password;
 
     if (!have_password) {
+        /* A TLV-level rejection arrives with HTTP 200, so the auth-shaped test
+         * must consider the HAP result kind as well as the HTTP status. */
         if (p->auth_credentials) {
             if (ap2_native_pair_verify(p, &err)) return true;
             ap2_set_connect_error(p,
-                                  ap2_status_is_auth(err.http_status)
+                                  (err.result == AP2_HAP_ERR_AUTH ||
+                                   ap2_status_is_auth(err.http_status))
                                       ? ap2_auth_error_kind(p)
                                       : AP2_CONNECT_ERROR_GENERIC,
                                   err.http_status, "HAP pair-verify failed");
@@ -1197,7 +1202,8 @@ static bool ap2_native_pair(struct ap2cl_s *p)
         }
         if (ap2_native_transient(p, NULL, &err)) return true;
         ap2_set_connect_error(p,
-                              ap2_status_is_auth(err.http_status)
+                              (err.result == AP2_HAP_ERR_AUTH ||
+                               ap2_status_is_auth(err.http_status))
                                   ? ap2_auth_error_kind(p)
                                   : AP2_CONNECT_ERROR_GENERIC,
                               err.http_status, "HAP transient pair-setup failed");

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -106,6 +106,7 @@ uint64_t ap2_txt_flags(const char *txt);
  * :param txt: full _airplay._tcp TXT ("key=value key=value ...") or NULL.
  * :param pw: mDNS pw field ("true" when a device password is required), or NULL.
  * :param have_credentials: stored HAP credentials are available (--auth).
+ * :param have_password: a non-empty device password was supplied (--password).
  * :param bit_depth: requested output bit depth (informational; hi-res rides
  *                   the realtime stream).
  * :param force_native: --ap2-native was given (forces the native AP2 flow).
@@ -113,9 +114,29 @@ uint64_t ap2_txt_flags(const char *txt);
  * :param ptp_enabled: the value passed to --ptp.
  */
 ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char *pw,
-                              bool have_credentials, int bit_depth,
-                              bool force_native,
+                              bool have_credentials, bool have_password,
+                              int bit_depth, bool force_native,
                               bool ptp_forced, bool ptp_enabled);
+
+/* Why the last connect attempt failed, for the caller's structured report. */
+typedef enum {
+    AP2_CONNECT_ERROR_NONE = 0,
+    AP2_CONNECT_ERROR_GENERIC,        /* anything not auth-related */
+    AP2_CONNECT_ERROR_AUTH_REQUIRED,  /* the device wants a password we lack */
+    AP2_CONNECT_ERROR_AUTH_FAILED,    /* the device rejected what we presented */
+} ap2_connect_error_t;
+
+/*
+ * Outcome of the last ap2cl_connect().
+ *
+ * :param p: client context.
+ * :param http_status: receives the most informative HTTP status seen (0 when
+ *                     none applies), or NULL.
+ * :param detail: receives a short single-line description owned by the client,
+ *                or NULL.
+ */
+ap2_connect_error_t ap2cl_connect_error(struct ap2cl_s *p, int *http_status,
+                                        const char **detail);
 
 /*
  * Create a new AirPlay 2 client context.

--- a/src/ap2_hap.c
+++ b/src/ap2_hap.c
@@ -15,7 +15,8 @@
  * Protocol flow (HAP transient pair-setup, X-Apple-HKP: 4, no credentials):
  *   1. Client sends state=0x01 + method=0 + flags=0x10 to /pair-setup
  *   2. Server responds with state=0x02 + SRP salt + SRP public key B
- *   3. Client runs SRP-6a (SHA-512, 3072-bit group, fixed PIN "3939") and
+ *   3. Client runs SRP-6a (SHA-512, 3072-bit group) with the fixed PIN "3939",
+ *      or with the device password on receivers that gate playback on one, and
  *      sends state=0x03 + public key A + client proof M1
  *   4. Server responds with state=0x04 + server proof; exchange stops here
  *      (no M5/M6, nothing is stored) and the SRP session key becomes the
@@ -47,6 +48,7 @@
 #include "../libraop/crosstools/src/platform.h"
 #include "cross_log.h"
 #include "ap2_hap.h"
+#include "ap2_io.h"
 
 extern log_level *loglevel;
 
@@ -71,8 +73,9 @@ extern log_level *loglevel;
 #define SRP_N_BYTES          384    /* 3072-bit modulus */
 #define SRP_HASH_LEN         SHA512_DIGEST_LENGTH
 #define SRP_USERNAME         "Pair-Setup"
-#define SRP_TRANSIENT_PIN    "3939" /* fixed PIN mandated for transient pairing */
+#define SRP_TRANSIENT_PIN    "3939" /* default secret for transient pairing */
 #define HAP_TRANSIENT_FLAG   0x10   /* kTLVFlag transient in the M1 Flags TLV */
+#define HAP_DIAG_BODY_MAX    512    /* body bytes dumped from a failed exchange */
 
 /* RFC 5054 3072-bit group used by HAP pair-setup; generator g = 5 */
 static const char srp_n_hex_3072[] =
@@ -471,16 +474,63 @@ done:
     return ok;
 }
 
+/* Record a failure cause for the caller, keeping the most informative HTTP
+ * status seen in this exchange when the failing step has none of its own. */
+static void hap_set_error(ap2_hap_error_t *err, ap2_hap_result_t result,
+                          int http_status, int tlv_error)
+{
+    if (!err) return;
+    err->result = result;
+    if (http_status) err->http_status = http_status;
+    err->tlv_error = tlv_error;
+}
+
+/*
+ * Log what the receiver actually answered on a failed exchange: the status
+ * line, every header (is there a WWW-Authenticate challenge?) and the body
+ * (what does its TLV/plist say?). This is the only evidence available for
+ * receivers whose password handling is undocumented.
+ */
+static void hap_log_response(const char *label, const uint8_t *data, int len)
+{
+    char dump[1600];
+    ap2_io_format_response_dump(data, len > 0 ? (size_t)len : 0,
+                                HAP_DIAG_BODY_MAX, dump, sizeof(dump));
+    LOG_ERROR("[HAP] %s response: %s", label, dump);
+}
+
+/* Check the status line of a raw pair-verify reply, dumping and recording a
+ * rejection. Returns true when the receiver answered 200. */
+static bool hap_verify_status_ok(const char *label, const uint8_t *data, int len,
+                                 ap2_hap_error_t *err)
+{
+    char line[64];
+    size_t n = (size_t)len < sizeof(line) - 1 ? (size_t)len : sizeof(line) - 1;
+    if (len > 0) memcpy(line, data, n);
+    else n = 0;
+    line[n] = '\0';
+
+    int status = 0;
+    sscanf(line, "%*s %d", &status);
+    if (status == 200) return true;
+    LOG_ERROR("[HAP] %s rejected (status %d)", label, status);
+    hap_log_response(label, data, len);
+    hap_set_error(err, AP2_HAP_ERR_AUTH, status, 0);
+    return false;
+}
+
 /*
  * POST a TLV body to /pair-setup (X-Apple-HKP: 4 = transient, 3 = full
  * HomeKit pairing with a PIN) and read the complete RTSP response. Returns
  * the HTTP status code (0 on transport error) and points *resp_body (with
- * *resp_body_len) at the body inside resp_buf.
+ * *resp_body_len) at the body inside resp_buf. A non-200 reply is dumped
+ * under label before returning.
  */
 static int hap_post_pair_setup_path(int sock_fd, const char *path, int cseq, int hkp,
                                const uint8_t *body, int body_len,
                                uint8_t *resp_buf, int resp_buf_size,
-                               uint8_t **resp_body, int *resp_body_len)
+                               uint8_t **resp_body, int *resp_body_len,
+                               const char *label)
 {
     char http_req[256];
     int hdr_len = snprintf(http_req, sizeof(http_req),
@@ -524,6 +574,7 @@ static int hap_post_pair_setup_path(int sock_fd, const char *path, int cseq, int
 
     if (header_len == 0 || total < header_len + content_len) {
         LOG_ERROR("[HAP] Incomplete pair-setup response (%d bytes)", total);
+        if (total > 0) hap_log_response(label, resp_buf, total);
         return 0;
     }
 
@@ -531,6 +582,7 @@ static int hap_post_pair_setup_path(int sock_fd, const char *path, int cseq, int
     sscanf((char *)resp_buf, "%*s %d", &status);
     *resp_body = resp_buf + header_len;
     *resp_body_len = content_len;
+    if (status != 200) hap_log_response(label, resp_buf, header_len + content_len);
     return status;
 }
 
@@ -602,9 +654,17 @@ void ap2_hap_destroy(struct ap2_hap_ctx *ctx)
     }
 }
 
-bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
+bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd,
+                         ap2_hap_error_t *err_out)
 {
     if (!ctx) return false;
+    if (err_out) {
+        ap2_hap_error_t empty = {0};
+        *err_out = empty;
+    }
+    /* Set once a pair-verify reply carries a non-200 status: a later content
+     * failure is then reported as a rejection rather than a protocol mismatch. */
+    bool rejected = false;
 
     LOG_INFO("[HAP] Starting pair-verify...");
 
@@ -643,6 +703,7 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
     if (write(sock_fd, http_req, hdr_len) != hdr_len ||
         write(sock_fd, msg1.data, msg1.len) != msg1.len) {
         LOG_ERROR("[HAP] Failed to send pair-verify M1");
+        hap_set_error(err_out, AP2_HAP_ERR_TRANSPORT, 0, 0);
         tlv_free(&msg1);
         EVP_PKEY_free(eph_key);
         return false;
@@ -654,9 +715,13 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
     int resp_len = read(sock_fd, resp_buf, sizeof(resp_buf));
     if (resp_len <= 0) {
         LOG_ERROR("[HAP] No response to pair-verify M1");
+        hap_set_error(err_out, AP2_HAP_ERR_TRANSPORT, 0, 0);
         EVP_PKEY_free(eph_key);
         return false;
     }
+    /* The status is recorded (and a rejection dumped) without changing the
+     * flow below: the M2 content checks stay the ones that decide. */
+    rejected = !hap_verify_status_ok("pair-verify M2", resp_buf, resp_len, err_out);
 
     /* Find HTTP body (after \r\n\r\n) */
     uint8_t *body = NULL;
@@ -671,6 +736,8 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
     }
     if (!body || body_len < 4) {
         LOG_ERROR("[HAP] Invalid pair-verify M2 response (resp_len=%d, body_len=%d)", resp_len, body_len);
+        hap_set_error(err_out,
+                      rejected ? AP2_HAP_ERR_AUTH : AP2_HAP_ERR_PROTOCOL, 0, 0);
         /* Dump first 200 bytes for debugging */
         char hex[600];
         int dump_len = resp_len < 200 ? resp_len : 200;
@@ -690,6 +757,8 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
     if (!state_val || *state_val != 0x02 || spk_len != 32 || enc_len < HAP_TAG_SIZE) {
         LOG_ERROR("[HAP] Invalid pair-verify M2 content (state=%d, spk=%d, enc=%d)",
                   state_val ? *state_val : -1, spk_len, enc_len);
+        hap_set_error(err_out,
+                      rejected ? AP2_HAP_ERR_AUTH : AP2_HAP_ERR_PROTOCOL, 0, 0);
         free(encrypted_data);
         EVP_PKEY_free(eph_key);
         return false;
@@ -744,6 +813,7 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
 
     if (dec_len < 0) {
         LOG_ERROR("[HAP] Failed to decrypt M2 (auth tag verification failed)");
+        hap_set_error(err_out, AP2_HAP_ERR_AUTH, 0, 0);
         free(decrypted);
         EVP_PKEY_free(eph_key);
         return false;
@@ -754,6 +824,7 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
     const uint8_t *server_sig = tlv_find(decrypted, dec_len, TLV_SIGNATURE, &sig_len);
     if (!server_sig || sig_len != 64) {
         LOG_ERROR("[HAP] Missing or invalid server signature in M2");
+        hap_set_error(err_out, AP2_HAP_ERR_PROTOCOL, 0, 0);
         free(decrypted);
         EVP_PKEY_free(eph_key);
         return false;
@@ -876,6 +947,7 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
     if (write(sock_fd, http_req, hdr_len) != hdr_len ||
         write(sock_fd, msg3.data, msg3.len) != msg3.len) {
         LOG_ERROR("[HAP] Failed to send pair-verify M3");
+        hap_set_error(err_out, AP2_HAP_ERR_TRANSPORT, 0, 0);
         tlv_free(&msg3);
         EVP_PKEY_free(eph_key);
         return false;
@@ -884,6 +956,13 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
 
     /* Read M4 response */
     resp_len = read(sock_fd, resp_buf, sizeof(resp_buf));
+    if (resp_len > 0) {
+        if (!hap_verify_status_ok("pair-verify M4", resp_buf, resp_len, err_out))
+            rejected = true;
+    } else {
+        LOG_WARN("[HAP] No response to pair-verify M3");
+        hap_set_error(err_out, AP2_HAP_ERR_TRANSPORT, 0, 0);
+    }
     body = NULL;
     for (int i = 0; i < resp_len - 3; i++) {
         if (resp_buf[i] == '\r' && resp_buf[i+1] == '\n' &&
@@ -903,11 +982,15 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
         }
         if (state_val && *state_val != 0x04) {
             LOG_ERROR("[HAP] Pair-verify M4 unexpected state: %d", *state_val);
+            hap_set_error(err_out,
+                          rejected ? AP2_HAP_ERR_AUTH : AP2_HAP_ERR_PROTOCOL,
+                          0, 0);
             EVP_PKEY_free(eph_key);
             return false;
         }
     }
-    /* M4 HTTP status was already checked - if we got 200, pair-verify succeeded */
+    /* A non-200 reply was recorded and dumped above; reaching here with a
+     * well-formed M4 means the receiver accepted our credentials. */
 
     EVP_PKEY_free(eph_key);
 
@@ -919,6 +1002,7 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
                      "Control-Salt", "Control-Read-Encryption-Key",
                      ctx->read_key, 32)) {
         LOG_ERROR("[HAP] Failed to derive session keys");
+        hap_set_error(err_out, AP2_HAP_ERR_PROTOCOL, 0, 0);
         return false;
     }
 
@@ -936,11 +1020,21 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd)
     return true;
 }
 
-bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd)
+bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd,
+                                  const char *srp_secret, ap2_hap_error_t *err_out)
 {
     if (!ctx) return false;
+    if (err_out) {
+        ap2_hap_error_t empty = {0};
+        *err_out = empty;
+    }
 
-    LOG_INFO("[HAP] Starting transient pair-setup...");
+    /* An empty secret keeps the fixed transient PIN every credential-less
+     * receiver expects; a device password replaces it as the SRP secret. */
+    bool password_secret = srp_secret && *srp_secret;
+    const char *secret = password_secret ? srp_secret : SRP_TRANSIENT_PIN;
+    LOG_INFO("[HAP] Starting transient pair-setup (%s)...",
+             password_secret ? "device password" : "fixed PIN");
 
     uint8_t resp_buf[8192];
     uint8_t *body = NULL;
@@ -954,11 +1048,15 @@ bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd)
     tlv_add_uint8(&msg1, TLV_FLAGS, HAP_TRANSIENT_FLAG);
 
     int status = hap_post_pair_setup_path(sock_fd, "/pair-setup", 1, 4, msg1.data, msg1.len,
-                                     resp_buf, sizeof(resp_buf), &body, &body_len);
+                                     resp_buf, sizeof(resp_buf), &body, &body_len,
+                                     "pair-setup M1");
     tlv_free(&msg1);
     if (status != 200) {
         LOG_ERROR("[HAP] Pair-setup M1 rejected (status %d)%s", status,
                   status == 470 ? " - device requires full HomeKit pairing" : "");
+        hap_set_error(err_out,
+                      status ? AP2_HAP_ERR_AUTH : AP2_HAP_ERR_TRANSPORT,
+                      status, 0);
         return false;
     }
 
@@ -968,6 +1066,7 @@ bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd)
     const uint8_t *err = tlv_find(body, body_len, TLV_ERROR, &err_len);
     if (err && err_len > 0) {
         LOG_ERROR("[HAP] Pair-setup M2 error tag: %d", *err);
+        hap_set_error(err_out, AP2_HAP_ERR_AUTH, 0, *err);
         return false;
     }
     const uint8_t *salt = tlv_find(body, body_len, TLV_SALT, &salt_len);
@@ -977,6 +1076,7 @@ bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd)
         !b_pub || b_len <= 0 || b_len > SRP_N_BYTES) {
         LOG_ERROR("[HAP] Invalid pair-setup M2 content (state=%d, salt=%d, B=%d)",
                   state_val ? *state_val : -1, salt ? salt_len : -1, b_len);
+        hap_set_error(err_out, AP2_HAP_ERR_PROTOCOL, 0, 0);
         free(b_pub);
         return false;
     }
@@ -991,12 +1091,13 @@ bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd)
     uint8_t proof_m1[SRP_HASH_LEN], proof_hamk[SRP_HASH_LEN], session_key[SRP_HASH_LEN];
 
     bool srp_ok = srp_client_compute(salt_buf, sizeof(salt_buf), b_pub, b_len,
-                                     SRP_TRANSIENT_PIN,
+                                     secret,
                                      a_pub, &a_pub_len,
                                      proof_m1, proof_hamk, session_key);
     free(b_pub);
     if (!srp_ok) {
         LOG_ERROR("[HAP] SRP-6a computation failed");
+        hap_set_error(err_out, AP2_HAP_ERR_PROTOCOL, 0, 0);
         return false;
     }
 
@@ -1010,10 +1111,14 @@ bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd)
     tlv_add(&msg3, TLV_PROOF, proof_m1, SRP_HASH_LEN);
 
     status = hap_post_pair_setup_path(sock_fd, "/pair-setup", 2, 4, msg3.data, msg3.len,
-                                 resp_buf, sizeof(resp_buf), &body, &body_len);
+                                 resp_buf, sizeof(resp_buf), &body, &body_len,
+                                 "pair-setup M3");
     tlv_free(&msg3);
     if (status != 200) {
         LOG_ERROR("[HAP] Pair-setup M3 rejected (status %d)", status);
+        hap_set_error(err_out,
+                      status ? AP2_HAP_ERR_AUTH : AP2_HAP_ERR_TRANSPORT,
+                      status, 0);
         goto fail;
     }
 
@@ -1024,6 +1129,7 @@ bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd)
     if (err && err_len > 0) {
         LOG_ERROR("[HAP] Pair-setup M4 error tag: %d%s", *err,
                   *err == 0x02 ? " (authentication failed)" : "");
+        hap_set_error(err_out, AP2_HAP_ERR_AUTH, 0, *err);
         goto fail;
     }
     int srv_proof_len;
@@ -1031,10 +1137,15 @@ bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd)
     if (!state_val || *state_val != 0x04 || !srv_proof || srv_proof_len != SRP_HASH_LEN) {
         LOG_ERROR("[HAP] Invalid pair-setup M4 content (state=%d, proof=%d)",
                   state_val ? *state_val : -1, srv_proof ? srv_proof_len : -1);
+        hap_set_error(err_out, AP2_HAP_ERR_PROTOCOL, 0, 0);
         goto fail;
     }
+    /* A mismatching server proof means the two sides ran SRP with different
+     * secrets: the supplied password (or the fixed PIN) is not what this
+     * receiver expects. */
     if (memcmp(srv_proof, proof_hamk, SRP_HASH_LEN) != 0) {
         LOG_ERROR("[HAP] Server SRP proof mismatch in M4");
+        hap_set_error(err_out, AP2_HAP_ERR_AUTH, 0, 0);
         goto fail;
     }
 
@@ -1047,6 +1158,7 @@ bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd)
                      "Control-Salt", "Control-Read-Encryption-Key",
                      ctx->read_key, 32)) {
         LOG_ERROR("[HAP] Failed to derive session keys");
+        hap_set_error(err_out, AP2_HAP_ERR_PROTOCOL, 0, 0);
         goto fail;
     }
 
@@ -1098,7 +1210,8 @@ bool ap2_hap_pair_setup_pin(struct ap2_hap_ctx *ctx, int sock_fd,
      * accessories with a printed code do not need it, so treat any response as
      * success and continue. */
     int status = hap_post_pair_setup_path(sock_fd, "/pair-pin-start", 0, 3, NULL, 0,
-                                          resp_buf, sizeof(resp_buf), &body, &body_len);
+                                          resp_buf, sizeof(resp_buf), &body, &body_len,
+                                          "pair-pin-start");
     LOG_INFO("[HAP] /pair-pin-start -> %d (device should now show its PIN)", status);
 
     /* M1: state=1, method=0 (pair-setup with PIN) */
@@ -1107,7 +1220,8 @@ bool ap2_hap_pair_setup_pin(struct ap2_hap_ctx *ctx, int sock_fd,
     tlv_add_uint8(&msg1, TLV_STATE, 0x01);
     tlv_add_uint8(&msg1, TLV_METHOD, 0x00);
     status = hap_post_pair_setup_path(sock_fd, "/pair-setup", 1, 3, msg1.data, msg1.len,
-                                         resp_buf, sizeof(resp_buf), &body, &body_len);
+                                         resp_buf, sizeof(resp_buf), &body, &body_len,
+                                         "pair-setup PIN M1");
     tlv_free(&msg1);
     if (status != 200) {
         LOG_ERROR("[HAP] Pair-setup M1 rejected (status %d)", status);
@@ -1160,7 +1274,8 @@ bool ap2_hap_pair_setup_pin(struct ap2_hap_ctx *ctx, int sock_fd,
     tlv_add(&msg3, TLV_PUBLIC_KEY, a_pub, a_pub_len);
     tlv_add(&msg3, TLV_PROOF, proof_m1, SRP_HASH_LEN);
     status = hap_post_pair_setup_path(sock_fd, "/pair-setup", 2, 3, msg3.data, msg3.len,
-                                     resp_buf, sizeof(resp_buf), &body, &body_len);
+                                     resp_buf, sizeof(resp_buf), &body, &body_len,
+                                     "pair-setup PIN M3");
     tlv_free(&msg3);
     if (status != 200) {
         LOG_ERROR("[HAP] Pair-setup M3 rejected (status %d)", status);
@@ -1255,7 +1370,8 @@ bool ap2_hap_pair_setup_pin(struct ap2_hap_ctx *ctx, int sock_fd,
         tlv_add_uint8(&msg5, TLV_STATE, 0x05);
         tlv_add(&msg5, TLV_ENCRYPTED, enc_in, sub_len + HAP_TAG_SIZE);
         status = hap_post_pair_setup_path(sock_fd, "/pair-setup", 3, 3, msg5.data, msg5.len,
-                                         resp_buf, sizeof(resp_buf), &body, &body_len);
+                                         resp_buf, sizeof(resp_buf), &body, &body_len,
+                                         "pair-setup PIN M5");
         tlv_free(&msg5);
         free(enc_in); enc_in = NULL;
         if (status != 200) {

--- a/src/ap2_hap.h
+++ b/src/ap2_hap.h
@@ -36,7 +36,8 @@ typedef enum {
 /* Failure detail; only meaningful when the pairing call returned false. */
 typedef struct {
     ap2_hap_result_t result;
-    int http_status;   /* status of the last pairing POST (0 = none read) */
+    int http_status;   /* HTTP failure status; 0 when none was read or the
+                        * reply was 200 and the rejection is TLV-level */
     int tlv_error;     /* TLV error tag from M2/M4 (0 = none) */
 } ap2_hap_error_t;
 

--- a/src/ap2_hap.h
+++ b/src/ap2_hap.h
@@ -22,6 +22,25 @@
 struct ap2_hap_ctx;
 
 /*
+ * Why a pairing exchange failed. The caller needs to tell a rejected secret
+ * (another pairing mode may still work) from a dead connection (nothing left
+ * to try) and from a receiver speaking an unexpected dialect.
+ */
+typedef enum {
+    AP2_HAP_OK = 0,
+    AP2_HAP_ERR_TRANSPORT,  /* request not sent, or no complete response read */
+    AP2_HAP_ERR_AUTH,       /* non-200 on a pairing POST, or a TLV error tag */
+    AP2_HAP_ERR_PROTOCOL,   /* malformed or unexpected message content */
+} ap2_hap_result_t;
+
+/* Failure detail; only meaningful when the pairing call returned false. */
+typedef struct {
+    ap2_hap_result_t result;
+    int http_status;   /* status of the last pairing POST (0 = none read) */
+    int tlv_error;     /* TLV error tag from M2/M4 (0 = none) */
+} ap2_hap_error_t;
+
+/*
  * Create HAP context from hex credentials string (192 chars).
  * Pass NULL to create a bare context without long-term keys, usable only
  * with ap2_hap_pair_setup_transient().
@@ -39,26 +58,34 @@ void ap2_hap_destroy(struct ap2_hap_ctx *ctx);
  *
  * :param ctx: HAP context with credentials.
  * :param sock_fd: Connected TCP socket to the device.
+ * :param err: receives the failure cause, or NULL.
  * :returns: true on success, false on failure.
  *
  * On success, the context holds encryption keys for the session.
  */
-bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd);
+bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd,
+                         ap2_hap_error_t *err);
 
 /*
  * Perform HomeKit transient pair-setup (X-Apple-HKP: 4) over an established
  * TCP connection. Used for devices without stored credentials (Sonos, WiiM
- * and most third-party AirPlay 2 receivers): SRP-6a with the fixed PIN,
- * messages M1-M4 only, no long-term keys are created or stored.
+ * and most third-party AirPlay 2 receivers): SRP-6a, messages M1-M4 only, no
+ * long-term keys are created or stored.
  *
  * :param ctx: HAP context (no credentials required).
  * :param sock_fd: Connected TCP socket to the device.
+ * :param srp_secret: SRP secret to authenticate with; NULL or empty selects
+ *                    the fixed transient PIN. Receivers that gate playback on
+ *                    a device password expect that password here instead.
+ * :param err: receives the failure cause, or NULL.
  * :returns: true on success, false on failure.
  *
  * On success, the context holds encryption keys for the session and
  * ap2_hap_get_shared_secret() returns the audio key.
  */
-bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd);
+bool ap2_hap_pair_setup_transient(struct ap2_hap_ctx *ctx, int sock_fd,
+                                  const char *srp_secret,
+                                  ap2_hap_error_t *err);
 
 /* Callback that supplies the PIN the device is currently displaying. */
 typedef const char *(*ap2_hap_pin_cb)(void *arg);

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -284,6 +284,104 @@ int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
     return 1;
 }
 
+bool ap2_io_header_value(const uint8_t *data, size_t len, const char *name,
+                         char *out, size_t out_size)
+{
+    if (!out || !out_size) return false;
+    out[0] = '\0';
+    if (!data || !name) return false;
+
+    size_t header_end = ap2_find_header_end(data, len);
+    if (header_end >= 4) header_end -= 4;
+    else header_end = len;
+
+    size_t name_len = strlen(name);
+    size_t offset = 0;
+    bool status_line = true;
+    while (offset < header_end) {
+        size_t end = offset;
+        while (end + 1 < header_end &&
+               !(data[end] == '\r' && data[end + 1] == '\n'))
+            end++;
+        if (end + 1 >= header_end) end = header_end;
+        if (status_line) {
+            status_line = false;
+            offset = end + 2;
+            continue;
+        }
+
+        size_t colon = offset;
+        while (colon < end && data[colon] != ':') colon++;
+        if (colon < end && colon - offset == name_len &&
+            strncasecmp((const char *)data + offset, name, name_len) == 0) {
+            size_t value = colon + 1;
+            while (value < end && (data[value] == ' ' || data[value] == '\t'))
+                value++;
+            size_t value_end = end;
+            while (value_end > value &&
+                   (data[value_end - 1] == ' ' || data[value_end - 1] == '\t'))
+                value_end--;
+            size_t copy = value_end - value;
+            if (copy > out_size - 1) copy = out_size - 1;
+            memcpy(out, data + value, copy);
+            out[copy] = '\0';
+            return true;
+        }
+        offset = end + 2;
+    }
+    return false;
+}
+
+static size_t ap2_dump_append(char *out, size_t out_size, size_t pos,
+                              const char *text, size_t text_len)
+{
+    for (size_t i = 0; i < text_len && pos + 1 < out_size; i++)
+        out[pos++] = text[i];
+    out[pos] = '\0';
+    return pos;
+}
+
+size_t ap2_io_format_response_dump(const uint8_t *data, size_t len,
+                                   size_t body_cap, char *out, size_t out_size)
+{
+    if (!out || !out_size) return 0;
+    out[0] = '\0';
+    if (!data) return 0;
+
+    size_t header_len = ap2_find_header_end(data, len);
+    size_t header_end = header_len ? header_len - 4 : len;
+    size_t pos = 0;
+
+    /* Header block on one line: CRLF becomes " | " and any control byte folds
+     * to '.', so a malformed or binary reply still logs as a single line. */
+    for (size_t i = 0; i < header_end; i++) {
+        if (data[i] == '\r' && i + 1 < header_end && data[i + 1] == '\n') {
+            pos = ap2_dump_append(out, out_size, pos, " | ", 3);
+            i++;
+            continue;
+        }
+        char c = (char)data[i];
+        if (c < 0x20 || c == 0x7f) c = '.';
+        pos = ap2_dump_append(out, out_size, pos, &c, 1);
+    }
+    if (!header_len) return pos;
+
+    size_t body_len = len > header_len ? len - header_len : 0;
+    char head[48];
+    int head_len = snprintf(head, sizeof(head), " | body[%zu]=", body_len);
+    if (head_len > 0)
+        pos = ap2_dump_append(out, out_size, pos, head, (size_t)head_len);
+
+    size_t shown = body_len < body_cap ? body_len : body_cap;
+    for (size_t i = 0; i < shown; i++) {
+        char hex[3];
+        snprintf(hex, sizeof(hex), "%02x", data[header_len + i]);
+        pos = ap2_dump_append(out, out_size, pos, hex, 2);
+    }
+    if (shown < body_len) pos = ap2_dump_append(out, out_size, pos, "...", 3);
+    return pos;
+}
+
 int ap2_io_match_rtsp_response(const uint8_t *data, size_t len,
                                int expect_cseq,
                                ap2_rtsp_response_t *response,

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -57,6 +57,28 @@ bool ap2_io_feedback_miss_tolerated(const char *uri, int err,
 int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,
                                ap2_rtsp_response_t *response);
 
+/* Copy the value of the named header (case-insensitive, surrounding blanks
+ * trimmed) out of a raw RTSP/HTTP response into out. Returns true when the
+ * header is present; out is always NUL-terminated. */
+bool ap2_io_header_value(const uint8_t *data, size_t len, const char *name,
+                         char *out, size_t out_size);
+
+/*
+ * Render a raw RTSP/HTTP response as one printable diagnostic line: the status
+ * line and every header joined with " | ", then the body as hex. Used to log
+ * what a receiver actually answered when an exchange fails (a 401 challenge,
+ * a TLV error body); the body is capped so a large reply cannot flood the log.
+ *
+ * :param data: raw response bytes (headers, and body when present).
+ * :param len: number of valid bytes in data.
+ * :param body_cap: maximum number of body bytes rendered; the rest is elided.
+ * :param out: destination buffer, always NUL-terminated (truncated to fit).
+ * :param out_size: size of out in bytes.
+ * :returns: number of characters written, excluding the NUL.
+ */
+size_t ap2_io_format_response_dump(const uint8_t *data, size_t len,
+                                   size_t body_cap, char *out, size_t out_size);
+
 /* Locate the response with expect_cseq in a buffer that may start with
  * complete responses left over from abandoned (timed-out) requests; those
  * stale responses (lower CSeq) are skipped and counted in *discarded.

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -205,6 +205,36 @@ static void status_error(const char *msg)
     status_print("[ERROR] %s", msg);
 }
 
+/* Machine-readable failure codes Music Assistant matches on. */
+#define ERROR_CODE_AUTH_REQUIRED  "auth_required"
+#define ERROR_CODE_AUTH_FAILED    "auth_failed"
+#define ERROR_CODE_CONNECT_FAILED "connect_failed"
+
+/*
+ * Report a fatal failure as one machine-readable line followed by the
+ * human-readable one:
+ *   [STATUS] error code=<slug> http=<int> detail="<text>"
+ *   [ERROR] <msg>
+ * The detail is squeezed onto a single line and stripped of the double quotes
+ * that delimit it, so the contract holds for any device-supplied text.
+ */
+static void status_error_ex(const char *code, int http, const char *detail,
+                            const char *msg)
+{
+    char clean[256];
+    size_t out = 0;
+    for (const char *c = detail ? detail : ""; *c && out + 1 < sizeof(clean); c++) {
+        char ch = *c;
+        if (ch == '"') ch = '\'';
+        else if (ch == '\r' || ch == '\n' || ch == '\t') ch = ' ';
+        clean[out++] = ch;
+    }
+    clean[out] = '\0';
+    status_print("[STATUS] error code=%s http=%d detail=\"%s\"",
+                 code, http, clean);
+    status_error(msg);
+}
+
 static void remote_command_event(
     ap2_remote_command_t command, void *userdata)
 {
@@ -690,14 +720,18 @@ static int run_raop(cli_config_t *cfg)
     /* Resolve player */
     hostent = gethostbyname(cfg->host);
     if (!hostent) {
-        status_error("Cannot resolve hostname");
+        status_error_ex(ERROR_CODE_CONNECT_FAILED, 0,
+                        "cannot resolve the device hostname",
+                        "Cannot resolve hostname");
         return 1;
     }
     memcpy(&player_addr.s_addr, hostent->h_addr_list[0], hostent->h_length);
 
     /* Check AppleTV auth requirement */
     if (cfg->am && strcasestr(cfg->am, "appletv") && cfg->pk && *cfg->pk && (!cfg->secret || !*cfg->secret)) {
-        status_error("AppleTV requires authentication (need secret)");
+        status_error_ex(ERROR_CODE_CONNECT_FAILED, 0,
+                        "AppleTV pairing secret (--secret) is missing",
+                        "AppleTV requires authentication (need secret)");
         return 1;
     }
 
@@ -705,16 +739,11 @@ static int run_raop(cli_config_t *cfg)
     if ((cfg->encrypt) && cfg->et && strchr(cfg->et, '1'))
         crypto = RAOP_RSA;
 
-    /* Handle device password */
-    char *password = NULL;
-    if (cfg->pw && !strcasecmp(cfg->pw, "true")) {
-        if (cfg->password && *cfg->password)
-            password = cfg->password;
-        else {
-            status_error("Password required but not supplied");
-            return 1;
-        }
-    }
+    /* Arm RTSP digest authentication whenever a password was supplied: the
+     * mDNS pw flag only says the device advertises one, and libraop uses the
+     * password solely when the device actually challenges. A required password
+     * that was not supplied is rejected before any connect attempt (main). */
+    char *password = (cfg->password && *cfg->password) ? cfg->password : NULL;
 
     int latency = MS2TS(cfg->latency_ms, cfg->sample_rate);
 
@@ -741,14 +770,19 @@ static int run_raop(cli_config_t *cfg)
         cfg->volume > 0 ? raopcl_float_volume(cfg->volume) : -144.0f
     );
     if (!client) {
-        status_error("Cannot init RAOP client");
+        status_error_ex(ERROR_CODE_CONNECT_FAILED, 0,
+                        "cannot initialise the RAOP client",
+                        "Cannot init RAOP client");
         return 1;
     }
 
     /* Connect */
     LOG_INFO("Connecting to %s:%d via RAOP", inet_ntoa(player_addr), cfg->port);
     if (!raopcl_connect(client, player_addr, cfg->port, cfg->volume > 0)) {
-        status_error("Cannot connect to AirPlay device");
+        /* libraop does not expose the RTSP status of the failure, so a rejected
+         * password is not distinguishable from an unreachable device here. */
+        status_error_ex(ERROR_CODE_CONNECT_FAILED, 0, "RAOP connect failed",
+                        "Cannot connect to AirPlay device");
         request_command_stop();
         atomic_store(&g_raopcl, NULL);
         if (!join_command_thread()) return 1;
@@ -927,7 +961,9 @@ static int run_airplay2(cli_config_t *cfg)
         &device, &format, cfg->auth, cfg->password,
         cfg->dacp_id, cfg->active_remote, cfg->latency_ms, cfg->volume);
     if (!client) {
-        status_error("Cannot create AirPlay 2 client");
+        status_error_ex(ERROR_CODE_CONNECT_FAILED, 0,
+                        "cannot create the AirPlay 2 client",
+                        "Cannot create AirPlay 2 client");
         return 1;
     }
 
@@ -948,7 +984,14 @@ static int run_airplay2(cli_config_t *cfg)
     /* Connect: auth-setup + RAOP ANNOUNCE/SETUP/RECORD */
     LOG_INFO("Connecting to %s:%d via AirPlay 2", cfg->host, cfg->port);
     if (!ap2cl_connect(client)) {
-        status_error("Cannot connect to AirPlay 2 device");
+        int http = 0;
+        const char *detail = NULL;
+        ap2_connect_error_t kind = ap2cl_connect_error(client, &http, &detail);
+        const char *code = ERROR_CODE_CONNECT_FAILED;
+        if (kind == AP2_CONNECT_ERROR_AUTH_REQUIRED) code = ERROR_CODE_AUTH_REQUIRED;
+        else if (kind == AP2_CONNECT_ERROR_AUTH_FAILED) code = ERROR_CODE_AUTH_FAILED;
+        status_error_ex(code, http, detail,
+                        "Cannot connect to AirPlay 2 device");
         request_command_stop();
         atomic_store(&g_ap2cl, NULL);
         if (!join_command_thread()) return 1;
@@ -1305,7 +1348,8 @@ static void print_usage(const char *name)
     printf("  --raw                      Force uncompressed audio (ALAC-raw)\n");
     printf("  --encrypt                  Enable audio payload encryption\n");
     printf("  --secret <secret>          AppleTV pairing secret\n");
-    printf("  --password <password>      Device password\n");
+    printf("  --password <password>      Device password: RAOP digest auth, and the\n");
+    printf("                             AirPlay 2 transient pairing secret\n");
     printf("  --et <value>               mDNS et field (encryption types)\n");
     printf("  --md <value>               mDNS md field (metadata types)\n");
     printf("  --am <value>               mDNS am field (model name)\n");
@@ -1529,8 +1573,9 @@ int main(int argc, char *argv[])
      * cfg.protocol becomes the concrete protocol used for dispatch and
      * cfg.route carries the AirPlay 2 sub-decisions applied in run_airplay2(). */
     bool have_creds = cfg.auth && strlen(cfg.auth) == 192;
+    bool have_password = cfg.password && *cfg.password;
     cfg.route = ap2_resolve_route(cfg.proto_pref, cfg.ap2_txt, cfg.pw, have_creds,
-                                  cfg.bit_depth, cfg.force_native,
+                                  have_password, cfg.bit_depth, cfg.force_native,
                                   cfg.ptp, cfg.ptp);
     cfg.protocol = cfg.route.use_raop ? PROTO_RAOP : PROTO_AIRPLAY2;
     LOG_INFO("[AP2] auto-selected: %s; timing=%s; features=0x%llx; flags=0x%llx; bitdepth=%d",
@@ -1548,6 +1593,16 @@ int main(int argc, char *argv[])
            cfg.route.use_raop ? "legacy" : (cfg.route.native ? "native" : "raop-compat"),
            (!cfg.route.use_raop && cfg.route.ptp) ? "ptp" : "ntp");
     fflush(stdout);
+
+    /* The device advertises that it needs a password and we hold neither one
+     * nor stored credentials: every route would fail its handshake, so report
+     * what is missing instead of spending a connect attempt on it. */
+    if (cfg.pw && !strcasecmp(cfg.pw, "true") && !have_password && !have_creds) {
+        status_error_ex(ERROR_CODE_AUTH_REQUIRED, 0,
+                        "device requires a password; none was supplied",
+                        "Password required but not supplied");
+        return 1;
+    }
 
     if (!cfg.cmdpipe) {
         status_error("Streaming requires --cmdpipe");

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -349,8 +349,52 @@ static void test_info_format_tables(void)
     puts("ap2_bplist /info format-table tests passed");
 }
 
+/* A password-protected receiver keeps its native AirPlay 2 route: the password
+ * doubles as the transient pairing secret. Without one it still falls back to
+ * the RAOP-compatible flow, and every password-less decision is unchanged. */
+static void test_route_with_password(void)
+{
+    /* features bit 48 (AirPlay 2 + pairing) => "0x0,0x10000" */
+    const char *txt = "features=0x0,0x10000 flags=0x4";
+
+    ap2_route_t pw_supplied = ap2_resolve_route(
+        AP2_PROTO_AUTO, txt, "true", false, true, 16, false, false, false);
+    assert(!pw_supplied.use_raop && pw_supplied.native && pw_supplied.transient);
+    assert(strcmp(pw_supplied.reason, "native AP2, password, realtime") == 0);
+
+    ap2_route_t pw_missing = ap2_resolve_route(
+        AP2_PROTO_AUTO, txt, "true", false, false, 16, false, false, false);
+    assert(!pw_missing.use_raop && !pw_missing.native);
+
+    /* No password advertised: the plain transient route, password or not. */
+    ap2_route_t no_flag = ap2_resolve_route(
+        AP2_PROTO_AUTO, txt, NULL, false, false, 16, false, false, false);
+    assert(no_flag.native && no_flag.transient);
+    assert(strcmp(no_flag.reason, "native AP2, transient, realtime") == 0);
+
+    /* A PIN or legacy-pairing flag still wins over a supplied password. */
+    ap2_route_t pin_required = ap2_resolve_route(
+        AP2_PROTO_AUTO, "features=0x0,0x10000 flags=0x8", "true", false, true,
+        16, false, false, false);
+    assert(!pin_required.native);
+
+    /* Stored credentials keep pair-verify, whatever the password says. */
+    ap2_route_t with_creds = ap2_resolve_route(
+        AP2_PROTO_AUTO, txt, "true", true, true, 16, false, false, false);
+    assert(with_creds.native && !with_creds.transient);
+    assert(strcmp(with_creds.reason, "native AP2, pair-verify, realtime") == 0);
+
+    /* A device that is not AirPlay 2 at all stays on legacy RAOP. */
+    ap2_route_t legacy = ap2_resolve_route(
+        AP2_PROTO_AUTO, "features=0x0,0x0", "true", false, true, 16, false,
+        false, false);
+    assert(legacy.use_raop);
+    puts("ap2_client route password selection tests passed");
+}
+
 int main(void)
 {
+    test_route_with_password();
     test_info_format_tables();
     test_native_flush_resume_reuses_rtsp_session();
     test_native_flush_rejects_receiver_error();
@@ -370,6 +414,14 @@ int main(void)
         &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
     assert(client);
     ap2cl_force_native(client);
+
+    /* A client that has not connected reports no failure, and the accessor
+     * stays usable on a NULL client so the caller's error path cannot crash. */
+    int http = 1234;
+    const char *detail = NULL;
+    assert(ap2cl_connect_error(client, &http, &detail) == AP2_CONNECT_ERROR_NONE);
+    assert(http == 0 && detail && *detail == '\0');
+    assert(ap2cl_connect_error(NULL, NULL, NULL) == AP2_CONNECT_ERROR_GENERIC);
 
     health_check_t check = {
         .client = client,

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -321,6 +321,54 @@ static bool test_feedback_lock_timeouts_are_skipped(void)
     return true;
 }
 
+/* A 401 challenge is the evidence an auth failure turns on: its header must be
+ * readable out of the raw response, and the whole exchange must render as one
+ * printable log line. */
+static bool test_auth_response_diagnostics(void)
+{
+    static const uint8_t unauthorized[] =
+        "RTSP/1.0 401 Unauthorized\r\n"
+        "CSeq: 3\r\n"
+        "WWW-Authenticate: Digest realm=\"raop\", nonce=\"abc\"\r\n"
+        "Content-Length: 3\r\n\r\n"
+        "\x01\x02\xff";
+    const size_t len = sizeof(unauthorized) - 1;
+
+    char value[128];
+    CHECK(ap2_io_header_value(unauthorized, len, "www-authenticate",
+                              value, sizeof(value)));
+    CHECK(strcmp(value, "Digest realm=\"raop\", nonce=\"abc\"") == 0);
+    CHECK(ap2_io_header_value(unauthorized, len, "CSeq", value, sizeof(value)));
+    CHECK(strcmp(value, "3") == 0);
+    /* Absent headers report as such, and the status line is not a header. */
+    CHECK(!ap2_io_header_value(unauthorized, len, "Session", value, sizeof(value)));
+    CHECK(value[0] == '\0');
+    CHECK(!ap2_io_header_value(unauthorized, len, "RTSP/1.0", value, sizeof(value)));
+
+    char dump[256];
+    size_t written = ap2_io_format_response_dump(unauthorized, len, 512,
+                                                 dump, sizeof(dump));
+    CHECK(written == strlen(dump));
+    CHECK(strstr(dump, "RTSP/1.0 401 Unauthorized | CSeq: 3 | ") == dump);
+    CHECK(strstr(dump, "WWW-Authenticate: Digest") != NULL);
+    CHECK(strstr(dump, "body[3]=0102ff") != NULL);
+    CHECK(strchr(dump, '\n') == NULL && strchr(dump, '\r') == NULL);
+
+    /* The body cap elides the rest instead of flooding the log. */
+    CHECK(ap2_io_format_response_dump(unauthorized, len, 2, dump, sizeof(dump)));
+    CHECK(strstr(dump, "body[3]=0102...") != NULL);
+
+    /* A truncated reply (no header terminator) still renders, and a tiny
+     * destination truncates instead of overflowing. */
+    CHECK(ap2_io_format_response_dump(unauthorized, 12, 512, dump, sizeof(dump)));
+    CHECK(strcmp(dump, "RTSP/1.0 401") == 0);
+    char small[8];
+    CHECK(ap2_io_format_response_dump(unauthorized, len, 512, small,
+                                      sizeof(small)) == sizeof(small) - 1);
+    CHECK(strcmp(small, "RTSP/1.") == 0);
+    return true;
+}
+
 int main(void)
 {
     if (!test_fake_peer_response()) return 1;
@@ -343,6 +391,8 @@ int main(void)
     fprintf(stderr, "datagram outcomes passed\n");
     if (!test_feedback_lock_timeouts_are_skipped()) return 1;
     fprintf(stderr, "feedback contention accounting passed\n");
+    if (!test_auth_response_diagnostics()) return 1;
+    fprintf(stderr, "auth response diagnostics passed\n");
     puts("ap2_io tests passed");
     return 0;
 }


### PR DESCRIPTION
Streaming to password-protected AirPlay devices (for example a HomePod with "Require Password" enabled) failed with a generic error: the device password was never used on the AirPlay 2 route, and failures gave no clue that a password was the problem.

- Authenticate AirPlay 2 sessions with the device password: it is tried as the pairing secret first, with a fallback to stored pairing credentials when the receiver refuses that
- Use the password on the RAOP route whenever one is configured (previously only when the device announced password protection)
- Report failures to Music Assistant with a machine-readable error line: password required, password rejected, or a plain connect failure
- Log the full response of a failed handshake, so we can finally see what password-protected HomePods actually expect
- Refuse early with a clear error when a device requires a password and none was supplied

No behavior change when no password is involved. A wrong password on the legacy RAOP route still reports a generic connect failure — distinguishing it would require carrying libraop changes, which we decided against.

Companion PR: music-assistant/server#5134 (setup flow and user-facing errors on the server side).
