### PR TITLE
Gapless seeks and track changes on all AirPlay speakers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -577,45 +577,53 @@ capture.
 - **Single-stream flush-and-refill** — one reader thread drains the persistent
   stdin input into one bounded ring for the whole session, decoupled from
   network pacing. A warm seek/next is `ACTION=FLUSH`: it quiesces the audio
-  sends, flushes the receiver (RTSP FLUSH), parks the reader to take exclusive
-  fd access, resets the ring, and drains stdin to `EAGAIN` — removing exactly
-  the pre-flush audio the caller stopped writing — then, after the receiver
-  accepts the flush, acks `[STATUS] flushed` and releases the reader onto the
-  empty ring. The stream is then idle-primed: it keeps buffering the next track
-  and sends nothing until the next `START` (on the Apple splice timeline it
-  sends keepalive silence instead, so the immutable line cannot lapse across a
-  slow next-track spin-up). The next `START` re-anchors it. The one-shot
+  sends, performs the transport's warm-boundary action (splice timeline: keep
+  the receiver queue; deny-listed/stock path: RTSP FLUSH), parks the reader to
+  take exclusive fd access, resets the ring, and drains stdin to `EAGAIN` —
+  removing exactly the pre-flush audio the caller stopped writing — then acks
+  `[STATUS] flushed` and releases the reader onto the empty ring. The stream
+  is then idle-primed: it keeps buffering the next track and sends nothing
+  until the next `START` (on the splice timeline it sends keepalive silence
+  instead, so the immutable line cannot lapse across a slow next-track
+  spin-up). The next `START` re-anchors it. The one-shot
   `[STATUS] audio` signal (§6) is re-armed by the flush and fires after one
   complete transport packet is buffered, or when a final short packet reaches
   EOF. Partial PCM remains in the ring until a full packet is available; only
   the final EOF packet is padded with silence. The sender waits in bounded
   intervals so control failures remain visible during producer starvation.
-- **Apple splice timeline** — Apple's own receivers (tvOS/audioOS/macOS;
-  `model=`/`am=` prefix match) emit a ~100 ms noise burst on their native
-  realtime lane at any buffer discard (classic FLUSH with any RTP-Info, and
-  FLUSHBUFFERED alike), any anchor re-announce, and any late-frame delivery
-  (measured A/B on an Apple TV 4K, tvOS 27, 2026-07-30: the only clean warm
-  transitions were a natural drain and a bitstream-continuous splice; Apple
-  senders never exercise this corner — realtime streams are live and music
-  seeks ride the buffered lane). Native sessions to Apple models therefore run
-  a splice timeline: the anchor line frozen at the first START is immutable for
-  the whole session, no flush verb is ever sent, and every warm boundary
+- **Splice timeline** — every native session runs one mechanism for warm
+  boundaries: the anchor line frozen at the first START is immutable for the
+  whole session, no flush verb is ever sent, and every warm boundary
   (seek/next FLUSH+START, standby park/resume, pause/un-pause, starvation
-  recovery) keeps the wire bitstream-continuous — a forward stamp jump is
-  audible too, so the gap up to the commanded instant is FILLED with encoded
-  silence sent as ordinary chunks (sequence numbers and timestamps advance
-  normally; the final partial pad shares a chunk with the first real samples,
-  keeping the splice sample-exact). The commanded START selects
-  the splice instant on the line (the same instant for every member of a sync
-  group, so a group splices sample-aligned); the pacing depth is kept shallow
-  (600 ms) because the receiver's queued audio plays out before a splice is
-  audible. A commanded instant at or behind a member's head splices at that
-  member's own head instead — silently breaking the shared instant — so the
-  flush ack carries the frozen head's audible instant
-  (`[STATUS] flushed head_unix_ms=<ms>`), the depth rides `warm_lead_ms` on
-  the `[STATUS] latency` line, and the caller anchors every warm START beyond
-  all members' heads (plus their sync adjustments). Third-party receivers
-  keep the flush + re-anchor path below, which they handle cleanly.
+  recovery) keeps the wire bitstream-continuous — the gap up to the commanded
+  instant is FILLED with encoded silence sent as ordinary chunks (sequence
+  numbers and timestamps advance normally; the final partial pad shares a
+  chunk with the first real samples, keeping the splice sample-exact). The
+  mechanism is REQUIRED on Apple receivers (tvOS/audioOS/macOS): their
+  realtime lane emits a ~100 ms noise burst at any buffer discard (classic
+  FLUSH with any RTP-Info, and FLUSHBUFFERED alike), any anchor re-announce
+  (forward stamp jumps included), and any late-frame delivery — measured A/B
+  on an Apple TV 4K, tvOS 27, 2026-07-30: the only clean warm transitions
+  were a natural drain and a bitstream-continuous splice (Apple senders never
+  exercise this corner — realtime streams are live and music seeks ride the
+  buffered lane). The 2026-07-31 fleet A/B validated the same mechanism on
+  the third-party park (Sonos Era 100 pair, WiiM Pro, JBL MA9100HP:
+  cold/seek/next/pause/park/keepalive/late-join/group runs plus
+  delivery-stall ladders), so it is the default for everyone; a code-level
+  deny-list (`ap2_splice_denied`, empty) keeps the classic flush + re-anchor
+  path available for a receiver that measures splice-hostile. The commanded
+  START selects the splice instant on the line (the same instant for every
+  member of a sync group, so a group splices sample-aligned); the pacing
+  depth is kept shallow (600 ms) because the receiver's queued audio plays
+  out before a splice is audible. A commanded instant at or behind a
+  member's head splices at that member's own head instead — silently
+  breaking the shared instant — so the flush ack carries the frozen head's
+  audible instant (`[STATUS] flushed head_unix_ms=<ms>`), the depth rides
+  `warm_lead_ms` on the `[STATUS] latency` line, and the caller anchors
+  every warm START beyond all members' heads (plus their sync adjustments).
+  A lapsed line (resume over a long-idle pipeline) re-anchors fresh — the
+  clean session-start shape — and deny-listed receivers keep the classic
+  warm path throughout.
 - **Realtime send outcomes** — local UDP backpressure is a bounded transient
   drop that advances sequence, RTP, and scheduling timestamps. Encode,
   allocation, encryption, socket, and control failures are terminal and produce

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -591,9 +591,10 @@ capture.
   EOF. Partial PCM remains in the ring until a full packet is available; only
   the final EOF packet is padded with silence. The sender waits in bounded
   intervals so control failures remain visible during producer starvation.
-- **Splice timeline** — every native session runs one mechanism for warm
-  boundaries: the anchor line frozen at the first START is immutable for the
-  whole session, no flush verb is ever sent, and every warm boundary
+- **Splice timeline** — the default warm-boundary mechanism for every native
+  session (deny-listed receivers, below, are the exception): the anchor line
+  frozen at the first START is immutable for the whole session, no flush verb
+  is ever sent on this path, and every warm boundary
   (seek/next FLUSH+START, standby park/resume, pause/un-pause, starvation
   recovery) keeps the wire bitstream-continuous — the gap up to the commanded
   instant is FILLED with encoded silence sent as ordinary chunks (sequence

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -608,7 +608,8 @@ capture.
   were a natural drain and a bitstream-continuous splice (Apple senders never
   exercise this corner — realtime streams are live and music seeks ride the
   buffered lane). The 2026-07-31 fleet A/B validated the same mechanism on
-  the third-party park (Sonos Era 100 pair, WiiM Pro, JBL MA9100HP:
+  the third-party park (Sonos Era 100 pair and solo, Sonos Bookshelf, WiiM
+  Pro, Edifier MS50A, Samsung HW-LS60D:
   cold/seek/next/pause/park/keepalive/late-join/group runs plus
   delivery-stall ladders), so it is the default for everyone; a code-level
   deny-list (`ap2_splice_denied`, empty) keeps the classic flush + re-anchor

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -832,11 +832,12 @@ static bool ap2_features_has_ptp(const char *txt)
  * buffer discard, anchor re-announce, or late-frame delivery — measured A/B
  * on an Apple TV 4K, tvOS 27, 2026-07-30; the only clean warm transitions
  * were a natural drain and a bitstream-continuous splice), and the
- * 2026-07-31 fleet A/B cleared the third-party park (Sonos Era 100 pair,
- * WiiM Pro, JBL MA9100HP: cold/seek/next/pause/park/keepalive/late-join/
- * group runs, delivery-stall ladders) on the same mechanism. Add a `model=`
- * (_airplay TXT) / `am=` (_raop) prefix here only when a receiver measures
- * splice-hostile on hardware. */
+ * 2026-07-31 fleet A/B cleared the third-party park (Sonos Era 100 pair and
+ * solo, Sonos Bookshelf, WiiM Pro, Edifier MS50A, Samsung HW-LS60D:
+ * cold/seek/next/pause/park/keepalive/late-join/group runs, delivery-stall
+ * ladders) on the same mechanism. Add a `model=` (_airplay TXT) / `am=`
+ * (_raop) prefix here only when a receiver measures splice-hostile on
+ * hardware. */
 static bool ap2_splice_denied(const char *txt, const char *am)
 {
     static const char *const prefixes[] = { NULL };

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -84,7 +84,7 @@ extern log_level *loglevel;
  * after the connection and the audio feed are both confirmed, so no setup
  * slack is needed on top. */
 #define AP2_MIN_WARM_LEAD_MS         250
-/* Receiver queue depth on the Apple splice timeline (§ splice below): the
+/* Receiver queue depth on the splice timeline (§ splice below): the
  * depth IS the audible latency of a warm splice, so it stays shallow. */
 #define AP2_SPLICE_PACING_MS         600
 /* Raw bytes kept from a failed exchange for the auth diagnostics dump: enough
@@ -179,9 +179,10 @@ struct ap2cl_s {
     uint64_t sync_packets_dropped;
     atomic_uint feedback_failures;
     uint64_t timeline_reanchors;
-    bool splice_timeline;         /* Apple receiver: discard-free warm path on
-                                     one immutable anchor line (see the splice
-                                     comments at flush/resume/standby) */
+    bool splice_timeline;         /* discard-free warm path on one immutable
+                                     anchor line — the native default; false
+                                     only for deny-listed receivers (see the
+                                     splice comments at flush/resume/standby) */
     uint32_t splice_pad_frames;   /* silence frames still to send before the
                                      next real sample so it lands exactly on
                                      the commanded splice instant */
@@ -824,23 +825,24 @@ static bool ap2_features_has_ptp(const char *txt)
     return AP2_FEAT(ap2_txt_features(txt), AP2_FEAT_PTP) != 0;
 }
 
-/* Apple's own AirPlay receivers (tvOS/audioOS/macOS; `model=` in the _airplay
- * TXT, `am=` on _raop) share a receiver daemon whose realtime lane emits a
- * short noise burst on any buffer discard (FLUSH and FLUSHBUFFERED alike), any
- * anchor re-announce, and any late-frame delivery — measured A/B on hardware
- * (Apple TV 4K, tvOS 27, 2026-07-30; the only clean warm transitions were a
- * natural drain and a bitstream-continuous splice). Third-party receivers
- * handle the classic flush + re-anchor warm path cleanly, so only Apple models
- * take the splice timeline. */
-static bool ap2_apple_model(const char *txt, const char *am)
+/* Splice-timeline deny-list: receivers that need the classic flush +
+ * re-anchor warm path instead of the splice timeline (§DESIGN.md). The
+ * splice timeline is the default for every native session: Apple's own
+ * receivers REQUIRE it (their realtime lane emits a short noise burst on any
+ * buffer discard, anchor re-announce, or late-frame delivery — measured A/B
+ * on an Apple TV 4K, tvOS 27, 2026-07-30; the only clean warm transitions
+ * were a natural drain and a bitstream-continuous splice), and the
+ * 2026-07-31 fleet A/B cleared the third-party park (Sonos Era 100 pair,
+ * WiiM Pro, JBL MA9100HP: cold/seek/next/pause/park/keepalive/late-join/
+ * group runs, delivery-stall ladders) on the same mechanism. Add a `model=`
+ * (_airplay TXT) / `am=` (_raop) prefix here only when a receiver measures
+ * splice-hostile on hardware. */
+static bool ap2_splice_denied(const char *txt, const char *am)
 {
-    static const char *const prefixes[] = {
-        "AppleTV", "AudioAccessory", "AirPort", "HomePod",
-        "Mac", "iMac", "iPhone", "iPad", "iPod",
-    };
+    static const char *const prefixes[] = { NULL };
     const char *model = txt ? strstr(txt, "model=") : NULL;
     if (model) model += strlen("model=");
-    for (size_t i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
+    for (size_t i = 0; prefixes[i]; i++) {
         size_t len = strlen(prefixes[i]);
         if (model && strncmp(model, prefixes[i], len) == 0) return true;
         if (am && strncmp(am, prefixes[i], len) == 0) return true;
@@ -2276,11 +2278,15 @@ bool ap2cl_connect(struct ap2cl_s *p)
     if (!p) return false;
     ap2_set_connect_error(p, AP2_CONNECT_ERROR_GENERIC, 0, "connect failed");
     if (p->flow == FLOW_NATIVE_AP2) {
-        p->splice_timeline = ap2_apple_model(p->device.txt_records, p->am);
-        if (p->splice_timeline)
-            LOG_INFO("[AP2] Apple receiver: splice timeline active "
-                     "(discard-free warm path, %d ms queue depth)",
-                     AP2_SPLICE_PACING_MS);
+        p->splice_timeline =
+            !ap2_splice_denied(p->device.txt_records, p->am);
+        if (p->splice_timeline) {
+            LOG_INFO("[AP2] splice timeline (discard-free warm path, "
+                     "%d ms queue depth)", AP2_SPLICE_PACING_MS);
+        } else {
+            LOG_INFO("[AP2] deny-listed receiver: classic flush + re-anchor "
+                     "warm path");
+        }
         LOG_INFO("[AP2] Connecting via native AP2 flow to %s:%d",
                  p->device.address, p->device.port);
         return ap2_native_connect(p);
@@ -3518,6 +3524,11 @@ void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet)
 void ap2cl_test_set_splice(struct ap2cl_s *p, bool enable)
 {
     p->splice_timeline = enable;
+}
+
+bool ap2cl_test_splice_default(const char *txt, const char *am)
+{
+    return !ap2_splice_denied(txt, am);
 }
 
 void ap2cl_test_set_anchor_valid(struct ap2cl_s *p, bool valid)

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -339,7 +339,7 @@ void ap2cl_latency_info(struct ap2cl_s *p, int *lead_ms, uint32_t *dev_min, uint
 int ap2cl_render_latency_ms(struct ap2cl_s *p);
 
 /* Frames between the delivery head and the audible position (elapsed
- * reporting): the shallow pacing depth on the Apple splice timeline, the
+ * reporting): the shallow pacing depth on the splice timeline, the
  * latency lead otherwise. */
 uint32_t ap2cl_audible_lag_frames(struct ap2cl_s *p);
 

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -1166,7 +1166,7 @@ static int run_airplay2(cli_config_t *cfg)
                 eof_reported = false;
                 eof_time = 0;
             }
-            /* Splice pad (Apple splice timeline): silence owed to the wire
+            /* Splice pad (splice timeline): silence owed to the wire
              * before the next real sample, sent as ordinary encoded chunks so
              * sequence numbers and timestamps stay contiguous (any stamp jump
              * is an audible noise burst). A partial pad occupies the head of

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -29,6 +29,7 @@ void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p);
 bool ap2cl_test_first_packet(struct ap2cl_s *p);
 void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet);
 void ap2cl_test_set_splice(struct ap2cl_s *p, bool enable);
+bool ap2cl_test_splice_default(const char *txt, const char *am);
 void ap2cl_test_set_anchor_valid(struct ap2cl_s *p, bool valid);
 bool ap2cl_test_anchor_valid(struct ap2cl_s *p);
 uint64_t ap2cl_test_head_ts(struct ap2cl_s *p);
@@ -399,7 +400,30 @@ static void test_route_with_password(void)
     puts("ap2_client route password selection tests passed");
 }
 
-/* The Apple splice timeline never sends a flush verb and never rebases: the
+/* The splice timeline is the default for every native session; the deny-list
+ * (classic flush + re-anchor fallback) ships empty. The 2026-07-31 fleet A/B
+ * cleared the third-party park on the splice mechanism — adding a deny entry
+ * must consciously update this pin. */
+static void test_splice_default_resolution(void)
+{
+    /* Apple receivers (the mechanism is REQUIRED there). */
+    assert(ap2cl_test_splice_default(
+        "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE", NULL));
+    assert(ap2cl_test_splice_default(NULL, "AudioAccessory5,1"));
+    /* The validated third-party park. */
+    assert(ap2cl_test_splice_default(
+        "model=Era 100 features=0x445F8A00,0x801C340", NULL));
+    assert(ap2cl_test_splice_default(
+        "model=WiiM Pro Receiver features=0x445F8A00,0x1C340", NULL));
+    assert(ap2cl_test_splice_default(
+        "model=JBL MA9100HP features=0x445F8A00,0x1C340", NULL));
+    assert(ap2cl_test_splice_default(NULL, "Era 100"));
+    /* No TXT at all still defaults to the splice timeline. */
+    assert(ap2cl_test_splice_default(NULL, NULL));
+    puts("ap2_client splice default resolution tests passed");
+}
+
+/* The splice timeline never sends a flush verb and never rebases: the
  * warm boundary is a forward-only stamp skip on one immutable anchor line.
  * The RTSP socket must stay silent across flush + standby, and resume must
  * keep the sequence/timestamp relation contiguous. */
@@ -567,6 +591,7 @@ int main(void)
     test_info_format_tables();
     test_native_flush_resume_reuses_rtsp_session();
     test_native_flush_rejects_receiver_error();
+    test_splice_default_resolution();
     test_splice_timeline_warm_path();
     test_feedback_miss_tolerated_then_recovered();
 

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -410,13 +410,13 @@ static void test_splice_default_resolution(void)
     assert(ap2cl_test_splice_default(
         "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE", NULL));
     assert(ap2cl_test_splice_default(NULL, "AudioAccessory5,1"));
-    /* The validated third-party park. */
+    /* Third-party receivers stay on the default. */
     assert(ap2cl_test_splice_default(
         "model=Era 100 features=0x445F8A00,0x801C340", NULL));
     assert(ap2cl_test_splice_default(
         "model=WiiM Pro Receiver features=0x445F8A00,0x1C340", NULL));
     assert(ap2cl_test_splice_default(
-        "model=JBL MA9100HP features=0x445F8A00,0x1C340", NULL));
+        "model=HW-LS60D features=0xC05F8A00,0x1C340", NULL));
     assert(ap2cl_test_splice_default(NULL, "Era 100"));
     /* No TXT at all still defaults to the splice timeline. */
     assert(ap2cl_test_splice_default(NULL, NULL));


### PR DESCRIPTION
All native AirPlay 2 receivers now use the same warm-path mechanism that fixed the Apple noise bursts in #25: every seek, track change, pause and park is a bitstream-continuous splice on one immutable timeline — the receiver is never asked to discard audio, so there is no silence gap and no re-anchor at boundaries.

- Splice timeline becomes the default for every native AP2 session; the Apple-model gate is gone
- Classic flush + re-anchor demoted to a code-level deny-list fallback (ships empty) and the lapsed-line resume shape
- Fleet A/B validated on Sonos Era 100 (pairs and solo), Sonos Bookshelf, WiiM Pro, Edifier MS50A pair, Samsung HW-LS60D and two Apple TV 4Ks: solo boundaries, sync groups, a four-player Sonos household, late joins and delivery-stall ladders — zero errors or re-anchors on either arm
- DESIGN.md updated; new unit test pins the default resolution