### PR TITLE
Fix playback on speakers that only support AirPlay 2

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -53,11 +53,12 @@ Decision order:
    `--ap2-native` forces AirPlay 2 regardless.
 2. **Native vs RAOP-compat** — stored credentials (`--auth`) ⇒ native with
    pair-verify. `--ap2-native` ⇒ native with transient pairing.
-   In `auto`, a device that advertises pairing (bit 46 or 48) with no PIN and
+   Otherwise a device that advertises pairing (bit 46 or 48) with no PIN and
    no legacy flag ⇒ native with transient pairing, provided it either does not
-   require a password or one was supplied with `--password` (§3a). Otherwise
-   the RAOP-compat flow. An explicit `--protocol airplay2` without
-   credentials keeps RAOP-compat unless `--ap2-native` is given.
+   require a password or one was supplied with `--password` (§3a).
+   `--protocol airplay2` takes that route on the same terms, and also when the
+   TXT advertises no features at all — an AirPlay-2-only receiver, with no
+   `_raop` service behind it. Everything else ⇒ the RAOP-compat flow.
 3. **Timing** — `--ptp` forces PTP; otherwise the SupportsPTP feature bit
    selects PTP vs the NTP responder. If PTP is selected but UDP 319/320
    cannot be bound (no privilege, no daemon), the session falls back to NTP.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Protocol and architecture detail lives in `DESIGN.md`; open work in `TODO.md`.
 
 - **RAOP (AirPlay 1)** via libraop: ALAC (compressed by default), NTP timing,
   optional RSA payload encryption, legacy Apple TV pairing.
-- **AirPlay 2 RAOP-compat**: auth-setup + the RAOP flow — the proven path for
-  AirPlay 2 receivers without stored credentials.
+- **AirPlay 2 RAOP-compat**: auth-setup + the RAOP flow — the fallback for
+  AirPlay 2 receivers that can neither pair-verify nor pair transiently.
 - **AirPlay 2 native**: HAP pairing (transient, or pair-verify with stored
   credentials), encrypted RTSP, binary-plist SETUP, ChaCha20-Poly1305 audio,
   realtime (type 96) streaming with PTP or NTP timing.
@@ -104,9 +104,11 @@ cliairplay --ptp-daemon [--if <ip>] &
 # Grant only the privileged-port capability instead of running as root:
 sudo setcap cap_net_bind_service=+ep /path/to/cliairplay
 
-# Per device, connect a command-only session:
-cliairplay --protocol airplay2 --ptp-shared --cmdpipe /tmp/cap1 ... <ip1>
-cliairplay --protocol airplay2 --ptp-shared --cmdpipe /tmp/cap2 ... <ip2>
+# Per device, connect a command-only session. --ptp selects PTP timing (or pass
+# --txt and let the SupportsPTP bit do it); --ptp-shared then attaches the
+# daemon's clock instead of running an in-process engine.
+cliairplay --protocol airplay2 --ptp --ptp-shared --cmdpipe /tmp/cap1 ... <ip1>
+cliairplay --protocol airplay2 --ptp --ptp-shared --cmdpipe /tmp/cap2 ... <ip2>
 
 # Wait until both report [STATUS] audio, then send the same start to both:
 # START_UNIX_MS=<T>
@@ -131,7 +133,7 @@ cliairplay [options] --cmdpipe <path> <host_ip>
 
 | Option | Description |
 |--------|-------------|
-| `--protocol <auto\|raop\|airplay2>` | Streaming protocol (default: `auto`, which resolves the full route — RAOP vs AirPlay 2, native vs compat, PTP vs NTP — from the mDNS TXT records in `--txt`). `raop`/`airplay2` force the protocol; `airplay2` uses the native flow with `--auth` or `--ap2-native`, the RAOP-compat flow otherwise. |
+| `--protocol <auto\|raop\|airplay2>` | Streaming protocol (default: `auto`, which resolves the full route — RAOP vs AirPlay 2, native vs compat, PTP vs NTP — from the mDNS TXT records in `--txt`). `raop`/`airplay2` force the protocol; `airplay2` picks native vs RAOP-compat on the same terms as `auto`, and goes native when `--txt` advertises no features at all (an AirPlay-2-only receiver). |
 
 ### Common
 
@@ -165,13 +167,13 @@ cliairplay [options] --cmdpipe <path> <host_ip>
 | Option | Description |
 |--------|-------------|
 | `--auth <hex>` | HAP credentials (192 hex chars, from `--pair-setup`). Selects the native flow with pair-verify. |
-| `--ap2-native` | Force the native flow without credentials (transient pairing). Without this or `--auth`, an explicit `--protocol airplay2` uses the RAOP-compat flow. |
+| `--ap2-native` | Force the native flow without credentials (transient pairing), whatever the TXT advertises. |
 | `--txt <k=v ...>` | mDNS TXT records of the `_airplay._tcp` service; drives route auto-selection. |
 | `--publish-ip <ip>` | Address advertised to devices (timing-peer lists) when it differs from the bind address (Docker bridge, NAT). |
 | `--name <name>` | Device name (native flow). |
 | `--hostname <host>` | Device hostname (native flow). |
 | `--ptp` | Force PTP grandmaster timing (binds UDP 319/320, needs privilege). Default: auto by the SupportsPTP feature bit. |
-| `--ptp-shared` | Prefer the shared PTP daemon clock (multi-room): attach the daemon's shm instead of running an engine; fall back to the in-process engine when no daemon is live. |
+| `--ptp-shared` | Prefer the shared PTP daemon clock (multi-room): attach the daemon's shm instead of running an engine; fall back to the in-process engine when no daemon is live. Picks the clock *source*, not the timing mode — pair it with `--ptp` or a `--txt` advertising SupportsPTP. |
 
 ### Utility / daemon modes
 

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -844,29 +844,22 @@ ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char
         return r;
     }
 
-    /* 2. Native AP2 vs RAOP-compatible flow. Stored credentials or an explicit
-     * override select native; in AUTO, transient-pairable devices (pairing bits,
-     * no PIN/legacy flag, and either no password required or one supplied) go
-     * native too — the device password doubles as the transient SRP secret, so a
-     * password-protected receiver no longer has to drop to RAOP-compat. Explicit
-     * --protocol airplay2 keeps the proven RAOP-compat default unless native is
-     * forced. */
-    bool native, transient = false;
-    if (have_credentials) {
-        native = true;            /* pair-verify with stored keys (Apple TV/HomePod) */
-    } else if (force_native) {
-        native = true;
-        transient = true;         /* no creds -> transient pairing */
-    } else if (pref == AP2_PROTO_AUTO &&
-               (AP2_FEAT(r.features, AP2_FEAT_HK_PAIRING) ||
-                AP2_FEAT(r.features, AP2_FEAT_COREUTILS)) &&
-               !(r.flags & (AP2_SF_PIN_REQUIRED | AP2_SF_LEGACY_PAIRING)) &&
-               (!has_pw || have_password)) {
-        native = true;
-        transient = true;
-    } else {
-        native = false;           /* RAOP-compatible fallback */
-    }
+    /* 2. Native AP2 vs RAOP-compatible flow. Stored credentials or --ap2-native
+     * select native outright; otherwise a transient-pairable device goes native,
+     * a supplied password doubling as its SRP secret. --protocol airplay2 also
+     * pairs when the features say nothing at all — absent, unparseable and a
+     * literal 0x0,0x0 all test as 0 here, deliberately — because that flag is
+     * the caller naming an AirPlay-2-only receiver, which has no _raop service
+     * behind it. Everything else (features without the pairing bits, or a
+     * blocker native cannot clear either) stays on RAOP-compat. */
+    bool pairable = AP2_FEAT(r.features, AP2_FEAT_HK_PAIRING) ||
+                    AP2_FEAT(r.features, AP2_FEAT_COREUTILS) ||
+                    (pref == AP2_PROTO_AIRPLAY2 && r.features == 0);
+    bool pairing_blocked = (r.flags & (AP2_SF_PIN_REQUIRED | AP2_SF_LEGACY_PAIRING)) != 0 ||
+                           (has_pw && !have_password);
+
+    bool native = have_credentials || force_native || (pairable && !pairing_blocked);
+    bool transient = native && !have_credentials;   /* stored keys => pair-verify */
 
     if (!native) {
         r.use_raop = false;

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -392,9 +392,100 @@ static void test_route_with_password(void)
     puts("ap2_client route password selection tests passed");
 }
 
+/* An explicit --protocol airplay2 reaches the native flow on exactly the same
+ * terms as auto, so an AirPlay-2-only receiver (no _raop service to fall back
+ * on) is not routed into a RAOP-compatible flow it cannot answer. Only a real
+ * pairing blocker drops it back to RAOP-compat. */
+static void test_route_explicit_airplay2(void)
+{
+    /* features bit 48 (AirPlay 2 + pairing) => "0x0,0x10000" */
+    const char *txt = "features=0x0,0x10000 flags=0x4";
+
+    ap2_route_t transient = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, txt, NULL, false, false, 16, false, false, false);
+    assert(!transient.use_raop && transient.native && transient.transient);
+    assert(strcmp(transient.reason, "native AP2, transient, realtime") == 0);
+
+    /* Pairing bit 46 alone: auto would not even call this device AirPlay 2, but
+     * the explicit flag does, and it pairs transiently just the same. */
+    ap2_route_t hk_only = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, "features=0x0,0x4000", NULL, false, false, 16,
+        false, false, false);
+    assert(hk_only.native && hk_only.transient);
+
+    /* A receiver that advertises no features at all is the case the explicit
+     * flag exists for: trust the caller and pair transiently. */
+    ap2_route_t featureless = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, "model=Generic1,1 srcvers=770.8.1", NULL, false,
+        false, 16, false, false, false);
+    assert(featureless.native && featureless.transient);
+    ap2_route_t no_txt = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, NULL, NULL, false, false, 16, false, false, false);
+    assert(no_txt.native && no_txt.transient);
+    /* A features field that enumerates nothing, or one we cannot parse, says
+     * exactly as much as no field at all — all three take the same route. */
+    ap2_route_t zero_features = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, "features=0x0,0x0", NULL, false, false, 16, false,
+        false, false);
+    assert(zero_features.native && zero_features.transient);
+    ap2_route_t unparseable = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, "features=nonsense", NULL, false, false, 16, false,
+        false, false);
+    assert(unparseable.native && unparseable.transient);
+
+    /* That trust is explicit-only: auto still reads the same TXT as legacy. */
+    ap2_route_t featureless_auto = ap2_resolve_route(
+        AP2_PROTO_AUTO, "model=Generic1,1 srcvers=770.8.1", NULL, false, false,
+        16, false, false, false);
+    assert(featureless_auto.use_raop);
+
+    /* PIN or legacy pairing: native cannot work either, so RAOP-compat stays
+     * the last attempt worth making. */
+    ap2_route_t pin_required = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, "features=0x0,0x10000 flags=0x8", NULL, false,
+        false, 16, false, false, false);
+    assert(!pin_required.use_raop && !pin_required.native);
+    assert(strcmp(pin_required.reason, "AirPlay 2 (RAOP-compat)") == 0);
+
+    ap2_route_t legacy_pairing = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, "features=0x0,0x10000 flags=0x200", NULL, false,
+        false, 16, false, false, false);
+    assert(!legacy_pairing.use_raop && !legacy_pairing.native);
+
+    /* A required password we do not hold blocks transient pairing; supplying
+     * one unblocks it, exactly as under auto. */
+    ap2_route_t pw_missing = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, txt, "true", false, false, 16, false, false, false);
+    assert(!pw_missing.native);
+    ap2_route_t pw_supplied = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, txt, "true", false, true, 16, false, false, false);
+    assert(pw_supplied.native && pw_supplied.transient);
+    assert(strcmp(pw_supplied.reason, "native AP2, password, realtime") == 0);
+
+    /* Stored credentials still select pair-verify over transient pairing. */
+    ap2_route_t with_creds = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, txt, NULL, true, false, 16, false, false, false);
+    assert(with_creds.native && !with_creds.transient);
+    assert(strcmp(with_creds.reason, "native AP2, pair-verify, realtime") == 0);
+
+    /* An AirPlay 2 receiver without the pairing bits keeps the proven
+     * RAOP-compatible flow (features bit 38 only). */
+    ap2_route_t compat_only = ap2_resolve_route(
+        AP2_PROTO_AIRPLAY2, "features=0x0,0x40", NULL, false, false, 16, false,
+        false, false);
+    assert(!compat_only.use_raop && !compat_only.native);
+
+    /* --protocol raop is untouched by any of this. */
+    ap2_route_t forced_raop = ap2_resolve_route(
+        AP2_PROTO_RAOP, txt, NULL, false, false, 16, false, false, false);
+    assert(forced_raop.use_raop);
+    puts("ap2_client explicit airplay2 route tests passed");
+}
+
 int main(void)
 {
     test_route_with_password();
+    test_route_explicit_airplay2();
     test_info_format_tables();
     test_native_flush_resume_reuses_rtsp_session();
     test_native_flush_rejects_receiver_error();


### PR DESCRIPTION
Some speakers only offer AirPlay 2, with no older AirPlay 1 service alongside it. Music Assistant flags those with `--protocol airplay2`, but that flag always picked the legacy-compatible connection — the one such a speaker rejects. Playback failed immediately with a connection error.

- `--protocol airplay2` now picks the modern or legacy connection on the same terms `--protocol auto` already uses
- A speaker that advertises no capabilities at all is treated as AirPlay 2, which is exactly what the flag is for
- Speakers that need a PIN, legacy pairing, or a password we don't have still fall back to the legacy connection
- `--protocol auto` is unchanged
- Fixed the multi-room sync example in the README, which asked for the shared clock without ever selecting PTP timing