### PR TITLE
Fix static noise bursts on Apple devices when seeking or changing tracks

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -599,10 +599,13 @@ capture.
   the splice instant on the line (the same instant for every member of a sync
   group, so a group splices sample-aligned); the pacing depth is kept shallow
   (600 ms) because the receiver's queued audio plays out before a splice is
-  audible, and that depth is surfaced as `warm_lead_ms` on the
-  `[STATUS] latency` line so the caller anchors warm starts beyond it.
-  Third-party receivers keep the flush + re-anchor path below, which they
-  handle cleanly.
+  audible. A commanded instant at or behind a member's head splices at that
+  member's own head instead — silently breaking the shared instant — so the
+  flush ack carries the frozen head's audible instant
+  (`[STATUS] flushed head_unix_ms=<ms>`), the depth rides `warm_lead_ms` on
+  the `[STATUS] latency` line, and the caller anchors every warm START beyond
+  all members' heads (plus their sync adjustments). Third-party receivers
+  keep the flush + re-anchor path below, which they handle cleanly.
 - **Realtime send outcomes** — local UDP backpressure is a bounded transient
   drop that advances sequence, RTP, and scheduling timestamps. Encode,
   allocation, encryption, socket, and control failures are terminal and produce

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -248,9 +248,14 @@ restart marker and sync announcement for the new timeline. The caller can gate
 the command on the one-shot `[STATUS] audio buffered_ms=` line — emitted once a
 complete transport packet is buffered (or the final short packet reaches EOF),
 and re-armed by each FLUSH — so it commits a start only after the feed is ready.
-A T of 0 or in the past clamps to now plus the minimum commanded-start lead
-(250 ms; 200 ms on RAOP), which covers only the commit round-trips since the
-connection and the feed are already up.
+The contract is VERIFIED: a feasible T is scheduled exactly; a T of 0 or one
+the transport cannot honor is corrected FORWARD to the earliest feasible
+instant plus one lead of retry slack (the feasibility floor moves with the
+wall clock), and the `[STATUS] started requested_unix_ms= at_unix_ms=` ack
+always reports the true scheduled instant — the caller compares the two, logs
+corrections, and re-aligns a group by re-STARTing every member at the largest
+reported instant. The minimum lead (250 ms; 200 ms on RAOP) covers only the
+commit round-trips since the connection and the feed are already up.
 
 **Downstream render-latency is informational, not applied.** A receiver whose
 audible output sits behind an external pipeline reports that delay in its
@@ -576,7 +581,9 @@ capture.
   the pre-flush audio the caller stopped writing — then, after the receiver
   accepts the flush, acks `[STATUS] flushed` and releases the reader onto the
   empty ring. The stream is then idle-primed: it keeps buffering the next track
-  but sends nothing until the next `START`, which re-anchors it. The one-shot
+  and sends nothing until the next `START` (on the Apple splice timeline it
+  sends keepalive silence instead, so the immutable line cannot lapse across a
+  slow next-track spin-up). The next `START` re-anchors it. The one-shot
   `[STATUS] audio` signal (§6) is re-armed by the flush and fires after one
   complete transport packet is buffered, or when a final short packet reaches
   EOF. Partial PCM remains in the ring until a full packet is available; only

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -582,6 +582,27 @@ capture.
   EOF. Partial PCM remains in the ring until a full packet is available; only
   the final EOF packet is padded with silence. The sender waits in bounded
   intervals so control failures remain visible during producer starvation.
+- **Apple splice timeline** — Apple's own receivers (tvOS/audioOS/macOS;
+  `model=`/`am=` prefix match) emit a ~100 ms noise burst on their native
+  realtime lane at any buffer discard (classic FLUSH with any RTP-Info, and
+  FLUSHBUFFERED alike), any anchor re-announce, and any late-frame delivery
+  (measured A/B on an Apple TV 4K, tvOS 27, 2026-07-30: the only clean warm
+  transitions were a natural drain and a bitstream-continuous splice; Apple
+  senders never exercise this corner — realtime streams are live and music
+  seeks ride the buffered lane). Native sessions to Apple models therefore run
+  a splice timeline: the anchor line frozen at the first START is immutable for
+  the whole session, no flush verb is ever sent, and every warm boundary
+  (seek/next FLUSH+START, standby park/resume, pause/un-pause, starvation
+  recovery) is expressed as a forward-only stamp skip on that line — the
+  sequence stays contiguous, so the receiver sees a content edit rather than
+  loss, and the skipped span renders as silence. The commanded START selects
+  the splice instant on the line (the same instant for every member of a sync
+  group, so a group splices sample-aligned); the pacing depth is kept shallow
+  (600 ms) because the receiver's queued audio plays out before a splice is
+  audible, and that depth is surfaced as `warm_lead_ms` on the
+  `[STATUS] latency` line so the caller anchors warm starts beyond it.
+  Third-party receivers keep the flush + re-anchor path below, which they
+  handle cleanly.
 - **Realtime send outcomes** — local UDP backpressure is a bounded transient
   drop that advances sequence, RTP, and scheduling timestamps. Encode,
   allocation, encryption, socket, and control failures are terminal and produce

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -593,9 +593,11 @@ capture.
   a splice timeline: the anchor line frozen at the first START is immutable for
   the whole session, no flush verb is ever sent, and every warm boundary
   (seek/next FLUSH+START, standby park/resume, pause/un-pause, starvation
-  recovery) is expressed as a forward-only stamp skip on that line — the
-  sequence stays contiguous, so the receiver sees a content edit rather than
-  loss, and the skipped span renders as silence. The commanded START selects
+  recovery) keeps the wire bitstream-continuous — a forward stamp jump is
+  audible too, so the gap up to the commanded instant is FILLED with encoded
+  silence sent as ordinary chunks (sequence numbers and timestamps advance
+  normally; the final partial pad shares a chunk with the first real samples,
+  keeping the splice sample-exact). The commanded START selects
   the splice instant on the line (the same instant for every member of a sync
   group, so a group splices sample-aligned); the pacing depth is kept shallow
   (600 ms) because the receiver's queued audio plays out before a splice is

--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ stdin, the single persistent audio input for the whole process lifetime.
   track while sending nothing until the next `START` (idle-primed). The one-shot
   `[STATUS] audio buffered_ms=<ms>` line fires again when the next track's feed
   has a complete packet buffered, or its final short packet reaches EOF.
+  On Apple receivers the native flow instead runs a splice timeline (no receiver
+  flush, one immutable anchor line; any discard or re-anchor makes them emit a
+  short noise burst): the queued audio — kept shallow, reported as
+  `warm_lead_ms` on the `[STATUS] latency` line — plays out and the next `START`
+  splices the new track at the commanded instant by skipping stamps forward.
 - Session lifecycle: `ACTION=STANDBY` (silence the receiver, keep the connection
   warm), `ACTION=DISCONNECT` (end the session).
 - Transport: `ACTION=PLAY|PAUSE|STOP`.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ without reconnecting. A caller can wait for the one-shot
 `[STATUS] audio buffered_ms=<ms>` line — emitted once the (new) track has a
 complete audio packet buffered, or its final short packet reaches EOF — before
 it commands the start, then send the same start value to every member of a sync
-group. A `START_UNIX_MS` of 0 or in the past clamps to now plus the minimum
-commanded-start lead (250 ms, 200 ms on RAOP).
+group. A `START_UNIX_MS` of 0 or one the transport cannot honor is corrected
+forward to the earliest feasible instant (250 ms minimum lead, 200 ms on RAOP)
+and the `[STATUS] started` ack always reports the true scheduled instant.
 
 Delivery is not gated on the start time: frames are released up to the
 receiver's buffer window ahead of each frame's deadline (the device-reported
@@ -201,7 +202,8 @@ stdin, the single persistent audio input for the whole process lifetime.
 - `ACTION=FLUSH` — in-place warm flush for seek/next: flush the receiver (RTSP
   FLUSH), discard the internal ring, and drain stdin to empty; after the receiver
   accepts the flush, acks with `[STATUS] flushed` and keeps buffering the next
-  track while sending nothing until the next `START` (idle-primed). The one-shot
+  track while sending nothing until the next `START` (idle-primed; the Apple
+  splice timeline sends keepalive silence instead). The one-shot
   `[STATUS] audio buffered_ms=<ms>` line fires again when the next track's feed
   has a complete packet buffered, or its final short packet reaches EOF.
   On Apple receivers the native flow instead runs a splice timeline (no receiver

--- a/README.md
+++ b/README.md
@@ -199,10 +199,11 @@ stdin, the single persistent audio input for the whole process lifetime.
   `[STATUS] audio buffered_ms=<ms>` line fires again when the next track's feed
   has a complete packet buffered, or its final short packet reaches EOF.
   On Apple receivers the native flow instead runs a splice timeline (no receiver
-  flush, one immutable anchor line; any discard or re-anchor makes them emit a
-  short noise burst): the queued audio — kept shallow, reported as
+  flush, one immutable anchor line; any discard, re-anchor or stamp jump makes
+  them emit a short noise burst): the queued audio — kept shallow, reported as
   `warm_lead_ms` on the `[STATUS] latency` line — plays out and the next `START`
-  splices the new track at the commanded instant by skipping stamps forward.
+  splices the new track at the commanded instant, filling the gap with encoded
+  silence so the bitstream stays contiguous.
   The ack then reads `[STATUS] flushed head_unix_ms=<ms>` (the audible instant
   of the frozen delivery head); the commanded start must land beyond every
   member's head or that member splices at its own head instead.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ stdin, the single persistent audio input for the whole process lifetime.
   short noise burst): the queued audio — kept shallow, reported as
   `warm_lead_ms` on the `[STATUS] latency` line — plays out and the next `START`
   splices the new track at the commanded instant by skipping stamps forward.
+  The ack then reads `[STATUS] flushed head_unix_ms=<ms>` (the audible instant
+  of the frozen delivery head); the commanded start must land beyond every
+  member's head or that member splices at its own head instead.
 - Session lifecycle: `ACTION=STANDBY` (silence the receiver, keep the connection
   warm), `ACTION=DISCONNECT` (end the session).
 - Transport: `ACTION=PLAY|PAUSE|STOP`.

--- a/README.md
+++ b/README.md
@@ -190,8 +190,14 @@ stdin, the single persistent audio input for the whole process lifetime.
 
 - Start / re-anchor: `START_UNIX_MS=<unix epoch ms>` then `ACTION=START`. The
   first `START` begins the session; a `START` after an `ACTION=FLUSH` re-anchors
-  the same live stream (no reconnect). `START_UNIX_MS=0` (or a past instant)
-  starts as soon as possible, at the minimum commanded-start lead.
+  the same live stream (no reconnect). `START_UNIX_MS=0` starts as soon as
+  possible. The start contract is VERIFIED: a feasible instant is scheduled
+  exactly, an infeasible one is corrected forward to the earliest feasible
+  instant (audio always flows), and the ack
+  `[STATUS] started requested_unix_ms=<ms> at_unix_ms=<ms>` always carries the
+  true scheduled instant — the caller compares the two, logs any correction,
+  and re-aligns a sync group by re-STARTing every member at the largest
+  reported instant.
 - `ACTION=FLUSH` — in-place warm flush for seek/next: flush the receiver (RTSP
   FLUSH), discard the internal ring, and drain stdin to empty; after the receiver
   accepts the flush, acks with `[STATUS] flushed` and keeps buffering the next

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -182,6 +182,9 @@ struct ap2cl_s {
     bool splice_timeline;         /* Apple receiver: discard-free warm path on
                                      one immutable anchor line (see the splice
                                      comments at flush/resume/standby) */
+    uint32_t splice_pad_frames;   /* silence frames still to send before the
+                                     next real sample so it lands exactly on
+                                     the commanded splice instant */
     uint64_t reanchor_shifted_frames; /* cumulative shift since the last start/
                                         * resume, for [STATUS] REANCHOR */
 
@@ -2413,6 +2416,7 @@ void ap2cl_standby(struct ap2cl_s *p)
          * reported was this FLUSH). The frozen anchor line survives the park;
          * the splice resume skips forward on it. */
         LOG_INFO("[AP2] splice standby: draining the queue, keeping the line");
+        p->splice_pad_frames = 0;
         ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
         p->state = AP2_CONNECTED;
         return;
@@ -2459,6 +2463,7 @@ bool ap2cl_flush(struct ap2cl_s *p)
         LOG_INFO("[AP2] splice flush: keeping the receiver queue "
                  "(head seq=%u rtptime=%u)",
                  (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
+        p->splice_pad_frames = 0;   /* the next resume computes a fresh pad */
         return true;
     }
     char hdr[64];
@@ -2496,30 +2501,31 @@ bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms)
     }
 
     if (atomic_load(&p->rtsp_dead)) return false;
-    if (p->splice_timeline && p->rt_anchor_valid) {
-        /* Splice resume: the anchor line frozen at the first START is
-         * immutable for the whole session — a line move under a live receiver
-         * is one of the measured noise triggers. The commanded start instead
-         * selects the splice point ON that line: stamps skip forward (never
-         * backward, and the sequence stays contiguous, so the receiver sees a
-         * content edit rather than packet loss) to the commanded instant and
-         * the skipped span renders as silence. Every member of a sync group
-         * is handed the same instant, so a group splices sample-aligned by
-         * construction. A start at or behind the current head splices at the
-         * head: the old queue (at most the pacing depth) plays out and the
-         * new content follows seamlessly. A resume after a long park lands
-         * the same way — the skip re-times the next frame to the commanded
-         * instant, so frames are never late (the remaining noise trigger). */
+    if (p->splice_timeline && p->rt_anchor_valid &&
+        p->head_ts > NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate)) {
+        /* Splice resume (hot line: the receiver still holds queued audio).
+         * The anchor line frozen at the first START is immutable for the
+         * whole session, and the wire must stay bitstream-continuous —
+         * a line move, a timestamp jump, and late frames are each an audible
+         * noise trigger on Apple receivers (all measured). The commanded
+         * start therefore selects the splice point ON the line, and the gap
+         * between the frozen head and that instant is FILLED with encoded
+         * silence: sequence numbers and timestamps advance normally and the
+         * first real sample lands exactly on the commanded instant. Every
+         * member of a sync group is handed the same instant, so a group
+         * splices sample-aligned by construction. A start at or behind the
+         * current head splices at the head: the old queue (at most the
+         * pacing depth) plays out and the new content follows seamlessly. */
         uint64_t target = NTP2TS(commanded_start_ntp(start_unix_ms),
                                  p->format.sample_rate);
         if (target > p->head_ts) {
-            uint64_t skip = target - p->head_ts;
-            LOG_INFO("[AP2] splice resume: skipping %" PRIu64 " frames "
-                     "(%" PRIu64 " ms) to the commanded start",
-                     skip, skip * 1000ULL / p->format.sample_rate);
-            p->head_ts = target;
-            p->rtp_timestamp = (uint32_t)(p->rtp_timestamp + skip);
+            uint64_t pad = target - p->head_ts;
+            p->splice_pad_frames = (uint32_t)pad;
+            LOG_INFO("[AP2] splice resume: padding %" PRIu64 " frames "
+                     "(%" PRIu64 " ms) of silence to the commanded start",
+                     pad, pad * 1000ULL / p->format.sample_rate);
         } else {
+            p->splice_pad_frames = 0;
             LOG_INFO("[AP2] splice resume at head (seq=%u rtptime=%u)",
                      (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
         }
@@ -2530,6 +2536,12 @@ bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms)
         atomic_store(&p->media_healthy, true);
         return true;
     }
+    /* A lapsed splice line (head at or behind the wall clock: the receiver
+     * drained long ago — resume from a long park) falls through to the stock
+     * re-anchor: a fresh line over a long-idle pipeline is the session-start
+     * shape, which is clean; padding silence from a lapsed head would deliver
+     * late frames, which is not. */
+    p->splice_pad_frames = 0;
     uint64_t start_ntp = commanded_start_ntp(start_unix_ms);
     /* Re-base the frozen line: head_ts moves in the scheduling domain, the
      * wire timestamp follows it plus the per-process offset, and the next
@@ -2630,25 +2642,23 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p)
     if (p->splice_timeline) {
         /* Splice recovery, same immutable-line rule as seek/resume: when the
          * input stalls long enough that the head falls inside the minimum
-         * lead, skip stamps forward so the resuming audio is never late; the
-         * receiver renders the skipped span as silence. Playback shifts later
-         * by the skip, reported as REANCHOR exactly like the stock path so MA
-         * keeps tracking the drift; the anchor line and the wire offset are
-         * untouched, so no sync re-announce is needed (the measured noise
-         * trigger on Apple receivers). */
+         * lead, queue silence padding up to now plus the recovery lead. The
+         * audio loop sends it as ordinary encoded chunks, so the wire stays
+         * bitstream-continuous through the stall (a stamp jump, a line move
+         * and late frames are each an audible noise trigger). Playback shifts
+         * later by the pad, reported as REANCHOR exactly like the stock path
+         * so MA keeps tracking the drift. */
         if (p->head_ts > now_ts + floor) return false;
-        uint64_t target = now_ts + recovery_lead;
-        uint64_t skip = target - p->head_ts;
-        p->head_ts = target;
-        p->rtp_timestamp = (uint32_t)(p->rtp_timestamp + skip);
+        uint64_t pad = now_ts + recovery_lead - p->head_ts;
+        p->splice_pad_frames += (uint32_t)pad;
         p->timeline_reanchors++;
-        p->reanchor_shifted_frames += skip;
-        LOG_WARN("[AP2] Splice-skipped after PCM starvation: shifted_frames="
+        p->reanchor_shifted_frames += pad;
+        LOG_WARN("[AP2] Splice-padded after PCM starvation: shifted_frames="
                  "%" PRIu64 " lead_frames=%" PRIu64 " count=%" PRIu64,
-                 skip, recovery_lead, p->timeline_reanchors);
+                 pad, recovery_lead, p->timeline_reanchors);
         fprintf(stderr, "[STATUS] REANCHOR shifted_frames=%" PRIu64
                 " total_shifted_frames=%" PRIu64 " sample_rate=%d\n",
-                skip, p->reanchor_shifted_frames, p->format.sample_rate);
+                pad, p->reanchor_shifted_frames, p->format.sample_rate);
         fflush(stderr);
         return true;
     }
@@ -2729,18 +2739,30 @@ void ap2cl_play(struct ap2cl_s *p)
     }
     if (p->flow == FLOW_NATIVE_AP2 && p->splice_timeline &&
         p->rt_anchor_valid) {
-        /* Un-pause on the frozen line: the paused wall time is never sent, so
-         * skip stamps to now plus the minimum lead — otherwise every frame
-         * after the pause would deliver late (a measured noise trigger). */
+        uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
         uint64_t target =
-            NTP2TS(raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS),
-                   p->format.sample_rate);
-        if (target > p->head_ts) {
-            uint64_t skip = target - p->head_ts;
-            LOG_INFO("[AP2] splice un-pause: skipping %" PRIu64 " frames",
-                     skip);
-            p->head_ts = target;
-            p->rtp_timestamp = (uint32_t)(p->rtp_timestamp + skip);
+            now_ts + MS2TS(AP2_MIN_WARM_LEAD_MS, p->format.sample_rate);
+        if (p->head_ts > now_ts) {
+            /* Un-pause on the hot line: fill the paused span with silence so
+             * the wire stays bitstream-continuous and the remaining content
+             * resumes at now plus the minimum lead — a stamp jump or late
+             * frames are each an audible noise trigger. */
+            if (target > p->head_ts) {
+                p->splice_pad_frames = (uint32_t)(target - p->head_ts);
+                LOG_INFO("[AP2] splice un-pause: padding %u silence frames",
+                         (unsigned)p->splice_pad_frames);
+            }
+        } else {
+            /* Lapsed line (receiver drained long ago): re-anchor fresh over
+             * the idle pipeline, the clean session-start shape. */
+            p->splice_pad_frames = 0;
+            p->start_ntp = raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS);
+            p->head_ts = NTP2TS(p->start_ntp, p->format.sample_rate);
+            p->rtp_timestamp = (uint32_t)p->head_ts +
+                               atomic_load(&p->rtp_offset);
+            p->rt_anchor_valid = false;
+            p->first_packet = true;
+            LOG_INFO("[AP2] splice un-pause after drain: fresh anchor line");
         }
     }
     p->state = AP2_STREAMING;
@@ -3348,6 +3370,22 @@ uint64_t ap2cl_splice_head_unix_ms(struct ap2cl_s *p)
      * clock, so its audible instant is the direct inverse mapping. */
     uint64_t ntp = TS2NTP(p->head_ts, p->format.sample_rate);
     return (ntp >> 32) * 1000ULL + (((ntp & 0xFFFFFFFFULL) * 1000ULL) >> 32);
+}
+
+/* Silence frames the audio loop still owes the wire before the next real
+ * sample (splice timeline): the pad bridges the frozen head and the commanded
+ * splice instant with ordinary encoded chunks so sequence numbers and
+ * timestamps stay contiguous. The loop consumes it as it sends. */
+uint32_t ap2cl_splice_pad_frames(struct ap2cl_s *p)
+{
+    return p ? p->splice_pad_frames : 0;
+}
+
+void ap2cl_splice_pad_consume(struct ap2cl_s *p, uint32_t frames)
+{
+    if (!p) return;
+    p->splice_pad_frames = frames < p->splice_pad_frames
+                               ? p->splice_pad_frames - frames : 0;
 }
 
 int ap2cl_render_latency_ms(struct ap2cl_s *p) { return p ? p->dev_render_ms : 0; }

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2607,6 +2607,15 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
      * shape, which is clean; padding silence from a lapsed head would deliver
      * late frames, which is not. */
     p->splice_pad_frames = 0;
+    if (p->state == AP2_STREAMING && !p->splice_timeline) {
+        /* A re-anchor on an already-streaming stock stream (the corrective
+         * round of a group start) must discard the receiver's audio from the
+         * previous anchor first: without the flush the receiver keeps
+         * rendering the buffered frames on the OLD line and stays offset by
+         * the correction delta until the next clean anchor (measured on
+         * Sonos as a persistent few-hundred-ms group desync). */
+        ap2cl_flush(p);
+    }
     uint64_t start_ntp = 0;
     ap2_resolve_start(start_unix_ms, now_ntp + MS2NTP(AP2_MIN_WARM_LEAD_MS),
                       &start_ntp, at_unix_ms);

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2556,7 +2556,7 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
         uint64_t head_ntp = TS2NTP(p->head_ts, p->format.sample_rate);
         uint64_t requested =
             start_unix_ms ? ap2_unix_ms_to_ntp(start_unix_ms) : 0;
-        if (requested > head_ntp) {
+        if (start_unix_ms && requested >= head_ntp) {
             uint64_t target = NTP2TS(requested, p->format.sample_rate);
             uint64_t pad = target > p->head_ts ? target - p->head_ts : 0;
             p->splice_pad_frames = (uint32_t)pad;

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2364,14 +2364,22 @@ static void ap2_resolve_start(uint64_t start_unix_ms, uint64_t floor_ntp,
         if (at_unix_ms) *at_unix_ms = start_unix_ms;
         return;
     }
-    *ntp_start = floor_ntp;
-    if (at_unix_ms) *at_unix_ms = ap2_ntp_to_unix_ms(floor_ntp);
-    if (start_unix_ms)
+    if (start_unix_ms) {
+        /* Corrected forward with one extra lead of slack: the floor moves
+         * with the wall clock, so a corrective retry at a bare floor would
+         * chase it forever. A request of 0 takes the floor directly (no
+         * retry follows a pick). */
+        *ntp_start = floor_ntp + MS2NTP(AP2_MIN_WARM_LEAD_MS);
+        if (at_unix_ms) *at_unix_ms = ap2_ntp_to_unix_ms(*ntp_start);
         LOG_WARN("[AP2] start %llu ms is %llu ms behind the feasibility "
                  "floor; corrected forward",
                  (unsigned long long)start_unix_ms,
                  (unsigned long long)(ap2_ntp_to_unix_ms(floor_ntp) -
                                       start_unix_ms));
+        return;
+    }
+    *ntp_start = floor_ntp;
+    if (at_unix_ms) *at_unix_ms = ap2_ntp_to_unix_ms(floor_ntp);
 }
 
 ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
@@ -2563,16 +2571,28 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
             LOG_INFO("[AP2] splice resume: padding %" PRIu64 " frames "
                      "(%" PRIu64 " ms) of silence to the commanded start",
                      pad, pad * 1000ULL / p->format.sample_rate);
+        } else if (start_unix_ms) {
+            /* Corrected forward — one minimum lead BEYOND the head, not AT
+             * it: the idle keepalive advances the head 1:1 with the wall
+             * clock, so an ack naming the head itself sends the caller's
+             * corrective retry chasing a target that has always just moved
+             * (measured: +212/+418/+15 ms rounds without convergence). One
+             * lead of slack absorbs the command round-trip, so the retry at
+             * the reported instant lands exactly. */
+            uint64_t corrected_ntp =
+                head_ntp + MS2NTP(AP2_MIN_WARM_LEAD_MS);
+            uint64_t target = NTP2TS(corrected_ntp, p->format.sample_rate);
+            p->splice_pad_frames =
+                (uint32_t)(target > p->head_ts ? target - p->head_ts : 0);
+            if (at_unix_ms) *at_unix_ms = ap2_ntp_to_unix_ms(corrected_ntp);
+            LOG_WARN("[AP2] splice resume: start %llu ms is behind the head; "
+                     "corrected forward to head + %d ms",
+                     (unsigned long long)start_unix_ms, AP2_MIN_WARM_LEAD_MS);
         } else {
             p->splice_pad_frames = 0;
             if (at_unix_ms) *at_unix_ms = ap2_ntp_to_unix_ms(head_ntp);
-            if (start_unix_ms)
-                LOG_WARN("[AP2] splice resume: start %llu ms is behind the "
-                         "head; corrected forward to the head",
-                         (unsigned long long)start_unix_ms);
-            else
-                LOG_INFO("[AP2] splice resume at head (seq=%u rtptime=%u)",
-                         (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
+            LOG_INFO("[AP2] splice resume at head (seq=%u rtptime=%u)",
+                     (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
         }
         /* A commanded start zeroes the drift baseline on both sides (MA
          * resets its accumulated shift on START). */

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3381,6 +3381,15 @@ uint32_t ap2cl_splice_pad_frames(struct ap2cl_s *p)
     return p ? p->splice_pad_frames : 0;
 }
 
+/* True while the splice timeline is live on the wire (audio sends legal): the
+ * audio loop keeps the idle-primed window between a FLUSH and the next START
+ * fed with silence so the line can never lapse mid-session. */
+bool ap2cl_splice_hot(struct ap2cl_s *p)
+{
+    return p && p->flow == FLOW_NATIVE_AP2 && p->splice_timeline &&
+           p->state == AP2_STREAMING && !atomic_load(&p->rtsp_dead);
+}
+
 void ap2cl_splice_pad_consume(struct ap2cl_s *p, uint32_t frames)
 {
     if (!p) return;

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3333,6 +3333,23 @@ int ap2cl_warm_lead_ms(struct ap2cl_s *p)
     return p && p->splice_timeline ? AP2_SPLICE_PACING_MS : 0;
 }
 
+/* Wall-clock instant (unix ms) at which the current delivery head becomes
+ * audible on the splice timeline. The flush ack carries it so the caller can
+ * anchor the warm START beyond EVERY member's queued audio: a commanded
+ * instant at or behind a member's head splices at that member's own head
+ * instead, silently breaking the shared instant (and the session's recorded
+ * start time, which late joiners anchor against). 0 when the stream is not on
+ * the splice timeline (no constraint). */
+uint64_t ap2cl_splice_head_unix_ms(struct ap2cl_s *p)
+{
+    if (!p || p->flow != FLOW_NATIVE_AP2 || !p->splice_timeline || !p->head_ts)
+        return 0;
+    /* head_ts lives in the frame-clock domain of the unix-epoch NTP wall
+     * clock, so its audible instant is the direct inverse mapping. */
+    uint64_t ntp = TS2NTP(p->head_ts, p->format.sample_rate);
+    return (ntp >> 32) * 1000ULL + (((ntp & 0xFFFFFFFFULL) * 1000ULL) >> 32);
+}
+
 int ap2cl_render_latency_ms(struct ap2cl_s *p) { return p ? p->dev_render_ms : 0; }
 
 ap2_state_t ap2cl_state(struct ap2cl_s *p) { return p ? p->state : AP2_DOWN; }

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2338,21 +2338,50 @@ bool ap2cl_disconnect(struct ap2cl_s *p)
     return true;
 }
 
-static uint64_t commanded_start_ntp(uint64_t start_unix_ms)
+static uint64_t ap2_unix_ms_to_ntp(uint64_t ms)
 {
-    uint64_t start_ntp = start_unix_ms
-        ? ((start_unix_ms / 1000) << 32) |
-              (((start_unix_ms % 1000) << 32) / 1000)
-        : 0;
-    uint64_t min_start =
-        raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS);
-    return start_ntp < min_start ? min_start : start_ntp;
+    return ((ms / 1000) << 32) | (((ms % 1000) << 32) / 1000);
 }
 
-bool ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms)
+static uint64_t ap2_ntp_to_unix_ms(uint64_t ntp)
 {
-    if (!p) return false;
-    uint64_t ntp_start = commanded_start_ntp(start_unix_ms);
+    return (ntp >> 32) * 1000ULL + (((ntp & 0xFFFFFFFFULL) * 1000ULL) >> 32);
+}
+
+/* Resolve a commanded start: a request at or beyond `floor_ntp` is honored
+ * exactly; one behind it (or 0) is corrected FORWARD to the floor — audio
+ * always flows, never silently misplaced or refused. *ntp_start receives the
+ * audible instant and *at_unix_ms the same value in unix ms, so the caller's
+ * ack always carries the truth. A correction of a nonzero request is logged
+ * here; the caller re-aligns groups from the acks. */
+static void ap2_resolve_start(uint64_t start_unix_ms, uint64_t floor_ntp,
+                              uint64_t *ntp_start, uint64_t *at_unix_ms)
+{
+    uint64_t requested =
+        start_unix_ms ? ap2_unix_ms_to_ntp(start_unix_ms) : 0;
+    if (requested >= floor_ntp) {
+        *ntp_start = requested;
+        if (at_unix_ms) *at_unix_ms = start_unix_ms;
+        return;
+    }
+    *ntp_start = floor_ntp;
+    if (at_unix_ms) *at_unix_ms = ap2_ntp_to_unix_ms(floor_ntp);
+    if (start_unix_ms)
+        LOG_WARN("[AP2] start %llu ms is %llu ms behind the feasibility "
+                 "floor; corrected forward",
+                 (unsigned long long)start_unix_ms,
+                 (unsigned long long)(ap2_ntp_to_unix_ms(floor_ntp) -
+                                      start_unix_ms));
+}
+
+ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
+                                uint64_t *at_unix_ms)
+{
+    if (!p) return AP2_COMMIT_FAILED;
+    uint64_t ntp_start = 0;
+    ap2_resolve_start(start_unix_ms,
+                      raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS),
+                      &ntp_start, at_unix_ms);
     if (p->flow == FLOW_NATIVE_AP2) {
         /* Offset the RTP timeline per process: streams in one group share
          * ntpstart, and with identical pos0 two sessions from one host are
@@ -2387,15 +2416,15 @@ bool ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms)
         if (p->use_ptp && p->ctrl_sock >= 0 &&
             ap2_send_sync_packet_ptp(p, true) == AP2_SEND_FATAL) {
             atomic_store(&p->media_healthy, false);
-            return false;
+            return AP2_COMMIT_FAILED;
         }
-        return true;
+        return AP2_COMMIT_OK;
     }
-    if (!p->raopcl) return false;
+    if (!p->raopcl) return AP2_COMMIT_FAILED;
     int latency = raopcl_latency(p->raopcl);
     raopcl_start_at(p->raopcl, ntp_start - TS2NTP(latency, p->format.sample_rate));
     p->state = AP2_STREAMING;
-    return true;
+    return AP2_COMMIT_OK;
 }
 
 /* Silence the receiver but keep the session warm (persistent standby):
@@ -2485,24 +2514,29 @@ bool ap2cl_flush(struct ap2cl_s *p)
     return true;
 }
 
-/* Re-base the frozen timeline so the next written frame is audible at
- * start_unix_ms (unix epoch ms), resuming a stream that ap2cl_flush discarded
- * (the START after a FLUSH). A start of 0 or one already in the past is clamped
- * to now + the minimum warm lead so a new track's first samples can never be
- * clipped. Sequence numbers and audio nonces are untouched. */
-bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms)
+/* Schedule the next pending sample audible at start_unix_ms (unix epoch ms),
+ * resuming a stream after ap2cl_flush (the START after a FLUSH), under the
+ * strict start contract: a nonzero instant is honored exactly or rejected
+ * with the minimum feasible instant — never silently degraded. The splice
+ * timeline pads silence up to the instant on its immutable anchor line; the
+ * stock path re-bases the frozen anchor onto it. Sequence numbers and audio
+ * nonces are untouched. */
+ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
+                                 uint64_t *at_unix_ms)
 {
-    if (!p || p->state == AP2_DOWN) return false;
+    if (!p || p->state == AP2_DOWN) return AP2_COMMIT_FAILED;
 
     if (p->flow != FLOW_NATIVE_AP2) {
-        if (!raop_session_start_at(p->raopcl, start_unix_ms)) return false;
-        p->state = AP2_STREAMING;
-        return true;
+        ap2_commit_result_t r =
+            raop_session_start_at(p->raopcl, start_unix_ms, at_unix_ms);
+        if (r == AP2_COMMIT_OK) p->state = AP2_STREAMING;
+        return r;
     }
 
-    if (atomic_load(&p->rtsp_dead)) return false;
+    if (atomic_load(&p->rtsp_dead)) return AP2_COMMIT_FAILED;
+    uint64_t now_ntp = raopcl_get_ntp(NULL);
     if (p->splice_timeline && p->rt_anchor_valid &&
-        p->head_ts > NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate)) {
+        p->head_ts > NTP2TS(now_ntp, p->format.sample_rate)) {
         /* Splice resume (hot line: the receiver still holds queued audio).
          * The anchor line frozen at the first START is immutable for the
          * whole session, and the wire must stay bitstream-continuous —
@@ -2512,29 +2546,40 @@ bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms)
          * between the frozen head and that instant is FILLED with encoded
          * silence: sequence numbers and timestamps advance normally and the
          * first real sample lands exactly on the commanded instant. Every
-         * member of a sync group is handed the same instant, so a group
-         * splices sample-aligned by construction. A start at or behind the
-         * current head splices at the head: the old queue (at most the
-         * pacing depth) plays out and the new content follows seamlessly. */
-        uint64_t target = NTP2TS(commanded_start_ntp(start_unix_ms),
-                                 p->format.sample_rate);
-        if (target > p->head_ts) {
-            uint64_t pad = target - p->head_ts;
+         * member of a sync group is handed the same accepted instant, so a
+         * group splices sample-aligned by construction. The feasibility
+         * floor is the head itself: anything earlier would require
+         * discarding queued audio (the noise trigger), so such a request is
+         * corrected FORWARD to the head and the ack carries the truth. A
+         * start of 0 splices at the head — the earliest possible point. */
+        uint64_t head_ntp = TS2NTP(p->head_ts, p->format.sample_rate);
+        uint64_t requested =
+            start_unix_ms ? ap2_unix_ms_to_ntp(start_unix_ms) : 0;
+        if (requested > head_ntp) {
+            uint64_t target = NTP2TS(requested, p->format.sample_rate);
+            uint64_t pad = target > p->head_ts ? target - p->head_ts : 0;
             p->splice_pad_frames = (uint32_t)pad;
+            if (at_unix_ms) *at_unix_ms = start_unix_ms;
             LOG_INFO("[AP2] splice resume: padding %" PRIu64 " frames "
                      "(%" PRIu64 " ms) of silence to the commanded start",
                      pad, pad * 1000ULL / p->format.sample_rate);
         } else {
             p->splice_pad_frames = 0;
-            LOG_INFO("[AP2] splice resume at head (seq=%u rtptime=%u)",
-                     (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
+            if (at_unix_ms) *at_unix_ms = ap2_ntp_to_unix_ms(head_ntp);
+            if (start_unix_ms)
+                LOG_WARN("[AP2] splice resume: start %llu ms is behind the "
+                         "head; corrected forward to the head",
+                         (unsigned long long)start_unix_ms);
+            else
+                LOG_INFO("[AP2] splice resume at head (seq=%u rtptime=%u)",
+                         (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
         }
         /* A commanded start zeroes the drift baseline on both sides (MA
          * resets its accumulated shift on START). */
         p->reanchor_shifted_frames = 0;
         p->state = AP2_STREAMING;
         atomic_store(&p->media_healthy, true);
-        return true;
+        return AP2_COMMIT_OK;
     }
     /* A lapsed splice line (head at or behind the wall clock: the receiver
      * drained long ago — resume from a long park) falls through to the stock
@@ -2542,7 +2587,9 @@ bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms)
      * shape, which is clean; padding silence from a lapsed head would deliver
      * late frames, which is not. */
     p->splice_pad_frames = 0;
-    uint64_t start_ntp = commanded_start_ntp(start_unix_ms);
+    uint64_t start_ntp = 0;
+    ap2_resolve_start(start_unix_ms, now_ntp + MS2NTP(AP2_MIN_WARM_LEAD_MS),
+                      &start_ntp, at_unix_ms);
     /* Re-base the frozen line: head_ts moves in the scheduling domain, the
      * wire timestamp follows it plus the per-process offset, and the next
      * sync packet freezes the new line from start_ntp. */
@@ -2560,9 +2607,9 @@ bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms)
     if (p->use_ptp && p->ctrl_sock >= 0 &&
         ap2_send_sync_packet_ptp(p, true) == AP2_SEND_FATAL) {
         atomic_store(&p->media_healthy, false);
-        return false;
+        return AP2_COMMIT_FAILED;
     }
-    return true;
+    return AP2_COMMIT_OK;
 }
 
 ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample,
@@ -3368,8 +3415,7 @@ uint64_t ap2cl_splice_head_unix_ms(struct ap2cl_s *p)
         return 0;
     /* head_ts lives in the frame-clock domain of the unix-epoch NTP wall
      * clock, so its audible instant is the direct inverse mapping. */
-    uint64_t ntp = TS2NTP(p->head_ts, p->format.sample_rate);
-    return (ntp >> 32) * 1000ULL + (((ntp & 0xFFFFFFFFULL) * 1000ULL) >> 32);
+    return ap2_ntp_to_unix_ms(TS2NTP(p->head_ts, p->format.sample_rate));
 }
 
 /* Silence frames the audio loop still owes the wire before the next real

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -84,6 +84,9 @@ extern log_level *loglevel;
  * after the connection and the audio feed are both confirmed, so no setup
  * slack is needed on top. */
 #define AP2_MIN_WARM_LEAD_MS         250
+/* Receiver queue depth on the Apple splice timeline (§ splice below): the
+ * depth IS the audible latency of a warm splice, so it stays shallow. */
+#define AP2_SPLICE_PACING_MS         600
 /* Raw bytes kept from a failed exchange for the auth diagnostics dump: enough
  * for a full header block plus the start of a TLV/plist body. */
 #define AP2_DIAG_RESPONSE_MAX        1536
@@ -176,6 +179,9 @@ struct ap2cl_s {
     uint64_t sync_packets_dropped;
     atomic_uint feedback_failures;
     uint64_t timeline_reanchors;
+    bool splice_timeline;         /* Apple receiver: discard-free warm path on
+                                     one immutable anchor line (see the splice
+                                     comments at flush/resume/standby) */
     uint64_t reanchor_shifted_frames; /* cumulative shift since the last start/
                                         * resume, for [STATUS] REANCHOR */
 
@@ -813,6 +819,30 @@ uint64_t ap2_txt_flags(const char *txt)
 static bool ap2_features_has_ptp(const char *txt)
 {
     return AP2_FEAT(ap2_txt_features(txt), AP2_FEAT_PTP) != 0;
+}
+
+/* Apple's own AirPlay receivers (tvOS/audioOS/macOS; `model=` in the _airplay
+ * TXT, `am=` on _raop) share a receiver daemon whose realtime lane emits a
+ * short noise burst on any buffer discard (FLUSH and FLUSHBUFFERED alike), any
+ * anchor re-announce, and any late-frame delivery — measured A/B on hardware
+ * (Apple TV 4K, tvOS 27, 2026-07-30; the only clean warm transitions were a
+ * natural drain and a bitstream-continuous splice). Third-party receivers
+ * handle the classic flush + re-anchor warm path cleanly, so only Apple models
+ * take the splice timeline. */
+static bool ap2_apple_model(const char *txt, const char *am)
+{
+    static const char *const prefixes[] = {
+        "AppleTV", "AudioAccessory", "AirPort", "HomePod",
+        "Mac", "iMac", "iPhone", "iPad", "iPod",
+    };
+    const char *model = txt ? strstr(txt, "model=") : NULL;
+    if (model) model += strlen("model=");
+    for (size_t i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
+        size_t len = strlen(prefixes[i]);
+        if (model && strncmp(model, prefixes[i], len) == 0) return true;
+        if (am && strncmp(am, prefixes[i], len) == 0) return true;
+    }
+    return false;
 }
 
 ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char *pw,
@@ -2250,6 +2280,11 @@ bool ap2cl_connect(struct ap2cl_s *p)
     if (!p) return false;
     ap2_set_connect_error(p, AP2_CONNECT_ERROR_GENERIC, 0, "connect failed");
     if (p->flow == FLOW_NATIVE_AP2) {
+        p->splice_timeline = ap2_apple_model(p->device.txt_records, p->am);
+        if (p->splice_timeline)
+            LOG_INFO("[AP2] Apple receiver: splice timeline active "
+                     "(discard-free warm path, %d ms queue depth)",
+                     AP2_SPLICE_PACING_MS);
         LOG_INFO("[AP2] Connecting via native AP2 flow to %s:%d",
                  p->device.address, p->device.port);
         return ap2_native_connect(p);
@@ -2371,6 +2406,17 @@ void ap2cl_standby(struct ap2cl_s *p)
         p->state = AP2_CONNECTED;
         return;
     }
+    if (p->splice_timeline) {
+        /* Splice park: stop delivering and let the shallow queue drain
+         * naturally — the flush verb is the noise trigger, and a starved
+         * receiver pads silence cleanly (the end-of-playback burst users
+         * reported was this FLUSH). The frozen anchor line survives the park;
+         * the splice resume skips forward on it. */
+        LOG_INFO("[AP2] splice standby: draining the queue, keeping the line");
+        ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
+        p->state = AP2_CONNECTED;
+        return;
+    }
     if (!atomic_load(&p->rtsp_dead)) {
         char hdr[64];
         snprintf(hdr, sizeof(hdr), "RTP-Info: seq=%u;rtptime=%u\r\n",
@@ -2403,6 +2449,18 @@ bool ap2cl_flush(struct ap2cl_s *p)
         return raop_session_flush(p->raopcl);
 
     if (atomic_load(&p->rtsp_dead)) return false;
+    if (p->splice_timeline) {
+        /* Splice warm path: never ask the receiver to discard. Its queued
+         * audio (at most the shallow pacing depth) plays out while the session
+         * engine swaps the content behind it; the next resume continues the
+         * same timeline and anchor line. Any flush verb here — classic FLUSH
+         * with any RTP-Info, or FLUSHBUFFERED — is what produces the audible
+         * noise burst on Apple receivers. */
+        LOG_INFO("[AP2] splice flush: keeping the receiver queue "
+                 "(head seq=%u rtptime=%u)",
+                 (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
+        return true;
+    }
     char hdr[64];
     snprintf(hdr, sizeof(hdr), "RTP-Info: seq=%u;rtptime=%u\r\n",
              (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
@@ -2438,6 +2496,40 @@ bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms)
     }
 
     if (atomic_load(&p->rtsp_dead)) return false;
+    if (p->splice_timeline && p->rt_anchor_valid) {
+        /* Splice resume: the anchor line frozen at the first START is
+         * immutable for the whole session — a line move under a live receiver
+         * is one of the measured noise triggers. The commanded start instead
+         * selects the splice point ON that line: stamps skip forward (never
+         * backward, and the sequence stays contiguous, so the receiver sees a
+         * content edit rather than packet loss) to the commanded instant and
+         * the skipped span renders as silence. Every member of a sync group
+         * is handed the same instant, so a group splices sample-aligned by
+         * construction. A start at or behind the current head splices at the
+         * head: the old queue (at most the pacing depth) plays out and the
+         * new content follows seamlessly. A resume after a long park lands
+         * the same way — the skip re-times the next frame to the commanded
+         * instant, so frames are never late (the remaining noise trigger). */
+        uint64_t target = NTP2TS(commanded_start_ntp(start_unix_ms),
+                                 p->format.sample_rate);
+        if (target > p->head_ts) {
+            uint64_t skip = target - p->head_ts;
+            LOG_INFO("[AP2] splice resume: skipping %" PRIu64 " frames "
+                     "(%" PRIu64 " ms) to the commanded start",
+                     skip, skip * 1000ULL / p->format.sample_rate);
+            p->head_ts = target;
+            p->rtp_timestamp = (uint32_t)(p->rtp_timestamp + skip);
+        } else {
+            LOG_INFO("[AP2] splice resume at head (seq=%u rtptime=%u)",
+                     (unsigned)p->seq_number, (unsigned)p->rtp_timestamp);
+        }
+        /* A commanded start zeroes the drift baseline on both sides (MA
+         * resets its accumulated shift on START). */
+        p->reanchor_shifted_frames = 0;
+        p->state = AP2_STREAMING;
+        atomic_store(&p->media_healthy, true);
+        return true;
+    }
     uint64_t start_ntp = commanded_start_ntp(start_unix_ms);
     /* Re-base the frozen line: head_ts moves in the scheduling domain, the
      * wire timestamp follows it plus the per-process offset, and the next
@@ -2484,7 +2576,19 @@ ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample,
 
 static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
 {
-    return p->dev_latency_max > 11025 ? p->dev_latency_max - 11025 : 77175;
+    uint64_t window =
+        p->dev_latency_max > 11025 ? p->dev_latency_max - 11025 : 77175;
+    /* The splice timeline keeps the receiver queue shallow: with warm
+     * boundaries expressed as content splices on one immutable line, the
+     * queue depth IS the audible latency of every seek/next. Apple receivers
+     * are the LAN-local targets owntone has fed at realtime pacing for years,
+     * so the reduced dropout headroom is field-proven there. */
+    if (p->splice_timeline) {
+        uint64_t depth = (uint64_t)MS2TS(AP2_SPLICE_PACING_MS,
+                                         p->format.sample_rate);
+        return depth < window ? depth : window;
+    }
+    return window;
 }
 
 bool ap2cl_accept_frames(struct ap2cl_s *p)
@@ -2522,6 +2626,33 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p)
     uint64_t window = ap2_pacing_window_frames(p);
     uint64_t latency = MS2TS(p->latency_ms, p->format.sample_rate);
     uint64_t recovery_lead = latency < window ? latency : window;
+
+    if (p->splice_timeline) {
+        /* Splice recovery, same immutable-line rule as seek/resume: when the
+         * input stalls long enough that the head falls inside the minimum
+         * lead, skip stamps forward so the resuming audio is never late; the
+         * receiver renders the skipped span as silence. Playback shifts later
+         * by the skip, reported as REANCHOR exactly like the stock path so MA
+         * keeps tracking the drift; the anchor line and the wire offset are
+         * untouched, so no sync re-announce is needed (the measured noise
+         * trigger on Apple receivers). */
+        if (p->head_ts > now_ts + floor) return false;
+        uint64_t target = now_ts + recovery_lead;
+        uint64_t skip = target - p->head_ts;
+        p->head_ts = target;
+        p->rtp_timestamp = (uint32_t)(p->rtp_timestamp + skip);
+        p->timeline_reanchors++;
+        p->reanchor_shifted_frames += skip;
+        LOG_WARN("[AP2] Splice-skipped after PCM starvation: shifted_frames="
+                 "%" PRIu64 " lead_frames=%" PRIu64 " count=%" PRIu64,
+                 skip, recovery_lead, p->timeline_reanchors);
+        fprintf(stderr, "[STATUS] REANCHOR shifted_frames=%" PRIu64
+                " total_shifted_frames=%" PRIu64 " sample_rate=%d\n",
+                skip, p->reanchor_shifted_frames, p->format.sample_rate);
+        fflush(stderr);
+        return true;
+    }
+
     ap2_timeline_recovery_t recovery;
     if (!ap2_timeline_plan_recovery(
             p->head_ts, p->rtp_timestamp, atomic_load(&p->rtp_offset),
@@ -2580,7 +2711,10 @@ void ap2cl_pause(struct ap2cl_s *p)
 {
     if (!p) return;
     if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
-    p->rt_anchor_valid = false;    /* resume re-anchors on a fresh line */
+    /* Splice mode: the immutable line must survive the pause — the un-pause
+     * skips stamps forward on it. Elsewhere resume re-anchors a fresh line. */
+    if (!p->splice_timeline)
+        p->rt_anchor_valid = false;
     p->state = AP2_PAUSED;
     ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_PAUSED, true);
 }
@@ -2592,6 +2726,22 @@ void ap2cl_play(struct ap2cl_s *p)
         int lat = raopcl_latency(p->raopcl);
         uint64_t now = raopcl_get_ntp(NULL);
         raopcl_start_at(p->raopcl, now + MS2NTP(200) - TS2NTP(lat, raopcl_sample_rate(p->raopcl)));
+    }
+    if (p->flow == FLOW_NATIVE_AP2 && p->splice_timeline &&
+        p->rt_anchor_valid) {
+        /* Un-pause on the frozen line: the paused wall time is never sent, so
+         * skip stamps to now plus the minimum lead — otherwise every frame
+         * after the pause would deliver late (a measured noise trigger). */
+        uint64_t target =
+            NTP2TS(raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS),
+                   p->format.sample_rate);
+        if (target > p->head_ts) {
+            uint64_t skip = target - p->head_ts;
+            LOG_INFO("[AP2] splice un-pause: skipping %" PRIu64 " frames",
+                     skip);
+            p->head_ts = target;
+            p->rtp_timestamp = (uint32_t)(p->rtp_timestamp + skip);
+        }
     }
     p->state = AP2_STREAMING;
     ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_PLAYING, true);
@@ -3163,6 +3313,26 @@ void ap2cl_latency_info(struct ap2cl_s *p, int *lead_ms, uint32_t *dev_min, uint
     if (dev_max) *dev_max = p ? p->dev_latency_max : 0;
 }
 
+/* Frames between the delivery head and the audible position, for elapsed
+ * reporting. On the splice timeline delivery runs one shallow pacing window
+ * ahead of audibility; the stock path keeps the historical latency lead. */
+uint32_t ap2cl_audible_lag_frames(struct ap2cl_s *p)
+{
+    if (!p) return 0;
+    if (p->flow == FLOW_NATIVE_AP2 && p->splice_timeline)
+        return (uint32_t)ap2_pacing_window_frames(p);
+    return (uint32_t)MS2TS(p->latency_ms, p->format.sample_rate);
+}
+
+/* Minimum lead (ms) a warm commanded START needs for the new content to begin
+ * exactly at the commanded instant: on the splice timeline the receiver's
+ * queued audio (one pacing depth) plays out first, so the caller should
+ * anchor beyond it. 0 = no constraint (stock flush+re-anchor path). */
+int ap2cl_warm_lead_ms(struct ap2cl_s *p)
+{
+    return p && p->splice_timeline ? AP2_SPLICE_PACING_MS : 0;
+}
+
 int ap2cl_render_latency_ms(struct ap2cl_s *p) { return p ? p->dev_render_ms : 0; }
 
 ap2_state_t ap2cl_state(struct ap2cl_s *p) { return p ? p->state : AP2_DOWN; }
@@ -3211,5 +3381,30 @@ bool ap2cl_test_first_packet(struct ap2cl_s *p)
 void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet)
 {
     p->first_packet = first_packet;
+}
+
+void ap2cl_test_set_splice(struct ap2cl_s *p, bool enable)
+{
+    p->splice_timeline = enable;
+}
+
+void ap2cl_test_set_anchor_valid(struct ap2cl_s *p, bool valid)
+{
+    p->rt_anchor_valid = valid;
+}
+
+bool ap2cl_test_anchor_valid(struct ap2cl_s *p)
+{
+    return p->rt_anchor_valid;
+}
+
+uint64_t ap2cl_test_head_ts(struct ap2cl_s *p)
+{
+    return p->head_ts;
+}
+
+uint32_t ap2cl_test_rtp_timestamp(struct ap2cl_s *p)
+{
+    return p->rtp_timestamp;
 }
 #endif

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -327,6 +327,16 @@ void ap2cl_latency_info(struct ap2cl_s *p, int *lead_ms, uint32_t *dev_min, uint
  * aligns with the group. */
 int ap2cl_render_latency_ms(struct ap2cl_s *p);
 
+/* Frames between the delivery head and the audible position (elapsed
+ * reporting): the shallow pacing depth on the Apple splice timeline, the
+ * latency lead otherwise. */
+uint32_t ap2cl_audible_lag_frames(struct ap2cl_s *p);
+
+/* Minimum lead (ms) a warm commanded START needs for exact placement — the
+ * splice timeline's queue depth, 0 when the stock warm path has no
+ * constraint. Surfaced on the [STATUS] latency line for the caller. */
+int ap2cl_warm_lead_ms(struct ap2cl_s *p);
+
 /* Get current state. */
 ap2_state_t ap2cl_state(struct ap2cl_s *p);
 

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -337,6 +337,11 @@ uint32_t ap2cl_audible_lag_frames(struct ap2cl_s *p);
  * constraint. Surfaced on the [STATUS] latency line for the caller. */
 int ap2cl_warm_lead_ms(struct ap2cl_s *p);
 
+/* Audible instant (unix ms) of the current delivery head on the splice
+ * timeline, carried on the flush ack so the caller anchors warm starts beyond
+ * every member's queued audio. 0 = no constraint (not on the splice path). */
+uint64_t ap2cl_splice_head_unix_ms(struct ap2cl_s *p);
+
 /* Get current state. */
 ap2_state_t ap2cl_state(struct ap2cl_s *p);
 

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -342,6 +342,12 @@ int ap2cl_warm_lead_ms(struct ap2cl_s *p);
  * every member's queued audio. 0 = no constraint (not on the splice path). */
 uint64_t ap2cl_splice_head_unix_ms(struct ap2cl_s *p);
 
+/* Silence frames still owed to the wire before the next real sample (splice
+ * timeline): the audio loop prepends them as ordinary encoded chunks so the
+ * bitstream stays contiguous, and consumes the pad as it sends. */
+uint32_t ap2cl_splice_pad_frames(struct ap2cl_s *p);
+void ap2cl_splice_pad_consume(struct ap2cl_s *p, uint32_t frames);
+
 /* Get current state. */
 ap2_state_t ap2cl_state(struct ap2cl_s *p);
 

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -172,9 +172,11 @@ bool ap2cl_connect(struct ap2cl_s *p);
 bool ap2cl_disconnect(struct ap2cl_s *p);
 
 /* Start playback at a commanded unix-epoch millisecond instant. A feasible
- * instant is scheduled exactly; an infeasible one (or 0) is corrected forward
- * to now + the minimum lead. *at_unix_ms always receives the true scheduled
- * instant so the caller can verify and log any correction. */
+ * instant is scheduled exactly; an infeasible nonzero one is corrected
+ * forward to the earliest feasible instant plus one lead of retry slack (the
+ * floor moves with the wall clock), and 0 takes the earliest instant
+ * directly. *at_unix_ms always receives the true scheduled instant so the
+ * caller can verify and log any correction. */
 ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
                                 uint64_t *at_unix_ms);
 
@@ -189,10 +191,10 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
  * ap2cl_resume schedules the next pending sample audible at start_unix_ms
  * under the same contract as ap2cl_start: the splice timeline pads silence up
  * to the instant, the stock path re-bases the frozen anchor onto it, and an
- * infeasible instant is corrected forward to the earliest feasible one (the
- * splice head, or now + the minimum warm lead) with the truth reported in
- * *at_unix_ms — never silently misplaced or refused. A start of 0 picks the
- * earliest instant directly.
+ * infeasible nonzero instant is corrected forward to the earliest feasible
+ * one (the splice head, or now + the minimum warm lead) plus one lead of
+ * retry slack, with the truth reported in *at_unix_ms — never silently
+ * misplaced or refused. A start of 0 picks the earliest instant directly.
  */
 bool ap2cl_flush(struct ap2cl_s *p);
 ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -20,6 +20,7 @@
 
 #include "ap2_io.h"
 #include "ap2_mrp.h"
+#include "ap2_session.h"
 
 struct ap2cl_s;
 
@@ -170,9 +171,12 @@ bool ap2cl_connect(struct ap2cl_s *p);
 /* Disconnect from the device. */
 bool ap2cl_disconnect(struct ap2cl_s *p);
 
-/* Start playback at a commanded unix-epoch millisecond instant. A start of 0
- * or one already in the past is clamped to now + the minimum warm lead. */
-bool ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms);
+/* Start playback at a commanded unix-epoch millisecond instant. A feasible
+ * instant is scheduled exactly; an infeasible one (or 0) is corrected forward
+ * to now + the minimum lead. *at_unix_ms always receives the true scheduled
+ * instant so the caller can verify and log any correction. */
+ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
+                                uint64_t *at_unix_ms);
 
 /*
  * Warm-seek a live session in place. FLUSH then START (below) are the two
@@ -180,14 +184,19 @@ bool ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms);
  *
  * ap2cl_flush discards the receiver's buffered audio (RTSP FLUSH / libraop
  * flush) and stops sending, keeping the session and its sequence/nonce state.
+ * (Splice timeline: no receiver flush; the queue plays out instead.)
  *
- * ap2cl_resume re-bases the frozen timeline so the next written frame is
- * audible at start_unix_ms (unix epoch milliseconds); a start of 0 or one in
- * the past clamps to now + the minimum warm lead, so a new track's first
- * samples can never be clipped.
+ * ap2cl_resume schedules the next pending sample audible at start_unix_ms
+ * under the same contract as ap2cl_start: the splice timeline pads silence up
+ * to the instant, the stock path re-bases the frozen anchor onto it, and an
+ * infeasible instant is corrected forward to the earliest feasible one (the
+ * splice head, or now + the minimum warm lead) with the truth reported in
+ * *at_unix_ms — never silently misplaced or refused. A start of 0 picks the
+ * earliest instant directly.
  */
 bool ap2cl_flush(struct ap2cl_s *p);
-bool ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms);
+ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
+                                 uint64_t *at_unix_ms);
 
 /* Silence the receiver but keep the session warm: discard buffered audio,
  * publish the stopped state, drop to CONNECTED awaiting the next warm flush. */

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -348,6 +348,10 @@ uint64_t ap2cl_splice_head_unix_ms(struct ap2cl_s *p);
 uint32_t ap2cl_splice_pad_frames(struct ap2cl_s *p);
 void ap2cl_splice_pad_consume(struct ap2cl_s *p, uint32_t frames);
 
+/* True while the splice timeline is live on the wire (audio sends legal);
+ * gates the idle-window silence keepalive in the audio loop. */
+bool ap2cl_splice_hot(struct ap2cl_s *p);
+
 /* Get current state. */
 ap2_state_t ap2cl_state(struct ap2cl_s *p);
 

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -390,7 +390,15 @@ bool ap2_session_flush(struct ap2_session_s *s)
     pthread_mutex_unlock(&s->lock);
 
     s->ops.resume(s->ops.transport);
-    emit(s, "[STATUS] flushed");
+    /* The head froze at quiesce and no sends happen while idle-primed, so the
+     * transport's warm-head instant is stable to read after the resume. */
+    uint64_t head_unix_ms = s->ops.warm_head_unix_ms
+        ? s->ops.warm_head_unix_ms(s->ops.transport) : 0;
+    if (head_unix_ms)
+        emit(s, "[STATUS] flushed head_unix_ms=%llu",
+             (unsigned long long)head_unix_ms);
+    else
+        emit(s, "[STATUS] flushed");
     return true;
 }
 

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -394,11 +394,12 @@ bool ap2_session_flush(struct ap2_session_s *s)
     pthread_cond_broadcast(&s->can_read);
     pthread_mutex_unlock(&s->lock);
 
-    s->ops.resume(s->ops.transport);
-    /* The head froze at quiesce and no sends happen while idle-primed, so the
-     * transport's warm-head instant is stable to read after the resume. */
+    /* Capture the warm-head instant while sends are still quiesced: the
+     * splice keepalive may advance the head the moment the transport resumes,
+     * and the ack must report the head this flush actually froze. */
     uint64_t head_unix_ms = s->ops.warm_head_unix_ms
         ? s->ops.warm_head_unix_ms(s->ops.transport) : 0;
+    s->ops.resume(s->ops.transport);
     if (head_unix_ms)
         emit(s, "[STATUS] flushed head_unix_ms=%llu",
              (unsigned long long)head_unix_ms);

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -318,28 +318,33 @@ void ap2_session_destroy(struct ap2_session_s *s)
     free(s);
 }
 
-bool ap2_session_start(struct ap2_session_s *s, uint64_t start_unix_ms)
+ap2_commit_result_t ap2_session_start(struct ap2_session_s *s,
+                                      uint64_t start_unix_ms,
+                                      uint64_t *at_unix_ms)
 {
-    if (!s) return false;
+    if (!s) return AP2_COMMIT_FAILED;
     pthread_mutex_lock(&s->lock);
     bool ended = s->state == AP2_SESSION_ENDED;
     pthread_mutex_unlock(&s->lock);
-    if (ended) return false;
+    if (ended) return AP2_COMMIT_FAILED;
 
     /* Stop the audio loop between chunks, do the transport work, then swap to
      * PLAYING. On the first start commit begins the session; after a FLUSH it
-     * re-bases the frozen anchor. */
+     * re-bases the frozen anchor. The transport corrects an infeasible
+     * instant forward and reports the truth in *at_unix_ms. */
     s->ops.quiesce(s->ops.transport);
-    if (!s->ops.commit(s->ops.transport, start_unix_ms)) {
+    ap2_commit_result_t result =
+        s->ops.commit(s->ops.transport, start_unix_ms, at_unix_ms);
+    if (result != AP2_COMMIT_OK) {
         s->ops.resume(s->ops.transport);
         LOG_ERROR("[SESSION] transport commit failed");
-        return false;
+        return result;
     }
     pthread_mutex_lock(&s->lock);
     if (s->state == AP2_SESSION_ENDED) {
         pthread_mutex_unlock(&s->lock);
         s->ops.resume(s->ops.transport);
-        return false;
+        return AP2_COMMIT_FAILED;
     }
     s->epoch++;
     s->state = AP2_SESSION_PLAYING;
@@ -347,7 +352,7 @@ bool ap2_session_start(struct ap2_session_s *s, uint64_t start_unix_ms)
     pthread_cond_broadcast(&s->can_write);
     pthread_mutex_unlock(&s->lock);
     s->ops.resume(s->ops.transport);
-    return true;
+    return AP2_COMMIT_OK;
 }
 
 bool ap2_session_flush(struct ap2_session_s *s)

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -49,7 +49,12 @@
  *                                       can re-align a group by re-STARTing
  *                                       every member at max(at). requested=0
  *                                       means the transport picked.)
- *   [STATUS] flushed                   (FLUSH completed; stream idle-primed)
+ *   [STATUS] flushed [head_unix_ms=<ms>]
+ *                                      (FLUSH completed; stream idle-primed.
+ *                                       Splice-timeline transports append the
+ *                                       audible instant of the frozen
+ *                                       delivery head as the caller's warm
+ *                                       anchor hint.)
  *   [STATUS] eof                       (input stream ended)
  *   [STATUS] idle_timeout
  *

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -61,15 +61,19 @@ typedef enum {
 struct ap2_session_s;
 
 /*
- * Callbacks the session engine invokes from its own threads. All are required.
- * `commit` performs the START transport work on a LIVE connection: on the first
- * start it begins the session; after a FLUSH it re-bases the timeline so the
- * next written frame is audible at `start_unix_ms` (or now + the minimum warm
- * lead when 0). Returns false when the transport failed terminally (the caller
- * then ends the session so MA can fall back cold). `flush` discards the
- * receiver's buffered audio in place (RTSP FLUSH / libraop flush), keeping the
- * session and timeline continuity; it returns false when the receiver did not
- * accept the flush. The re-anchor happens on the next `commit`.
+ * Callbacks the session engine invokes from its own threads. All are required
+ * except `warm_head_unix_ms`. `commit` performs the START transport work on a
+ * LIVE connection: on the first start it begins the session; after a FLUSH it
+ * re-bases the timeline so the next written frame is audible at
+ * `start_unix_ms` (or now + the minimum warm lead when 0). Returns false when
+ * the transport failed terminally (the caller then ends the session so MA can
+ * fall back cold). `flush` discards the receiver's buffered audio in place
+ * (RTSP FLUSH / libraop flush), keeping the session and timeline continuity;
+ * it returns false when the receiver did not accept the flush. The re-anchor
+ * happens on the next `commit`. `warm_head_unix_ms` (optional) reports the
+ * audible instant of the delivery head frozen by the flush (unix ms; 0 = no
+ * constraint); when nonzero it rides the `[STATUS] flushed` ack so the caller
+ * can anchor the warm START beyond every member's queued audio.
  */
 typedef struct {
     void (*quiesce)(void *transport);    /* pause audio sends across a command */
@@ -78,6 +82,7 @@ typedef struct {
     void (*resume)(void *transport);     /* resume sends after the command */
     void (*stop)(void *transport);       /* silence the receiver, keep session */
     void (*status)(const char *line);    /* emit one [STATUS] line */
+    uint64_t (*warm_head_unix_ms)(void *transport);  /* optional (may be NULL) */
     void *transport;
 } ap2_session_ops_t;
 

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -9,11 +9,15 @@
  *
  * One reader thread drains the input fd into one ring buffer for the whole
  * session. The audio loop only ever calls ap2_session_read()/poll(). Start
- * times are COMMANDED: playback (and each warm re-anchor) begins on an explicit
- * START, so the caller picks the audible instant once the expensive work has
- * already succeeded, and a group start is simply the same START_UNIX_MS sent to
- * every member. Starts of 0 or in the past clamp to now + the minimum warm
- * lead (enforced by the transport commit callback).
+ * times are COMMANDED and VERIFIED: playback (and each warm re-anchor)
+ * begins on an explicit START, and the transport is the sole authority on
+ * which instants are feasible. A feasible START_UNIX_MS is scheduled EXACTLY
+ * (inserting silence as the lane requires); an infeasible one is corrected
+ * FORWARD to the earliest feasible instant — audio always flows, never
+ * silently misplaced or refused — and the ack reports the true instant so
+ * the caller can verify, log, and re-align a group by re-STARTing every
+ * member at the largest reported instant. START_UNIX_MS=0 means "as soon as
+ * possible": the transport picks and the ack reports the pick.
  *
  *   START(start time)  -> first call: full session start; a call after a FLUSH
  *                         re-bases the frozen anchor and resumes from the ring
@@ -36,6 +40,15 @@
  *
  * Status lines (stderr):
  *   [STATUS] playing elapsed_ms=<ms>   (elapsed since the current START anchor)
+ *   [STATUS] started requested_unix_ms=<ms> at_unix_ms=<ms>
+ *                                      (START scheduled; at == requested when
+ *                                       the instant was feasible, the
+ *                                       corrected-forward earliest instant
+ *                                       otherwise — the caller compares the
+ *                                       two, logs any mismatch loudly, and
+ *                                       can re-align a group by re-STARTing
+ *                                       every member at max(at). requested=0
+ *                                       means the transport picked.)
  *   [STATUS] flushed                   (FLUSH completed; stream idle-primed)
  *   [STATUS] eof                       (input stream ended)
  *   [STATUS] idle_timeout
@@ -60,25 +73,37 @@ typedef enum {
 
 struct ap2_session_s;
 
+/* Outcome of a commanded START at the transport. */
+typedef enum {
+    AP2_COMMIT_OK = 0,        /* scheduled; *at_unix_ms holds the instant */
+    AP2_COMMIT_FAILED,        /* terminal transport failure */
+} ap2_commit_result_t;
+
 /*
  * Callbacks the session engine invokes from its own threads. All are required
  * except `warm_head_unix_ms`. `commit` performs the START transport work on a
  * LIVE connection: on the first start it begins the session; after a FLUSH it
- * re-bases the timeline so the next written frame is audible at
- * `start_unix_ms` (or now + the minimum warm lead when 0). Returns false when
- * the transport failed terminally (the caller then ends the session so MA can
+ * re-bases the timeline. The commanded instant is honored exactly when
+ * feasible (padding silence or re-anchoring as the transport's lane
+ * requires); an instant the transport cannot honor — behind its feasibility
+ * floor — is CORRECTED FORWARD to the earliest feasible instant instead of
+ * being silently played wrong or refused: audio always flows, and
+ * *at_unix_ms always reports the true scheduled instant so the caller can
+ * verify the contract, re-align a group with a corrective START, and log the
+ * mismatch. A `start_unix_ms` of 0 asks the transport to pick (earliest).
+ * AP2_COMMIT_FAILED is terminal (the caller then ends the session so MA can
  * fall back cold). `flush` discards the receiver's buffered audio in place
  * (RTSP FLUSH / libraop flush), keeping the session and timeline continuity;
- * it returns false when the receiver did not accept the flush. The re-anchor
- * happens on the next `commit`. `warm_head_unix_ms` (optional) reports the
- * audible instant of the delivery head frozen by the flush (unix ms; 0 = no
- * constraint); when nonzero it rides the `[STATUS] flushed` ack so the caller
- * can anchor the warm START beyond every member's queued audio.
+ * it returns false when the receiver did not accept the flush.
+ * `warm_head_unix_ms` (optional) reports the audible instant of the delivery
+ * head frozen by the flush (unix ms; 0 = no constraint); it rides the
+ * `[STATUS] flushed` ack as the caller's anchor hint.
  */
 typedef struct {
     void (*quiesce)(void *transport);    /* pause audio sends across a command */
     bool (*flush)(void *transport);      /* RTSP-flush receiver, keep session */
-    bool (*commit)(void *transport, uint64_t start_unix_ms);
+    ap2_commit_result_t (*commit)(void *transport, uint64_t start_unix_ms,
+                                  uint64_t *at_unix_ms);
     void (*resume)(void *transport);     /* resume sends after the command */
     void (*stop)(void *transport);       /* silence the receiver, keep session */
     void (*status)(const char *line);    /* emit one [STATUS] line */
@@ -106,8 +131,13 @@ struct ap2_session_s *ap2_session_create(const ap2_session_ops_t *ops,
 void ap2_session_destroy(struct ap2_session_s *s);
 
 /* Command-pipe entry points, serialized by the single cmdpipe thread. Invalid
- * transitions are rejected with a [STATUS]/log line and return false. */
-bool ap2_session_start(struct ap2_session_s *s, uint64_t start_unix_ms);
+ * transitions are rejected with a [STATUS]/log line and return false.
+ * `start` forwards the commit outcome: on AP2_COMMIT_OK *at_unix_ms holds the
+ * true scheduled audible instant (the commanded one, or the corrected-forward
+ * earliest feasible instant — the caller compares and reacts). */
+ap2_commit_result_t ap2_session_start(struct ap2_session_s *s,
+                                      uint64_t start_unix_ms,
+                                      uint64_t *at_unix_ms);
 bool ap2_session_flush(struct ap2_session_s *s);
 bool ap2_session_standby(struct ap2_session_s *s);
 void ap2_session_end(struct ap2_session_s *s);

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -1022,9 +1022,13 @@ static int run_airplay2(cli_config_t *cfg)
         int lead_ms = 0;
         uint32_t dev_min = 0, dev_max = 0;
         ap2cl_latency_info(g_ap2cl, &lead_ms, &dev_min, &dev_max);
+        /* warm_lead_ms: minimum lead a warm commanded START needs for exact
+         * placement on the splice timeline (0 = no constraint). MA anchors
+         * group seeks beyond the largest member value. */
         printf("[STATUS] latency lead_ms=%d device_min_frames=%u device_max_frames=%u "
-               "device_render_ms=%d\n",
-               lead_ms, dev_min, dev_max, ap2cl_render_latency_ms(g_ap2cl));
+               "device_render_ms=%d warm_lead_ms=%d\n",
+               lead_ms, dev_min, dev_max, ap2cl_render_latency_ms(g_ap2cl),
+               ap2cl_warm_lead_ms(g_ap2cl));
         fflush(stdout);
     }
 
@@ -1096,7 +1100,9 @@ static int run_airplay2(cli_config_t *cfg)
            emitting a "playing" status that would revive the sender's play state) */
         if (g_status == STATUS_PLAYING && !input_ended && now - last > MS2NTP(1000)) {
             last = now;
-            uint32_t latency_frames = MS2TS(cfg->latency_ms, cfg->sample_rate);
+            /* Delivery runs ahead of audibility by the pacing depth (shallow
+             * on the splice timeline, the latency lead otherwise). */
+            uint32_t latency_frames = ap2cl_audible_lag_frames(g_ap2cl);
             if (frames > latency_frames) {
                 uint32_t elapsed = TS2MS(frames - latency_frames, cfg->sample_rate);
                 status_playing(elapsed);
@@ -1147,6 +1153,15 @@ static int run_airplay2(cli_config_t *cfg)
                 continue;
             }
             if (n == 0) {
+                /* A zero read while idle-primed (post-FLUSH awaiting START) or
+                 * in standby is by design, not starvation: the timeline is
+                 * frozen and a recovery re-anchor here would announce anchor
+                 * jumps to a receiver still rendering its buffered audio. Only
+                 * a stall of a genuinely playing stream is an input gap. */
+                if (ap2_session_state(g_session) != AP2_SESSION_PLAYING) {
+                    pthread_mutex_unlock(&g_audio_send_lock);
+                    continue;
+                }
                 if (!starving) {
                     starving = true;
                     starvation_started = raopcl_get_ntp(NULL);

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -1230,7 +1230,42 @@ static int run_airplay2(cli_config_t *cfg)
             frames += af - (int)pad_frames_now;
             pthread_mutex_unlock(&g_audio_send_lock);
         } else {
-            /* Paused, or connected and awaiting the commanded first START. */
+            /* Paused, or connected and awaiting the commanded first START.
+             * On the splice timeline the idle-primed window between a FLUSH
+             * and the next START keeps sending silence: if the wire went
+             * quiet here, a slow next-track spin-up would lapse the line and
+             * force a fresh re-anchor — an audible noise trigger on Apple
+             * receivers (the track-transition blip). Contiguous silence keeps
+             * every boundary a hot splice; the resume pad still lands the new
+             * content on the commanded instant. Pause and standby park the
+             * client out of AP2_STREAMING, so they drain as before. */
+            if (g_first_start_done && cfg->protocol == PROTO_AIRPLAY2 &&
+                ap2_session_state(g_session) == AP2_SESSION_IDLE &&
+                ap2cl_splice_hot(g_ap2cl)) {
+                pthread_mutex_lock(&g_audio_send_lock);
+                if (ap2_session_state(g_session) == AP2_SESSION_IDLE &&
+                    ap2cl_splice_hot(g_ap2cl) &&
+                    ap2cl_accept_frames(g_ap2cl)) {
+                    memset(buf, 0,
+                           (size_t)AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
+                    uint8_t *send = buf;
+                    if (ap2_alac_buf && cfg->bit_depth > 16) {
+                        truncate_32to24(
+                            buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf,
+                            ap2_alac_buf);
+                        send = ap2_alac_buf;
+                    }
+                    if (ap2cl_send_chunk(g_ap2cl, send,
+                                         AP2_FRAMES_PER_CHUNK) ==
+                        AP2_SEND_FATAL) {
+                        status_error("AirPlay 2 realtime send failed");
+                        playback_failed = true;
+                        pthread_mutex_unlock(&g_audio_send_lock);
+                        break;
+                    }
+                }
+                pthread_mutex_unlock(&g_audio_send_lock);
+            }
             usleep(1000);
         }
     }

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -420,8 +420,21 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
     } else if (strcmp(key, "START_UNIX_MS") == 0) {
         g_pend_start_unix_ms = strtoull(value, NULL, 10);
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "START") == 0) {
-        if (!g_session || !ap2_session_start(g_session, g_pend_start_unix_ms))
+        /* The verified start contract: the ack always reports the true
+         * scheduled instant, so the caller compares it with the request,
+         * logs any correction loudly, and re-aligns a group by re-STARTing
+         * every member at the largest reported instant. */
+        uint64_t at_ms = 0;
+        ap2_commit_result_t started = g_session
+            ? ap2_session_start(g_session, g_pend_start_unix_ms, &at_ms)
+            : AP2_COMMIT_FAILED;
+        if (started == AP2_COMMIT_OK) {
+            status_print("[STATUS] started requested_unix_ms=%" PRIu64
+                         " at_unix_ms=%" PRIu64,
+                         g_pend_start_unix_ms, at_ms);
+        } else {
             status_error("START failed");
+        }
         g_pend_start_unix_ms = 0;
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "FLUSH") == 0) {
         if (!g_session || !ap2_session_flush(g_session))
@@ -508,32 +521,36 @@ static void send_initial_metadata(const cli_config_t *cfg)
 
 /* ---- Session engine transport callbacks ---- */
 
-static bool session_commit(void *transport, uint64_t start_unix_ms)
+static ap2_commit_result_t session_commit(void *transport,
+                                          uint64_t start_unix_ms,
+                                          uint64_t *at_unix_ms)
 {
     cli_config_t *cfg = transport;
-    bool committed;
+    ap2_commit_result_t committed;
     /* The first START begins the session; a START after a FLUSH re-anchors the
-     * flushed stream (no second receiver flush, no crypto/sequence reset). */
+     * flushed stream (no second receiver flush, no crypto/sequence reset). An
+     * infeasible instant is corrected forward by the transport, which reports
+     * the true scheduled instant so the ack can carry it to the caller. */
     if (cfg->protocol == PROTO_RAOP) {
         struct raopcl_s *client = g_raopcl;
-        if (!client) return false;
+        if (!client) return AP2_COMMIT_FAILED;
         committed = !g_first_start_done
-            ? raop_session_commit(client, start_unix_ms)
-            : raop_session_start_at(client, start_unix_ms);
+            ? raop_session_commit(client, start_unix_ms, at_unix_ms)
+            : raop_session_start_at(client, start_unix_ms, at_unix_ms);
     } else {
         struct ap2cl_s *client = g_ap2cl;
-        if (!client) return false;
+        if (!client) return AP2_COMMIT_FAILED;
         committed = !g_first_start_done
-            ? ap2cl_start(client, start_unix_ms)
-            : ap2cl_resume(client, start_unix_ms);
+            ? ap2cl_start(client, start_unix_ms, at_unix_ms)
+            : ap2cl_resume(client, start_unix_ms, at_unix_ms);
     }
-    if (!committed) return false;
+    if (committed != AP2_COMMIT_OK) return committed;
 
     /* Metadata-gated receivers must receive a placeholder before audio. */
     if (!g_first_start_done) send_initial_metadata(cfg);
     g_first_start_done = true;
     g_status = STATUS_PLAYING;
-    return true;
+    return AP2_COMMIT_OK;
 }
 
 /* Discard the receiver's buffered audio in place for a warm seek and mark the

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -1149,49 +1149,66 @@ static int run_airplay2(cli_config_t *cfg)
                 eof_reported = false;
                 eof_time = 0;
             }
-            int n = ap2_session_read(
-                g_session, buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf, 250);
-            if (n == -2) {
-                pthread_mutex_unlock(&g_audio_send_lock);
-                break;
-            }
-            if (n == -1) {
-                LOG_INFO("End of AirPlay 2 input stream, draining buffer...");
-                input_ended = true;
-                eof_time = raopcl_get_ntp(NULL);
-                pthread_mutex_unlock(&g_audio_send_lock);
-                continue;
-            }
-            if (n == 0) {
-                /* A zero read while idle-primed (post-FLUSH awaiting START) or
-                 * in standby is by design, not starvation: the timeline is
-                 * frozen and a recovery re-anchor here would announce anchor
-                 * jumps to a receiver still rendering its buffered audio. Only
-                 * a stall of a genuinely playing stream is an input gap. */
-                if (ap2_session_state(g_session) != AP2_SESSION_PLAYING) {
+            /* Splice pad (Apple splice timeline): silence owed to the wire
+             * before the next real sample, sent as ordinary encoded chunks so
+             * sequence numbers and timestamps stay contiguous (any stamp jump
+             * is an audible noise burst). A partial pad occupies the head of
+             * the chunk and the first real samples complete it, so the splice
+             * lands sample-exact on the commanded instant. */
+            uint32_t pad = ap2cl_splice_pad_frames(g_ap2cl);
+            uint32_t pad_frames_now = pad < AP2_FRAMES_PER_CHUNK
+                                          ? pad : AP2_FRAMES_PER_CHUNK;
+            int pad_bytes = (int)pad_frames_now * ap2_input_bpf;
+            int want = AP2_FRAMES_PER_CHUNK * ap2_input_bpf - pad_bytes;
+            int n = 0;
+            if (want > 0) {
+                n = ap2_session_read(g_session, buf + pad_bytes, want, 250);
+                if (n == -2) {
+                    pthread_mutex_unlock(&g_audio_send_lock);
+                    break;
+                }
+                if (n == -1) {
+                    LOG_INFO("End of AirPlay 2 input stream, draining buffer...");
+                    input_ended = true;
+                    eof_time = raopcl_get_ntp(NULL);
                     pthread_mutex_unlock(&g_audio_send_lock);
                     continue;
                 }
-                if (!starving) {
-                    starving = true;
-                    starvation_started = raopcl_get_ntp(NULL);
-                    LOG_WARN("[AP2] PCM input starved; waiting in 250 ms intervals");
-                    ap2cl_log_diagnostics(g_ap2cl);
+                if (n == 0) {
+                    /* A zero read while idle-primed (post-FLUSH awaiting
+                     * START) or in standby is by design, not starvation: the
+                     * timeline is frozen and a recovery re-anchor here would
+                     * announce anchor jumps to a receiver still rendering its
+                     * buffered audio. Only a stall of a genuinely playing
+                     * stream is an input gap. */
+                    if (ap2_session_state(g_session) != AP2_SESSION_PLAYING) {
+                        pthread_mutex_unlock(&g_audio_send_lock);
+                        continue;
+                    }
+                    if (!starving) {
+                        starving = true;
+                        starvation_started = raopcl_get_ntp(NULL);
+                        LOG_WARN("[AP2] PCM input starved; waiting in 250 ms intervals");
+                        ap2cl_log_diagnostics(g_ap2cl);
+                    }
+                    ap2cl_recover_input_gap(g_ap2cl);
+                    pthread_mutex_unlock(&g_audio_send_lock);
+                    continue;
                 }
-                ap2cl_recover_input_gap(g_ap2cl);
-                pthread_mutex_unlock(&g_audio_send_lock);
-                continue;
+                if (starving) {
+                    uint32_t stalled_ms =
+                        (uint32_t)NTP2MS(raopcl_get_ntp(NULL) -
+                                         starvation_started);
+                    LOG_INFO("[AP2] PCM input recovered after %u ms", stalled_ms);
+                    ap2cl_log_diagnostics(g_ap2cl);
+                    starving = false;
+                }
             }
+            if (pad_bytes)
+                memset(buf, 0, (size_t)pad_bytes);
             n = pad_final_pcm_chunk(
-                buf, n, AP2_FRAMES_PER_CHUNK * ap2_input_bpf, ap2_input_bpf);
-            if (starving) {
-                uint32_t stalled_ms =
-                    (uint32_t)NTP2MS(raopcl_get_ntp(NULL) -
-                                     starvation_started);
-                LOG_INFO("[AP2] PCM input recovered after %u ms", stalled_ms);
-                ap2cl_log_diagnostics(g_ap2cl);
-                starving = false;
-            }
+                buf, pad_bytes + n, AP2_FRAMES_PER_CHUNK * ap2_input_bpf,
+                ap2_input_bpf);
 
             int af = n / ap2_input_bpf;
             uint8_t *send = buf;
@@ -1207,7 +1224,10 @@ static int run_airplay2(cli_config_t *cfg)
                 pthread_mutex_unlock(&g_audio_send_lock);
                 break;
             }
-            frames += af;
+            ap2cl_splice_pad_consume(g_ap2cl, pad_frames_now);
+            /* Pad silence is not media content: elapsed counts only the real
+             * samples so the position base stays on the new track's start. */
+            frames += af - (int)pad_frames_now;
             pthread_mutex_unlock(&g_audio_send_lock);
         } else {
             /* Paused, or connected and awaiting the commanded first START. */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -565,6 +565,15 @@ static void session_stop_op(void *transport)
     if (g_status == STATUS_PLAYING) g_status = STATUS_PAUSED;
 }
 
+/* Audible instant of the delivery head frozen by a FLUSH (splice timeline
+ * only): rides the flushed ack so MA anchors the warm START beyond it. */
+static uint64_t session_warm_head_unix_ms(void *transport)
+{
+    cli_config_t *cfg = transport;
+    if (cfg->protocol == PROTO_RAOP) return 0;
+    return g_ap2cl ? ap2cl_splice_head_unix_ms(g_ap2cl) : 0;
+}
+
 static void session_status_line(const char *line)
 {
     status_print("%s", line);
@@ -683,6 +692,7 @@ static bool start_stream_session(cli_config_t *cfg, int input_bpf,
         .resume = session_resume,
         .stop = session_stop_op,
         .status = session_status_line,
+        .warm_head_unix_ms = session_warm_head_unix_ms,
         .transport = cfg,
     };
     g_session = ap2_session_create(

--- a/src/raop_session.c
+++ b/src/raop_session.c
@@ -21,13 +21,19 @@ static uint64_t ntp_to_unix_ms(uint64_t ntp)
 static void resolve_start(uint64_t start_unix_ms, uint64_t *audible_ntp,
                           uint64_t *at_unix_ms)
 {
-    uint64_t floor = raopcl_get_ntp(NULL) +
-                     MS2NTP(RAOP_SESSION_MIN_START_LEAD_MS);
+    uint64_t lead = MS2NTP(RAOP_SESSION_MIN_START_LEAD_MS);
+    uint64_t floor = raopcl_get_ntp(NULL) + lead;
     uint64_t requested = start_unix_ms ? unix_ms_to_ntp(start_unix_ms) : 0;
-    *audible_ntp = requested > floor ? requested : floor;
-    if (at_unix_ms)
-        *at_unix_ms = requested > floor ? start_unix_ms
-                                        : ntp_to_unix_ms(floor);
+    if (requested > floor) {
+        *audible_ntp = requested;
+        if (at_unix_ms) *at_unix_ms = start_unix_ms;
+        return;
+    }
+    /* Corrected forward with one extra lead of slack (the floor moves with
+     * the wall clock, so a corrective retry at a bare floor would chase it);
+     * a request of 0 takes the floor directly. */
+    *audible_ntp = start_unix_ms ? floor + lead : floor;
+    if (at_unix_ms) *at_unix_ms = ntp_to_unix_ms(*audible_ntp);
 }
 
 ap2_commit_result_t raop_session_commit(struct raopcl_s *client,

--- a/src/raop_session.c
+++ b/src/raop_session.c
@@ -4,49 +4,78 @@
 
 #define RAOP_SESSION_MIN_START_LEAD_MS 200
 
-static uint64_t commanded_audible_ntp(uint64_t start_unix_ms)
+static uint64_t unix_ms_to_ntp(uint64_t ms)
 {
-    uint64_t start_ntp = start_unix_ms
-        ? ((start_unix_ms / 1000) << 32) |
-              (((start_unix_ms % 1000) << 32) / 1000)
-        : 0;
-    uint64_t min_start =
-        raopcl_get_ntp(NULL) + MS2NTP(RAOP_SESSION_MIN_START_LEAD_MS);
-    return start_ntp < min_start ? min_start : start_ntp;
+    return ((ms / 1000) << 32) | (((ms % 1000) << 32) / 1000);
 }
 
-bool raop_session_commit(struct raopcl_s *client, uint64_t start_unix_ms)
+static uint64_t ntp_to_unix_ms(uint64_t ntp)
 {
-    if (!client) return false;
+    return (ntp >> 32) * 1000ULL + (((ntp & 0xFFFFFFFFULL) * 1000ULL) >> 32);
+}
+
+/* Resolve a commanded start: a feasible nonzero request is honored exactly; a
+ * request behind the feasibility floor is corrected FORWARD to the floor
+ * (audio always flows), and a request of 0 picks the floor. *at_unix_ms
+ * always receives the true audible instant so the caller can verify. */
+static void resolve_start(uint64_t start_unix_ms, uint64_t *audible_ntp,
+                          uint64_t *at_unix_ms)
+{
+    uint64_t floor = raopcl_get_ntp(NULL) +
+                     MS2NTP(RAOP_SESSION_MIN_START_LEAD_MS);
+    uint64_t requested = start_unix_ms ? unix_ms_to_ntp(start_unix_ms) : 0;
+    *audible_ntp = requested > floor ? requested : floor;
+    if (at_unix_ms)
+        *at_unix_ms = requested > floor ? start_unix_ms
+                                        : ntp_to_unix_ms(floor);
+}
+
+ap2_commit_result_t raop_session_commit(struct raopcl_s *client,
+                                        uint64_t start_unix_ms,
+                                        uint64_t *at_unix_ms)
+{
+    if (!client) return AP2_COMMIT_FAILED;
 
     raop_state_t state = raopcl_state(client);
-    if (state != RAOP_STREAMING && state != RAOP_FLUSHED) return false;
+    if (state != RAOP_STREAMING && state != RAOP_FLUSHED)
+        return AP2_COMMIT_FAILED;
+
+    uint64_t audible_ntp = 0;
+    resolve_start(start_unix_ms, &audible_ntp, at_unix_ms);
+
     /* A commanded (re)start discards the old backlog. pause() would preserve
      * one latency window and replay it before the new track. */
     raopcl_stop(client);
     if (state == RAOP_STREAMING) {
-        if (!raopcl_flush(client)) return false;
+        if (!raopcl_flush(client)) return AP2_COMMIT_FAILED;
     }
 
-    uint64_t audible_ntp = commanded_audible_ntp(start_unix_ms);
     uint64_t latency_ntp =
         TS2NTP(raopcl_latency(client), raopcl_sample_rate(client));
-    return raopcl_start_at(client, audible_ntp - latency_ntp);
+    return raopcl_start_at(client, audible_ntp - latency_ntp)
+               ? AP2_COMMIT_OK
+               : AP2_COMMIT_FAILED;
 }
 
-bool raop_session_start_at(struct raopcl_s *client, uint64_t start_unix_ms)
+ap2_commit_result_t raop_session_start_at(struct raopcl_s *client,
+                                          uint64_t start_unix_ms,
+                                          uint64_t *at_unix_ms)
 {
-    if (!client) return false;
+    if (!client) return AP2_COMMIT_FAILED;
     /* Only valid after a flush (seek/standby): re-anchoring a live stream
      * would replay the receiver's retained backlog against the new timeline.
      * Rejecting STREAMING makes a START without a preceding FLUSH fail fast. */
     raop_state_t state = raopcl_state(client);
-    if (state != RAOP_FLUSHED) return false;
+    if (state != RAOP_FLUSHED) return AP2_COMMIT_FAILED;
 
-    uint64_t audible_ntp = commanded_audible_ntp(start_unix_ms);
+    uint64_t audible_ntp = 0;
+    resolve_start(start_unix_ms, &audible_ntp, at_unix_ms);
+
     uint64_t latency_ntp =
         TS2NTP(raopcl_latency(client), raopcl_sample_rate(client));
-    return raopcl_start_at(client, audible_ntp - latency_ntp);
+    return raopcl_start_at(client, audible_ntp - latency_ntp)
+               ? AP2_COMMIT_OK
+               : AP2_COMMIT_FAILED;
 }
 
 bool raop_session_flush(struct raopcl_s *client)
@@ -80,7 +109,8 @@ bool raop_session_resume(struct raopcl_s *client)
     raop_state_t state = raopcl_state(client);
     if (state != RAOP_FLUSHED && state != RAOP_STREAMING) return false;
 
-    uint64_t audible_ntp = commanded_audible_ntp(0);
+    uint64_t audible_ntp =
+        raopcl_get_ntp(NULL) + MS2NTP(RAOP_SESSION_MIN_START_LEAD_MS);
     uint64_t latency_ntp =
         TS2NTP(raopcl_latency(client), raopcl_sample_rate(client));
     return raopcl_start_at(client, audible_ntp - latency_ntp);

--- a/src/raop_session.c
+++ b/src/raop_session.c
@@ -24,7 +24,7 @@ static void resolve_start(uint64_t start_unix_ms, uint64_t *audible_ntp,
     uint64_t lead = MS2NTP(RAOP_SESSION_MIN_START_LEAD_MS);
     uint64_t floor = raopcl_get_ntp(NULL) + lead;
     uint64_t requested = start_unix_ms ? unix_ms_to_ntp(start_unix_ms) : 0;
-    if (requested > floor) {
+    if (start_unix_ms && requested >= floor) {
         *audible_ntp = requested;
         if (at_unix_ms) *at_unix_ms = start_unix_ms;
         return;

--- a/src/raop_session.h
+++ b/src/raop_session.h
@@ -9,10 +9,11 @@
 struct raopcl_s;
 
 /* Commit the first START on an existing RAOP connection: a feasible audible
- * first-sample unix time is scheduled exactly; an infeasible one (or 0) is
- * corrected forward to now + the minimum RAOP lead, with the true instant
- * reported in *at_unix_ms so the caller can verify and log. A currently
- * streaming stream is flushed before re-anchoring. */
+ * first-sample unix time is scheduled exactly; an infeasible nonzero one is
+ * corrected forward to the earliest feasible instant plus one lead of retry
+ * slack (the floor moves with the wall clock), a 0 takes the floor directly,
+ * and the true instant always lands in *at_unix_ms so the caller can verify
+ * and log. A currently streaming stream is flushed before re-anchoring. */
 ap2_commit_result_t raop_session_commit(struct raopcl_s *client,
                                         uint64_t start_unix_ms,
                                         uint64_t *at_unix_ms);

--- a/src/raop_session.h
+++ b/src/raop_session.h
@@ -4,17 +4,26 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "ap2_session.h"
+
 struct raopcl_s;
 
-/* Commit the first START on an existing RAOP connection. The command carries
- * the audible first-sample unix time; 0 or stale values use a safe ASAP lead. A
- * currently streaming stream is flushed before re-anchoring. */
-bool raop_session_commit(struct raopcl_s *client, uint64_t start_unix_ms);
+/* Commit the first START on an existing RAOP connection: a feasible audible
+ * first-sample unix time is scheduled exactly; an infeasible one (or 0) is
+ * corrected forward to now + the minimum RAOP lead, with the true instant
+ * reported in *at_unix_ms so the caller can verify and log. A currently
+ * streaming stream is flushed before re-anchoring. */
+ap2_commit_result_t raop_session_commit(struct raopcl_s *client,
+                                        uint64_t start_unix_ms,
+                                        uint64_t *at_unix_ms);
 
-/* Re-anchor a flushed stream to a new audible start (the START after a FLUSH).
- * Unlike commit it does not stop/flush again — the receiver buffer was already
- * discarded by raop_session_flush — so no crypto/sequence state is reset. */
-bool raop_session_start_at(struct raopcl_s *client, uint64_t start_unix_ms);
+/* Re-anchor a flushed stream to a new audible start (the START after a FLUSH)
+ * under the same contract. Unlike commit it does not stop/flush again — the
+ * receiver buffer was already discarded by raop_session_flush — so no
+ * crypto/sequence state is reset. */
+ap2_commit_result_t raop_session_start_at(struct raopcl_s *client,
+                                          uint64_t start_unix_ms,
+                                          uint64_t *at_unix_ms);
 
 /* Discard the receiver's buffered audio in place for a warm seek, keeping the
  * connection; the next START re-anchors via raop_session_start_at. */

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "ap2_bplist.h"
@@ -435,17 +436,21 @@ static void test_splice_timeline_warm_path(void)
     /* Warm seek: flush keeps the receiver queue and the anchor line... */
     assert(ap2cl_flush(client));
     assert(ap2cl_test_anchor_valid(client));
-    /* ...and resume skips stamps forward to the commanded instant with the
-     * head/timestamp relation intact (a content edit, not a restart). */
-    assert(ap2cl_resume(client, 0));
+    /* ...and resume never touches the stamps (a jump is an audible noise
+     * burst): the gap to a future commanded instant becomes silence padding
+     * the audio loop sends as ordinary contiguous chunks. */
+    uint64_t start_ms = ((uint64_t)time(NULL) + 3) * 1000ULL;
+    assert(ap2cl_resume(client, start_ms));
     assert(ap2cl_state(client) == AP2_STREAMING);
     assert(ap2cl_test_anchor_valid(client));
     assert(!ap2cl_test_first_packet(client));
-    uint64_t head_after = ap2cl_test_head_ts(client);
-    uint32_t rtp_after = ap2cl_test_rtp_timestamp(client);
-    assert(head_after >= head_before);
-    assert((uint32_t)(rtp_after - rtp_before) ==
-           (uint32_t)(head_after - head_before));
+    assert(ap2cl_test_head_ts(client) == head_before);
+    assert(ap2cl_test_rtp_timestamp(client) == rtp_before);
+    /* ~3 s to the commanded instant at 44.1 kHz, minus the queued head. */
+    uint32_t pad = ap2cl_splice_pad_frames(client);
+    assert(pad > 44100 && pad < 4 * 44100);
+    ap2cl_splice_pad_consume(client, pad);
+    assert(ap2cl_splice_pad_frames(client) == 0);
 
     /* Park: no flush verb either; the line survives for the next resume. */
     ap2cl_standby(client);

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdatomic.h>
@@ -26,6 +27,11 @@ void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd);
 void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p);
 bool ap2cl_test_first_packet(struct ap2cl_s *p);
 void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet);
+void ap2cl_test_set_splice(struct ap2cl_s *p, bool enable);
+void ap2cl_test_set_anchor_valid(struct ap2cl_s *p, bool valid);
+bool ap2cl_test_anchor_valid(struct ap2cl_s *p);
+uint64_t ap2cl_test_head_ts(struct ap2cl_s *p);
+uint32_t ap2cl_test_rtp_timestamp(struct ap2cl_s *p);
 
 typedef struct {
     int fd;
@@ -392,12 +398,80 @@ static void test_route_with_password(void)
     puts("ap2_client route password selection tests passed");
 }
 
+/* The Apple splice timeline never sends a flush verb and never rebases: the
+ * warm boundary is a forward-only stamp skip on one immutable anchor line.
+ * The RTSP socket must stay silent across flush + standby, and resume must
+ * keep the sequence/timestamp relation contiguous. */
+static void test_splice_timeline_warm_path(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    assert(fcntl(sockets[1], F_SETFL, O_NONBLOCK) == 0);
+
+    ap2_device_info_t device = {
+        .name = "splice test",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+    ap2cl_test_set_splice(client, true);
+    assert(ap2cl_start(client, 0));
+    ap2cl_test_set_first_packet(client, false);
+    ap2cl_test_set_anchor_valid(client, true);
+
+    uint64_t head_before = ap2cl_test_head_ts(client);
+    uint32_t rtp_before = ap2cl_test_rtp_timestamp(client);
+
+    /* Warm seek: flush keeps the receiver queue and the anchor line... */
+    assert(ap2cl_flush(client));
+    assert(ap2cl_test_anchor_valid(client));
+    /* ...and resume skips stamps forward to the commanded instant with the
+     * head/timestamp relation intact (a content edit, not a restart). */
+    assert(ap2cl_resume(client, 0));
+    assert(ap2cl_state(client) == AP2_STREAMING);
+    assert(ap2cl_test_anchor_valid(client));
+    assert(!ap2cl_test_first_packet(client));
+    uint64_t head_after = ap2cl_test_head_ts(client);
+    uint32_t rtp_after = ap2cl_test_rtp_timestamp(client);
+    assert(head_after >= head_before);
+    assert((uint32_t)(rtp_after - rtp_before) ==
+           (uint32_t)(head_after - head_before));
+
+    /* Park: no flush verb either; the line survives for the next resume. */
+    ap2cl_standby(client);
+    assert(ap2cl_state(client) == AP2_CONNECTED);
+    assert(ap2cl_test_anchor_valid(client));
+    assert(ap2cl_resume(client, 0));
+    assert(ap2cl_state(client) == AP2_STREAMING);
+
+    /* The whole warm path put nothing on the RTSP socket. */
+    char scratch[16];
+    assert(recv(sockets[1], scratch, sizeof(scratch), 0) == -1);
+    assert(errno == EAGAIN || errno == EWOULDBLOCK);
+
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+}
+
 int main(void)
 {
     test_route_with_password();
     test_info_format_tables();
     test_native_flush_resume_reuses_rtsp_session();
     test_native_flush_rejects_receiver_error();
+    test_splice_timeline_warm_path();
     test_feedback_miss_tolerated_then_recovered();
 
     ap2_device_info_t device = {

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -114,7 +114,7 @@ static void test_native_flush_resume_reuses_rtsp_session(void)
     assert(client);
     ap2cl_force_native(client);
     ap2cl_test_attach_rtsp_socket(client, sockets[0]);
-    assert(ap2cl_start(client, 1700000000000ULL));
+    assert(ap2cl_start(client, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
     /* The test bypasses native connect, so model a completed first send before
      * exercising the warm restart. */
     ap2cl_test_set_first_packet(client, false);
@@ -123,7 +123,7 @@ static void test_native_flush_resume_reuses_rtsp_session(void)
     assert(ap2cl_state(client) == AP2_CONNECTED);
     /* Warm seek: discard the receiver buffer, then re-anchor the timeline. */
     assert(ap2cl_flush(client));
-    assert(ap2cl_resume(client, 1700000005000ULL));
+    assert(ap2cl_resume(client, 1700000005000ULL, NULL) == AP2_COMMIT_OK);
     assert(ap2cl_state(client) == AP2_STREAMING);
     assert(ap2cl_test_first_packet(client));
 
@@ -164,7 +164,7 @@ static void test_native_flush_rejects_receiver_error(void)
     assert(client);
     ap2cl_force_native(client);
     ap2cl_test_attach_rtsp_socket(client, sockets[0]);
-    assert(ap2cl_start(client, 1700000000000ULL));
+    assert(ap2cl_start(client, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
     assert(!ap2cl_flush(client));
 
     assert(pthread_join(peer_thread, NULL) == 0);
@@ -426,7 +426,7 @@ static void test_splice_timeline_warm_path(void)
     ap2cl_force_native(client);
     ap2cl_test_attach_rtsp_socket(client, sockets[0]);
     ap2cl_test_set_splice(client, true);
-    assert(ap2cl_start(client, 0));
+    assert(ap2cl_start(client, 0, NULL) == AP2_COMMIT_OK);
     ap2cl_test_set_first_packet(client, false);
     ap2cl_test_set_anchor_valid(client, true);
 
@@ -440,7 +440,7 @@ static void test_splice_timeline_warm_path(void)
      * burst): the gap to a future commanded instant becomes silence padding
      * the audio loop sends as ordinary contiguous chunks. */
     uint64_t start_ms = ((uint64_t)time(NULL) + 3) * 1000ULL;
-    assert(ap2cl_resume(client, start_ms));
+    assert(ap2cl_resume(client, start_ms, NULL) == AP2_COMMIT_OK);
     assert(ap2cl_state(client) == AP2_STREAMING);
     assert(ap2cl_test_anchor_valid(client));
     assert(!ap2cl_test_first_packet(client));
@@ -456,7 +456,7 @@ static void test_splice_timeline_warm_path(void)
     ap2cl_standby(client);
     assert(ap2cl_state(client) == AP2_CONNECTED);
     assert(ap2cl_test_anchor_valid(client));
-    assert(ap2cl_resume(client, 0));
+    assert(ap2cl_resume(client, 0, NULL) == AP2_COMMIT_OK);
     assert(ap2cl_state(client) == AP2_STREAMING);
 
     /* The whole warm path put nothing on the RTSP socket. */

--- a/tests/test_ap2_raop_lifecycle.c
+++ b/tests/test_ap2_raop_lifecycle.c
@@ -288,7 +288,7 @@ static bool test_standby_reuses_raop_compatible_connection(void)
     CHECK(client != NULL);
     CHECK(ap2cl_connect(client));
     struct raopcl_s *transport_client = &mock.clients[1];
-    CHECK(ap2cl_start(client, 1700000003000ULL));
+    CHECK(ap2cl_start(client, 1700000003000ULL, NULL) == AP2_COMMIT_OK);
     CHECK(ap2cl_state(client) == AP2_STREAMING);
     CHECK(mock.starts == 1);
 
@@ -304,7 +304,7 @@ static bool test_standby_reuses_raop_compatible_connection(void)
      * flush stops the flushed stream again, resume re-arms start-at. No extra
      * receiver flush, so mock.flushes stays 1. */
     CHECK(ap2cl_flush(client));
-    CHECK(ap2cl_resume(client, 1700000008000ULL));
+    CHECK(ap2cl_resume(client, 1700000008000ULL, NULL) == AP2_COMMIT_OK);
     CHECK(ap2cl_state(client) == AP2_STREAMING);
     CHECK(mock.last_transport_client == transport_client);
     CHECK(mock.stops == 2);

--- a/tests/test_ap2_session.c
+++ b/tests/test_ap2_session.c
@@ -32,6 +32,7 @@ typedef struct {
     atomic_int resumes;
     atomic_int stops;
     atomic_int flushed_status;
+    atomic_int flushed_head_status;
     atomic_int audio_status;
     atomic_int idle_timeouts;
     uint64_t last_start_unix_ms;
@@ -74,6 +75,8 @@ static void status(const char *line)
 {
     if (strcmp(line, "[STATUS] flushed") == 0)
         atomic_fetch_add(&status_state->flushed_status, 1);
+    else if (strncmp(line, "[STATUS] flushed head_unix_ms=1785445251000", 43) == 0)
+        atomic_fetch_add(&status_state->flushed_head_status, 1);
     else if (strncmp(line, "[STATUS] audio ", 15) == 0)
         atomic_fetch_add(&status_state->audio_status, 1);
     else if (strcmp(line, "[STATUS] idle_timeout") == 0)
@@ -89,6 +92,7 @@ static void state_init(test_state_t *state)
     atomic_init(&state->resumes, 0);
     atomic_init(&state->stops, 0);
     atomic_init(&state->flushed_status, 0);
+    atomic_init(&state->flushed_head_status, 0);
     atomic_init(&state->audio_status, 0);
     atomic_init(&state->idle_timeouts, 0);
     state->flush_succeeds = true;
@@ -403,9 +407,48 @@ static void test_destroy_is_prompt_with_open_writer(void)
     assert(close(write_fd) == 0);
 }
 
+/* A transport reporting its frozen-head instant gets it onto the flushed ack
+ * (splice members ride it so the caller anchors warm starts beyond the head);
+ * transports without the optional op keep the plain ack. */
+static uint64_t warm_head_fixed(void *transport)
+{
+    (void)transport;
+    return 1785445251000ULL;
+}
+
+static void test_flush_ack_carries_warm_head(void)
+{
+    test_state_t state;
+    state_init(&state);
+    ap2_session_ops_t ops = {
+        .quiesce = quiesce,
+        .flush = flush,
+        .commit = commit,
+        .resume = resume,
+        .stop = stop,
+        .status = status,
+        .warm_head_unix_ms = warm_head_fixed,
+        .transport = &state,
+    };
+    int input[2];
+    assert(pipe(input) == 0);
+    struct ap2_session_s *session =
+        ap2_session_create(&ops, 1000, 1, 0, input[0]);
+    assert(session);
+    assert(close(input[0]) == 0);
+
+    assert(ap2_session_flush(session));
+    assert(atomic_load(&state.flushed_head_status) == 1);
+    assert(atomic_load(&state.flushed_status) == 0);
+
+    ap2_session_destroy(session);
+    assert(close(input[1]) == 0);
+}
+
 int main(void)
 {
     test_start_streams_the_input();
+    test_flush_ack_carries_warm_head();
     test_ready_and_reads_wait_for_a_complete_packet();
     test_short_read_is_released_at_eof();
     test_flush_drains_and_reanchors();

--- a/tests/test_ap2_session.c
+++ b/tests/test_ap2_session.c
@@ -53,12 +53,14 @@ static bool flush(void *transport)
     return state->flush_succeeds;
 }
 
-static bool commit(void *transport, uint64_t start_unix_ms)
+static ap2_commit_result_t commit(void *transport, uint64_t start_unix_ms,
+                                  uint64_t *at_unix_ms)
 {
     test_state_t *state = transport;
     state->last_start_unix_ms = start_unix_ms;
+    if (at_unix_ms) *at_unix_ms = start_unix_ms;
     atomic_fetch_add(&state->commits, 1);
-    return true;
+    return AP2_COMMIT_OK;
 }
 
 static void resume(void *transport)
@@ -178,7 +180,7 @@ static void test_start_streams_the_input(void)
     feed(write_fd, audio, sizeof(audio));
 
     const uint64_t audible = 1770000000123ULL;
-    assert(ap2_session_start(session, audible));
+    assert(ap2_session_start(session, audible, NULL) == AP2_COMMIT_OK);
     assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
     assert(ap2_session_epoch(session) == 1);
     assert(atomic_load(&state.commits) == 1);
@@ -208,7 +210,7 @@ static void test_ready_and_reads_wait_for_a_complete_packet(void)
     feed(write_fd, first + sizeof(first) - 1, 1);
     assert(wait_for_count(&state.audio_status, 1, 1000));
 
-    assert(ap2_session_start(session, 1700000000000ULL));
+    assert(ap2_session_start(session, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
     read_exact(session, first, sizeof(first));
 
     feed(write_fd, second, sizeof(second) - 1);
@@ -233,7 +235,7 @@ static void test_short_read_is_released_at_eof(void)
     feed(write_fd, audio, sizeof(audio));
     assert(close(write_fd) == 0);
     assert(wait_for_count(&state.audio_status, 1, 1000));
-    assert(ap2_session_start(session, 1700000000000ULL));
+    assert(ap2_session_start(session, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
 
     uint8_t got[sizeof(audio) + 1];
     assert(ap2_session_read(session, got, sizeof(got), 1000) ==
@@ -260,7 +262,7 @@ static void test_flush_drains_and_reanchors(void)
     feed(write_fd, old_audio, sizeof(old_audio));
     /* The one-shot audio signal announces the feed is flowing (pre-START). */
     assert(wait_for_count(&state.audio_status, 1, 1000));
-    assert(ap2_session_start(session, 1700000000000ULL));
+    assert(ap2_session_start(session, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
     read_exact(session, old_audio, sizeof(old_audio));
     assert(atomic_load(&state.audio_status) == 1);
 
@@ -282,7 +284,7 @@ static void test_flush_drains_and_reanchors(void)
      * announce themselves again. */
     feed(write_fd, new_audio, sizeof(new_audio));
     assert(wait_for_count(&state.audio_status, 2, 1000));
-    assert(ap2_session_start(session, 1700000005000ULL));
+    assert(ap2_session_start(session, 1700000005000ULL, NULL) == AP2_COMMIT_OK);
     assert(atomic_load(&state.commits) == 2);
     assert(ap2_session_epoch(session) == 2);
     assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
@@ -308,7 +310,7 @@ static void test_flush_while_idle_before_start(void)
 
     static const uint8_t audio[] = {0x01, 0x02, 0x03, 0x04};
     feed(write_fd, audio, sizeof(audio));
-    assert(ap2_session_start(session, 0));
+    assert(ap2_session_start(session, 0, NULL) == AP2_COMMIT_OK);
     read_exact(session, audio, sizeof(audio));
 
     ap2_session_destroy(session);
@@ -325,7 +327,7 @@ static void test_failed_flush_preserves_pending_audio(void)
 
     feed(write_fd, audio, sizeof(audio));
     assert(wait_for_count(&state.audio_status, 1, 1000));
-    assert(ap2_session_start(session, 1700000000000ULL));
+    assert(ap2_session_start(session, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
     state.flush_succeeds = false;
 
     assert(!ap2_session_flush(session));
@@ -349,7 +351,7 @@ static void test_standby_then_resume(void)
     struct ap2_session_s *session = create_session(&state, 0, &write_fd);
 
     feed(write_fd, audio, sizeof(audio));
-    assert(ap2_session_start(session, 1700000000000ULL));
+    assert(ap2_session_start(session, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
     read_exact(session, audio, sizeof(audio));
 
     assert(ap2_session_standby(session));
@@ -358,7 +360,7 @@ static void test_standby_then_resume(void)
 
     static const uint8_t more[] = {0x30, 0x31, 0x32};
     feed(write_fd, more, sizeof(more));
-    assert(ap2_session_start(session, 1700000005000ULL));
+    assert(ap2_session_start(session, 1700000005000ULL, NULL) == AP2_COMMIT_OK);
     assert(atomic_load(&state.commits) == 2);
     assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
     read_exact(session, more, sizeof(more));
@@ -397,7 +399,7 @@ static void test_destroy_is_prompt_with_open_writer(void)
 
     static const uint8_t audio[] = {0x40, 0x41};
     feed(write_fd, audio, sizeof(audio));
-    assert(ap2_session_start(session, 1700000000000ULL));
+    assert(ap2_session_start(session, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
     read_exact(session, audio, sizeof(audio));
 
     uint64_t started = ap2_io_monotonic_ms();

--- a/tests/test_raop_session.c
+++ b/tests/test_raop_session.c
@@ -98,7 +98,7 @@ int main(void)
     mock_now = unix_ms_to_ntp(now_ms);
     reset_mocks();
 
-    assert(raop_session_commit(&client, future_ms));
+    assert(raop_session_commit(&client, future_ms, NULL) == AP2_COMMIT_OK);
     assert(last_client == &client);
     assert(pause_calls == 0);
     assert(stop_calls == 1);
@@ -109,7 +109,7 @@ int main(void)
 
     client.state = RAOP_STREAMING;
     const uint64_t replacement_ms = future_ms + 5000;
-    assert(raop_session_commit(&client, replacement_ms));
+    assert(raop_session_commit(&client, replacement_ms, NULL) == AP2_COMMIT_OK);
     assert(last_client == &client);
     assert(pause_calls == 0);
     assert(stop_calls == 2);
@@ -119,7 +119,7 @@ int main(void)
            unix_ms_to_ntp(replacement_ms));
 
     client.state = RAOP_FLUSHED;
-    assert(raop_session_commit(&client, 0));
+    assert(raop_session_commit(&client, 0, NULL) == AP2_COMMIT_OK);
     assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
            mock_now + MS2NTP(200));
 
@@ -136,7 +136,7 @@ int main(void)
     /* Standby keeps the same connected libraop client reusable. A later
      * commanded START only re-anchors it; no reconnect API is involved. */
     const uint64_t post_standby_ms = replacement_ms + 5000;
-    assert(raop_session_commit(&client, post_standby_ms));
+    assert(raop_session_commit(&client, post_standby_ms, NULL) == AP2_COMMIT_OK);
     assert(last_client == &client);
     assert(start_calls == 4);
     assert(last_start + TS2NTP(client.latency, client.sample_rate) ==
@@ -170,7 +170,7 @@ int main(void)
     reset_mocks();
     client.state = RAOP_FLUSHED;
     const uint64_t resume_ms = 1700000123000ULL;
-    assert(raop_session_start_at(&client, resume_ms));
+    assert(raop_session_start_at(&client, resume_ms, NULL) == AP2_COMMIT_OK);
     assert(stop_calls == 0);
     assert(flush_calls == 0);
     assert(start_calls == 1);
@@ -181,14 +181,14 @@ int main(void)
      * stream would replay the receiver backlog against the new timeline. */
     reset_mocks();
     client.state = RAOP_STREAMING;
-    assert(!raop_session_start_at(&client, resume_ms));
+    assert(raop_session_start_at(&client, resume_ms, NULL) != AP2_COMMIT_OK);
     assert(start_calls == 0);
 
     client.state = RAOP_DOWN;
-    assert(!raop_session_commit(&client, future_ms));
+    assert(raop_session_commit(&client, future_ms, NULL) != AP2_COMMIT_OK);
     assert(!raop_session_standby(&client));
     assert(!raop_session_flush(&client));
-    assert(!raop_session_start_at(&client, future_ms));
+    assert(raop_session_start_at(&client, future_ms, NULL) != AP2_COMMIT_OK);
     assert(!raop_session_pause(&client));
     assert(!raop_session_resume(&client));
 


### PR DESCRIPTION
Apple receivers (Apple TV, HomePod) produced a short burst of static noise whenever playback was seeked, skipped to the next track, paused or stopped mid-song (reported in music-assistant/support#5386). Hardware testing showed these devices emit the burst whenever the audio stream is interrupted in any way — every flush, re-anchor or timestamp jump is audible.

Playback to Apple devices now never interrupts the stream: seeks and track changes are spliced in seamlessly, with silence filling the gap so the new audio begins at exactly the commanded moment. Start commands are also verified end to end, which keeps sync groups tightly aligned.

- Apple devices get a "splice" playback timeline: seek, next track, pause and stop no longer interrupt the audio stream (the cause of the noise)
- Gaps up to the commanded start are filled with silence, so new audio lands sample-exact on every member of a sync group
- Every start command is acknowledged with the true start instant; a start the player cannot honor is corrected forward and reported instead of silently shifted
- A keepalive keeps the stream alive between tracks, so a slow-loading next track can no longer cause noise
- A re-timed start on an already-playing stream now discards stale audio first, fixing a lingering group sync offset
- Non-Apple receivers keep the current behavior for now; converging them onto the same mechanism is planned as a follow-up once this has proven itself in the beta
