### PR TITLE
Keep the Apple TV now-playing screen stable during seeks and track changes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -406,7 +406,7 @@ Inner keys: `Title`, `Artist`, `Album`, `Duration`, `ElapsedTime`,
 track's progress pushes), `ArtworkData` (JPEG bytes), `ArtworkMIMEType`,
 `ArtworkIdentifier`.
 
-**Artwork evidence, probing, and send-once behavior.** AirPlaySender requests
+**Artwork evidence, probing, and per-push bytes.** AirPlaySender requests
 600x600 artwork from MediaRemote, and the captured iPhone command used a
 600x600, three-component baseline JPEG of about 43 KB. These establish a known
 sender shape, not a receiver maximum. No Apple source or hardware measurement
@@ -427,9 +427,29 @@ staging-allocation guard leaves room for the hardware matrix below and is
 explicitly not a receiver limit. Rejection clears previous MRP artwork,
 preventing stale cover art. No image codec is embedded in production code.
 
-Staged JPEG bytes ride only the *first* push for a given image, tagged with a
-fresh `ArtworkIdentifier`; later pushes carry the identifier without the bytes,
-so artwork is not re-sent on every progress tick over the shared RTSP channel.
+Staged JPEG bytes ride **every** now-playing push while artwork is retained.
+The `npi-text` / `mergePolicy: "replace"` bridge replaces the receiver's whole
+now-playing info per push: hardware measurement (Apple TV 4K, tvOS 26/27, via
+the receiver's own MRP `SET_STATE` re-broadcasts) shows that a push carrying
+only the `ArtworkIdentifier` — same `UniqueIdentifier`, same identifier, no
+`ArtworkData` — flips `artworkAvailable` to false, i.e. the receiver does not
+cache-and-restore artwork by identifier across replace pushes. An earlier
+send-once model (bytes on the first push, identifier-only afterwards) therefore
+lost cover art on every elapsed-only correction. Pushes are rare by design
+(seek, track change, play/pause; steady-state progress is extrapolated
+receiver-side, never streamed), so per-push bytes cost a few tens of KB on the
+control channel at human-action frequency, and a receiver that dropped its art
+self-heals on the next push.
+
+Identity churn is equally destructive and equally guarded: `set_metadata`
+mints a fresh `UniqueIdentifier` only when title/artist/album actually change
+(a redundant re-send under a fresh uid reads as a new item and orphans
+delivered artwork), a track change drops the previous track's staged art so it
+cannot ride the new item, and re-staging byte-identical artwork is a reported
+no-op (`unchanged`) that keeps the current `ArtworkIdentifier` — an identifier
+flip alone makes the receiver invalidate and re-resolve what it is already
+showing, which re-renders its Now Playing UI.
+
 The complete registration/now-playing/extended-state sequence is serialized;
 its return value carries request-scoped overall and `updateMRNowPlayingInfo`
 statuses, so concurrent pushes cannot overwrite the artwork response.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -427,19 +427,27 @@ staging-allocation guard leaves room for the hardware matrix below and is
 explicitly not a receiver limit. Rejection clears previous MRP artwork,
 preventing stale cover art. No image codec is embedded in production code.
 
-Staged JPEG bytes ride **every** now-playing push while artwork is retained.
-The `npi-text` / `mergePolicy: "replace"` bridge replaces the receiver's whole
-now-playing info per push: hardware measurement (Apple TV 4K, tvOS 26/27, via
-the receiver's own MRP `SET_STATE` re-broadcasts) shows that a push carrying
-only the `ArtworkIdentifier` — same `UniqueIdentifier`, same identifier, no
-`ArtworkData` — flips `artworkAvailable` to false, i.e. the receiver does not
-cache-and-restore artwork by identifier across replace pushes. An earlier
-send-once model (bytes on the first push, identifier-only afterwards) therefore
-lost cover art on every elapsed-only correction. Pushes are rare by design
-(seek, track change, play/pause; steady-state progress is extrapolated
-receiver-side, never streamed), so per-push bytes cost a few tens of KB on the
-control channel at human-action frequency, and a receiver that dropped its art
-self-heals on the next push.
+Staged JPEG bytes ride **every** `replace` now-playing push while artwork is
+retained. The `npi-text` / `mergePolicy: "replace"` bridge replaces the
+receiver's whole now-playing info per push: hardware measurement (Apple TV 4K,
+tvOS 26/27, via the receiver's own MRP `SET_STATE` re-broadcasts) shows that a
+replace push without `ArtworkData` flips `artworkAvailable` to false — with
+the identifier keys present or omitted entirely, both measured — i.e. the
+receiver neither caches by identifier nor preserves absent keys. An earlier
+send-once model (bytes on the first push, identifier-only afterwards)
+therefore lost cover art on every elapsed-only correction. Replace pushes are
+rare by design (track/artwork change, play/pause), so per-push bytes cost a
+few tens of KB on the control channel at human-action frequency, and a
+receiver that dropped its art self-heals on the next push.
+
+Pure timeline corrections (seek) use `mergePolicy: "update"` instead,
+carrying only the timeline fields and no artwork keys: a bytes-carrying
+replace push makes tvOS visibly re-decode and re-set the cover on every seek.
+Measured on the same hardware, the update push returns 200, the new elapsed
+lands as an in-place content-item update (no `SET_STATE` re-render), and
+`artworkAvailable` stays true. A receiver that rejects the policy with an
+HTTP error automatically gets full replace pushes for the rest of the session
+(`ap2cl_mrp_push_progress`).
 
 Identity churn is equally destructive and equally guarded: `set_metadata`
 mints a fresh `UniqueIdentifier` only when title/artist/album actually change

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3073,14 +3073,11 @@ typedef bool (*ap2_mrp_command_builder_t)(struct ap2_mrp_ctx *,
 
 static int ap2_mrp_post_command(struct ap2cl_s *p,
                                 ap2_mrp_command_builder_t builder,
-                                const char *tag,
-                                uint64_t *artwork_generation)
+                                const char *tag)
 {
     uint8_t *body = NULL; int body_len = 0;
     pthread_mutex_lock(&p->mrp_lock);
     bool built = p->mrp && builder(p->mrp, &body, &body_len);
-    if (built && artwork_generation)
-        *artwork_generation = ap2_mrp_artwork_generation(p->mrp);
     pthread_mutex_unlock(&p->mrp_lock);
     if (!built) return -1;
     uint8_t *resp = NULL;
@@ -3110,7 +3107,7 @@ static int ap2_mrp_send_playback_state(struct ap2cl_s *p,
 
     int status = ap2_mrp_post_command(
         p, ap2_mrp_build_playbackstate_command,
-        "[MRP] /command updateMRPlaybackState", NULL);
+        "[MRP] /command updateMRPlaybackState");
     if (ap2_mrp_status_ok(status))
         p->mrp_last_playback_state = state;
     return status;
@@ -3148,11 +3145,11 @@ static int ap2_mrp_send_extended_registration(struct ap2cl_s *p)
 
     int st_cmd = ap2_mrp_post_command(
         p, ap2_mrp_build_supportedcommands_command,
-        "[MRP] /command updateMRSupportedCommands", NULL);
+        "[MRP] /command updateMRSupportedCommands");
     int st_state = ap2_mrp_send_playback_state(p, state, true);
     int st_client = ap2_mrp_post_command(
         p, ap2_mrp_build_nowplayingclient_command,
-        "[MRP] /command updateMRNowPlayingClient", NULL);
+        "[MRP] /command updateMRNowPlayingClient");
 
     p->mrp_extended_registered =
         ap2_mrp_status_ok(st_cmd) && ap2_mrp_status_ok(st_state) &&
@@ -3182,18 +3179,12 @@ static ap2_mrp_push_result_t ap2cl_mrp_push_serialized(struct ap2cl_s *p)
         return result;
     }
 
-    uint64_t artwork_generation = 0;
     int status = ap2_mrp_post_command(
         p, ap2_mrp_build_nowplaying_command,
-        "[MRP] /command updateMRNowPlayingInfo", &artwork_generation);
+        "[MRP] /command updateMRNowPlayingInfo");
     result.nowplaying_status = status;
     result.overall_status = status;
     if (!ap2_mrp_status_ok(status)) return result;
-    pthread_mutex_lock(&p->mrp_lock);
-    if (p->mrp)
-        ap2_mrp_mark_artwork_sent_if_generation(
-            p->mrp, artwork_generation);
-    pthread_mutex_unlock(&p->mrp_lock);
 
     int ext_status;
     if (!p->mrp_extended_registered) {
@@ -3256,7 +3247,7 @@ static int ap2cl_mrp_register_serialized(struct ap2cl_s *p)
 
     int status = ap2_mrp_post_command(
         p, ap2_mrp_build_deviceinfo_command,
-        "[MRP] /command DEVICE_INFO", NULL);
+        "[MRP] /command DEVICE_INFO");
     p->mrp_device_registered = ap2_mrp_status_ok(status);
     return p->mrp_device_registered ? 1 : 0;
 }
@@ -3293,12 +3284,12 @@ bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size,
                        const char *data, ap2_mrp_artwork_info_t *mrp_info,
                        ap2_mrp_push_result_t *mrp_push)
 {
+    ap2_mrp_artwork_info_t local_info;
+    if (!mrp_info) mrp_info = &local_info;
     if (mrp_push) *mrp_push = ap2_mrp_push_result_empty();
-    if (mrp_info) {
-        memset(mrp_info, 0, sizeof(*mrp_info));
-        mrp_info->result = AP2_MRP_ARTWORK_NOT_APPLICABLE;
-        mrp_info->bytes = size > 0 ? (size_t)size : 0;
-    }
+    memset(mrp_info, 0, sizeof(*mrp_info));
+    mrp_info->result = AP2_MRP_ARTWORK_NOT_APPLICABLE;
+    mrp_info->bytes = size > 0 ? (size_t)size : 0;
     if (!p) return false;
     pthread_mutex_lock(&p->mrp_publish_lock);
     pthread_mutex_lock(&p->mrp_lock);
@@ -3308,6 +3299,13 @@ bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size,
         ap2_mrp_set_artwork(p->mrp, content_type, (const uint8_t *)data,
                             size, mrp_info);
     pthread_mutex_unlock(&p->mrp_lock);
+    if (mrp_info->result == AP2_MRP_ARTWORK_UNCHANGED) {
+        /* The receiver already holds these exact bytes under the current
+         * identifier; re-sending on either path would only make it re-render
+         * its Now Playing UI. */
+        pthread_mutex_unlock(&p->mrp_publish_lock);
+        return true;
+    }
     bool dmap_ok = false;
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
         /* Preserve the DMAP/SET_PARAMETER path for receivers such as Sonos;

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3262,14 +3262,15 @@ int ap2cl_mrp_register(struct ap2cl_s *p)
 }
 
 bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist,
-                        const char *album, int duration)
+                        const char *album, int duration, const char *item_id)
 {
     if (!p) return false;
     pthread_mutex_lock(&p->mrp_publish_lock);
     pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
     if (p->mrp)
-        ap2_mrp_set_metadata(p->mrp, title, artist, album, duration * 1000);
+        ap2_mrp_set_metadata(p->mrp, title, artist, album, duration * 1000,
+                             item_id);
     pthread_mutex_unlock(&p->mrp_lock);
     pthread_mutex_unlock(&p->mrp_publish_lock);
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0)

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3392,11 +3392,21 @@ bool ap2cl_set_progress(struct ap2cl_s *p, int elapsed_s, int duration_s)
     pthread_mutex_lock(&p->mrp_publish_lock);
     pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
+    bool have_mrp = p->mrp != NULL;
     if (p->mrp)
         ap2_mrp_set_progress(p->mrp, elapsed_s * 1000, duration_s * 1000,
                              p->state == AP2_STREAMING);
     pthread_mutex_unlock(&p->mrp_lock);
     pthread_mutex_unlock(&p->mrp_publish_lock);
+    if (have_mrp) {
+        /* MediaRemote owns now-playing on this receiver; the timeline rides
+         * the mergePolicy-"update" push that follows this call. The legacy
+         * SET_PARAMETER progress line exists for receivers without the MRP
+         * bridge (Sonos-class) — sending both makes an Apple TV process the
+         * same seek twice, and its legacy path visibly re-renders the
+         * now-playing screen. */
+        return true;
+    }
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
         /* progress: <start>/<current>/<end>, all in the STREAM's RTP timestamp
          * units (the per-process timeline offset included, so the values match

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -158,6 +158,8 @@ struct ap2cl_s {
     atomic_int mrp_event_health;
     bool mrp_device_registered;
     bool mrp_extended_registered;
+    bool mrp_progress_push_full;  /* receiver rejected the "update" policy;
+                                     timeline pushes use the full replace */
     int mrp_last_playback_state;
     ap2_remote_command_cb_t remote_command_cb;
     void *remote_command_userdata;
@@ -3164,7 +3166,8 @@ static int ap2_mrp_send_extended_registration(struct ap2cl_s *p)
 
 static int ap2cl_mrp_register_serialized(struct ap2cl_s *p);
 
-static ap2_mrp_push_result_t ap2cl_mrp_push_serialized(struct ap2cl_s *p)
+static ap2_mrp_push_result_t ap2cl_mrp_push_serialized_with(
+    struct ap2cl_s *p, ap2_mrp_command_builder_t builder)
 {
     ap2_mrp_push_result_t result = ap2_mrp_push_result_empty();
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return result;
@@ -3180,8 +3183,7 @@ static ap2_mrp_push_result_t ap2cl_mrp_push_serialized(struct ap2cl_s *p)
     }
 
     int status = ap2_mrp_post_command(
-        p, ap2_mrp_build_nowplaying_command,
-        "[MRP] /command updateMRNowPlayingInfo");
+        p, builder, "[MRP] /command updateMRNowPlayingInfo");
     result.nowplaying_status = status;
     result.overall_status = status;
     if (!ap2_mrp_status_ok(status)) return result;
@@ -3200,6 +3202,11 @@ static ap2_mrp_push_result_t ap2cl_mrp_push_serialized(struct ap2cl_s *p)
     return result;
 }
 
+static ap2_mrp_push_result_t ap2cl_mrp_push_serialized(struct ap2cl_s *p)
+{
+    return ap2cl_mrp_push_serialized_with(p, ap2_mrp_build_nowplaying_command);
+}
+
 ap2_mrp_push_result_t ap2cl_mrp_push_ex(struct ap2cl_s *p)
 {
     ap2_mrp_push_result_t result = ap2_mrp_push_result_empty();
@@ -3213,6 +3220,31 @@ ap2_mrp_push_result_t ap2cl_mrp_push_ex(struct ap2cl_s *p)
 int ap2cl_mrp_push(struct ap2cl_s *p)
 {
     return ap2cl_mrp_push_ex(p).overall_status;
+}
+
+int ap2cl_mrp_push_progress(struct ap2cl_s *p)
+{
+    ap2_mrp_push_result_t result = ap2_mrp_push_result_empty();
+    if (!p) return result.overall_status;
+    pthread_mutex_lock(&p->mrp_publish_lock);
+    if (!p->mrp_progress_push_full) {
+        result = ap2cl_mrp_push_serialized_with(
+            p, ap2_mrp_build_nowplaying_progress_command);
+        /* A receiver that rejects the "update" merge policy outright gets
+         * the full replace shape from now on (bytes riding along); only an
+         * HTTP-level rejection demotes — transport failures stay retryable
+         * on the lean shape. */
+        if (result.nowplaying_status >= 300) {
+            LOG_WARN("[MRP] timeline update push rejected (%d); "
+                     "using full now-playing pushes for this session",
+                     result.nowplaying_status);
+            p->mrp_progress_push_full = true;
+        }
+    }
+    if (p->mrp_progress_push_full)
+        result = ap2cl_mrp_push_serialized(p);
+    pthread_mutex_unlock(&p->mrp_publish_lock);
+    return result.overall_status;
 }
 
 /* MRP data-channel (path B) status for the [STATUS] mrp line:

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -243,9 +243,12 @@ bool ap2cl_feedback(struct ap2cl_s *p);
 /* Set volume (0-100). */
 bool ap2cl_set_volume(struct ap2cl_s *p, int volume);
 
-/* Set metadata (DAAP format). */
+/* Set metadata (DAAP format). item_id is the sender's stable per-track
+ * identity ("" = none): MediaRemote keys its now-playing item on it, so
+ * later tag refinements for the same item update in place instead of
+ * presenting as a new track. */
 bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist,
-                        const char *album, int duration);
+                        const char *album, int duration, const char *item_id);
 
 /*
  * Set artwork on the existing DMAP path and, when applicable, stage it for

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -273,6 +273,10 @@ bool ap2cl_set_progress(struct ap2cl_s *p, int elapsed_s, int duration_s);
  * failure, or -1 when the push does not apply to this session. */
 int ap2cl_mrp_push(struct ap2cl_s *p);
 
+/* Same, but with the timeline-correction body shape (see
+ * ap2_mrp_build_nowplaying_progress_command) for seek progress updates. */
+int ap2cl_mrp_push_progress(struct ap2cl_s *p);
+
 /* Serialized push with request-scoped overall and now-playing statuses. */
 ap2_mrp_push_result_t ap2cl_mrp_push_ex(struct ap2cl_s *p);
 

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -208,8 +208,6 @@ struct ap2_mrp_ctx {
     uint8_t *artwork;
     int artwork_len;
     char artwork_id[17];      /* 16-hex ArtworkIdentifier for the current art */
-    bool artwork_sent;        /* bytes already pushed once (then ref by id) */
-    uint64_t artwork_generation;
     uint64_t np_uid;          /* per-track now-playing UniqueIdentifier */
 
     time_t last_state_push;
@@ -239,6 +237,7 @@ const char *ap2_mrp_artwork_result_name(ap2_mrp_artwork_result_t result)
     switch (result) {
     case AP2_MRP_ARTWORK_NOT_APPLICABLE:    return "not_applicable";
     case AP2_MRP_ARTWORK_ACCEPTED:          return "accepted";
+    case AP2_MRP_ARTWORK_UNCHANGED:         return "unchanged";
     case AP2_MRP_ARTWORK_INVALID_ARGUMENT:  return "invalid_argument";
     case AP2_MRP_ARTWORK_UNSUPPORTED_TYPE:  return "unsupported_type";
     case AP2_MRP_ARTWORK_STAGING_LIMIT:     return "staging_limit";
@@ -331,7 +330,6 @@ static void mrp_reset_artwork(struct ap2_mrp_ctx *m)
     free(m->artwork_mime);
     m->artwork_mime = NULL;
     m->artwork_id[0] = '\0';
-    m->artwork_sent = false;
 }
 
 /* ---- Small helpers ---- */
@@ -386,6 +384,13 @@ static void mrp_replace_str(char **dst, const char *src)
 {
     free(*dst);
     *dst = mrp_strdup(src);
+}
+
+/* NULL-safe equality; NULL compares equal to the empty string, matching how
+ * the now-playing fields are serialized. */
+static bool mrp_str_eq(const char *a, const char *b)
+{
+    return strcmp(a ? a : "", b ? b : "") == 0;
 }
 
 /* ---- Growable byte buffer ---- */
@@ -1578,16 +1583,27 @@ bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
                           int duration_ms)
 {
     if (!m) return false;
+    /* The UniqueIdentifier must stay stable across a track's pushes: the
+     * receiver keys its now-playing item on it, so a fresh uid on a redundant
+     * re-send (registration burst, warm seek, progress correction) reads as a
+     * brand-new item and resets the receiver's Now Playing UI. Mint one only
+     * when the track actually changes. Random 63-bit, matching the large
+     * uint64 a real sender emits. */
+    bool track_changed = !mrp_str_eq(m->title, title) ||
+                         !mrp_str_eq(m->artist, artist) ||
+                         !mrp_str_eq(m->album, album);
     mrp_replace_str(&m->title, title);
     mrp_replace_str(&m->artist, artist);
     mrp_replace_str(&m->album, album);
     m->duration_ms = duration_ms > 0 ? duration_ms : 0;
-    /* New track: fresh UniqueIdentifier (stable across this track's progress
-     * pushes; changing it per push would reset the receiver's now-playing UI).
-     * Random 63-bit, matching the large uint64 a real sender emits. */
-    uint64_t uid = 0;
-    RAND_bytes((uint8_t *)&uid, sizeof(uid));
-    m->np_uid = uid & 0x7FFFFFFFFFFFFFFFULL;
+    if (track_changed || m->np_uid == 0) {
+        uint64_t uid = 0;
+        RAND_bytes((uint8_t *)&uid, sizeof(uid));
+        m->np_uid = uid & 0x7FFFFFFFFFFFFFFFULL;
+        /* The old track's staged artwork must not ride the new item; the
+         * caller stages the new track's art (or none) right after this. */
+        if (track_changed) mrp_reset_artwork(m);
+    }
     m->state_generation++;
     m->state_dirty = true;
     return true;
@@ -1615,6 +1631,19 @@ bool ap2_mrp_set_artwork(struct ap2_mrp_ctx *m, const char *mime,
         return false;
     }
 
+    /* A redundant re-send of the retained image is a no-op: keeping the
+     * ArtworkIdentifier means the receiver never invalidates and re-resolves
+     * the art it is already showing (an identifier flip re-renders the
+     * receiver's Now Playing UI even when the pixels are identical). */
+    if (m->artwork && m->artwork_len == len &&
+        memcmp(m->artwork, data, (size_t)len) == 0 &&
+        mrp_str_eq(m->artwork_mime, mime)) {
+        LOG_INFO("[MRP] artwork unchanged (%d bytes); keeping identifier %s",
+                 len, m->artwork_id);
+        info->result = AP2_MRP_ARTWORK_UNCHANGED;
+        return true;
+    }
+
     uint8_t *copy = malloc((size_t)len);
     char *mime_copy = mrp_strdup(mime);
     if (!copy || !mime_copy) {
@@ -1631,16 +1660,13 @@ bool ap2_mrp_set_artwork(struct ap2_mrp_ctx *m, const char *mime,
     m->artwork_len = len;
     free(m->artwork_mime);
     m->artwork_mime = mime_copy;
-    /* Fresh artwork: new ArtworkIdentifier and re-arm the one-shot byte send.
-     * Like a real sender, the /command push carries the bytes once and then
-     * references them by identifier (ap2_mrp_build_nowplaying_command). */
+    /* Fresh artwork: new ArtworkIdentifier for the new pixels. The bytes ride
+     * every now-playing push while retained (ap2_mrp_build_nowplaying_command). */
     uint8_t idb[8];
     RAND_bytes(idb, sizeof(idb));
     snprintf(m->artwork_id, sizeof(m->artwork_id),
              "%02x%02x%02x%02x%02x%02x%02x%02x",
              idb[0], idb[1], idb[2], idb[3], idb[4], idb[5], idb[6], idb[7]);
-    m->artwork_sent = false;
-    m->artwork_generation++;
     m->state_generation++;
     m->state_dirty = true;
     m->state_include_artwork = true;
@@ -1820,14 +1846,17 @@ bool ap2_mrp_build_nowplaying_command(struct ap2_mrp_ctx *m,
         ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoArtworkMIMEType",
                         ap2_pl_string(m->artwork_mime ? m->artwork_mime
                                                       : "image/jpeg"));
-        /* Carry the bytes only on the first push for this artwork; later pushes
-         * reference it by identifier (the receiver caches by id), exactly as a
-         * real sender does — avoids re-sending ~tens of KB on every progress
-         * tick over the shared RTSP channel. */
-        if (!m->artwork_sent) {
-            ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoArtworkData",
-                            ap2_pl_data(m->artwork, (size_t)m->artwork_len));
-        }
+        /* The npi-text bridge REPLACES the receiver's whole now-playing info
+         * on every push: a push carrying only the ArtworkIdentifier drops the
+         * artwork on tvOS (hardware-verified on tvOS 26/27 — artworkAvailable
+         * flips false on an elapsed-only push with stable identifiers). The
+         * bytes therefore ride EVERY push while artwork is retained. Pushes
+         * are rare by design (seek, track change, play/pause; the receiver
+         * extrapolates steady-state progress), so the cost stays a few tens
+         * of KB on the control channel, and a receiver that dropped its art
+         * self-heals on the next push. */
+        ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoArtworkData",
+                        ap2_pl_data(m->artwork, (size_t)m->artwork_len));
     }
 
     ap2_pl_node *params = ap2_pl_dict();
@@ -1843,24 +1872,6 @@ bool ap2_mrp_build_nowplaying_command(struct ap2_mrp_ctx *m,
     if (len <= 0) return false;
     *out_len = len;
     return true;
-}
-
-void ap2_mrp_mark_artwork_sent(struct ap2_mrp_ctx *m)
-{
-    if (m && m->artwork && m->artwork_len > 0)
-        m->artwork_sent = true;
-}
-
-uint64_t ap2_mrp_artwork_generation(struct ap2_mrp_ctx *m)
-{
-    return m ? m->artwork_generation : 0;
-}
-
-void ap2_mrp_mark_artwork_sent_if_generation(
-    struct ap2_mrp_ctx *m, uint64_t generation)
-{
-    if (m && m->artwork_generation == generation)
-        ap2_mrp_mark_artwork_sent(m);
 }
 
 /* Wrap a serialized protobuf as the bplist {"params": {"data": <varint length +

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -208,6 +208,7 @@ struct ap2_mrp_ctx {
     uint8_t *artwork;
     int artwork_len;
     char artwork_id[17];      /* 16-hex ArtworkIdentifier for the current art */
+    char *item_id;            /* sender's stable per-track identity ("" = none) */
     uint64_t np_uid;          /* per-track now-playing UniqueIdentifier */
 
     time_t last_state_push;
@@ -1436,6 +1437,7 @@ void ap2_mrp_destroy(struct ap2_mrp_ctx *m)
     free(m->title);
     free(m->artist);
     free(m->album);
+    free(m->item_id);
     free(m->artwork_mime);
     free(m->artwork);
     free(m);
@@ -1580,21 +1582,35 @@ void ap2_mrp_stop(struct ap2_mrp_ctx *m)
 
 bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
                           const char *artist, const char *album,
-                          int duration_ms)
+                          int duration_ms, const char *item_id)
 {
     if (!m) return false;
     /* The UniqueIdentifier must stay stable across a track's pushes: the
      * receiver keys its now-playing item on it, so a fresh uid on a redundant
      * re-send (registration burst, warm seek, progress correction) reads as a
      * brand-new item and resets the receiver's Now Playing UI. Mint one only
-     * when the track actually changes. Random 63-bit, matching the large
-     * uint64 a real sender emits. */
-    bool track_changed = !mrp_str_eq(m->title, title) ||
-                         !mrp_str_eq(m->artist, artist) ||
-                         !mrp_str_eq(m->album, album);
+     * when the track actually changes — keyed on the sender's item id when
+     * both sides have one, because the text tuple is NOT stable for one
+     * track: the server may refine tags mid-track (library enrichment
+     * settling after playback start), and such a refinement must update the
+     * existing item, not present as a new track. Random 63-bit, matching the
+     * large uint64 a real sender emits. */
+    bool have_ids = m->item_id && *m->item_id && item_id && *item_id;
+    bool track_changed = have_ids
+        ? strcmp(m->item_id, item_id) != 0
+        : (!mrp_str_eq(m->title, title) ||
+           !mrp_str_eq(m->artist, artist) ||
+           !mrp_str_eq(m->album, album));
+    if (track_changed && m->np_uid != 0) {
+        LOG_INFO("[MRP] now-playing item changed: \"%s\" (id %s) -> "
+                 "\"%s\" (id %s)",
+                 m->title ? m->title : "", m->item_id ? m->item_id : "-",
+                 title ? title : "", item_id ? item_id : "-");
+    }
     mrp_replace_str(&m->title, title);
     mrp_replace_str(&m->artist, artist);
     mrp_replace_str(&m->album, album);
+    mrp_replace_str(&m->item_id, item_id);
     m->duration_ms = duration_ms > 0 ? duration_ms : 0;
     if (track_changed || m->np_uid == 0) {
         uint64_t uid = 0;

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -1616,9 +1616,16 @@ bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
         uint64_t uid = 0;
         RAND_bytes((uint8_t *)&uid, sizeof(uid));
         m->np_uid = uid & 0x7FFFFFFFFFFFFFFFULL;
-        /* The old track's staged artwork must not ride the new item; the
-         * caller stages the new track's art (or none) right after this. */
-        if (track_changed) mrp_reset_artwork(m);
+        if (track_changed) {
+            /* The old track's staged artwork must not ride the new item; the
+             * caller stages the new track's art (or none) right after this. */
+            mrp_reset_artwork(m);
+            /* A new item starts at zero. Keeping the previous track's elapsed
+             * would push the new title at the old position; the sender's
+             * settled correction follows only when it starts elsewhere. */
+            m->elapsed_ms = 0;
+            m->elapsed_set_at = mrp_cf_now();
+        }
     }
     m->state_generation++;
     m->state_dirty = true;

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -1890,6 +1890,51 @@ bool ap2_mrp_build_nowplaying_command(struct ap2_mrp_ctx *m,
     return true;
 }
 
+bool ap2_mrp_build_nowplaying_progress_command(struct ap2_mrp_ctx *m,
+                                               uint8_t **out, int *out_len)
+{
+    if (!m || !out || !out_len) return false;
+    /* Pure timeline correction (seek): mergePolicy "update" carrying only the
+     * timeline fields. A "replace" push would need the artwork bytes riding
+     * along (any replace without ArtworkData drops the receiver's art — with
+     * or without the identifier keys, both hardware-verified), and a
+     * bytes-carrying push makes tvOS visibly re-decode and re-set the cover.
+     * The "update" shape measured on tvOS 26/27: HTTP 200, elapsed lands as
+     * an in-place content-item update, artworkAvailable stays true, no state
+     * re-render. A receiver that rejects the policy gets the full replace
+     * push instead (ap2cl_mrp_push_progress falls back per session). */
+    ap2_pl_node *info = ap2_pl_dict();
+    if (m->duration_ms > 0)
+        ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoDuration",
+                        ap2_pl_real((double)m->duration_ms / 1000.0));
+    ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoElapsedTime",
+                    ap2_pl_real((double)m->elapsed_ms / 1000.0));
+    ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoPlaybackRate",
+                    ap2_pl_real(m->playback_state == AP2_MRP_PLAYBACK_PLAYING
+                                    ? 1.0 : 0.0));
+    ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoDefaultPlaybackRate",
+                    ap2_pl_real(1.0));
+    ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoTimestamp",
+                    ap2_pl_date(m->elapsed_set_at > 0.0 ? m->elapsed_set_at
+                                                        : mrp_cf_now()));
+    ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoUniqueIdentifier",
+                    ap2_pl_int((int64_t)m->np_uid));
+
+    ap2_pl_node *params = ap2_pl_dict();
+    ap2_pl_dict_set(params, "type", ap2_pl_string("npi-text"));
+    ap2_pl_dict_set(params, "mergePolicy", ap2_pl_string("update"));
+    ap2_pl_dict_set(params, "params", info);
+    ap2_pl_node *root = ap2_pl_dict();
+    ap2_pl_dict_set(root, "type", ap2_pl_string("updateMRNowPlayingInfo"));
+    ap2_pl_dict_set(root, "params", params);
+
+    int len = ap2_pl_serialize(root, out);
+    ap2_pl_free(root);
+    if (len <= 0) return false;
+    *out_len = len;
+    return true;
+}
+
 /* Wrap a serialized protobuf as the bplist {"params": {"data": <varint length +
  * protobuf>}} that carries MRP messages — over the type-130 channel normally,
  * or over POST /command when that channel is unavailable (a real iPhone falls

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -1901,12 +1901,13 @@ bool ap2_mrp_build_nowplaying_progress_command(struct ap2_mrp_ctx *m,
      * bytes-carrying push makes tvOS visibly re-decode and re-set the cover.
      * The "update" shape measured on tvOS 26/27: HTTP 200, elapsed lands as
      * an in-place content-item update, artworkAvailable stays true, no state
-     * re-render. A receiver that rejects the policy gets the full replace
-     * push instead (ap2cl_mrp_push_progress falls back per session). */
+     * re-render. The dict stays minimal on purpose — no Duration (a total
+     * that changes re-lays-out the receiver's Now Playing screen) and no
+     * UniqueIdentifier (re-asserting the item identity invites a refresh);
+     * the update applies to the current now-playing item. A receiver that
+     * rejects the policy gets the full replace push instead
+     * (ap2cl_mrp_push_progress falls back per session). */
     ap2_pl_node *info = ap2_pl_dict();
-    if (m->duration_ms > 0)
-        ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoDuration",
-                        ap2_pl_real((double)m->duration_ms / 1000.0));
     ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoElapsedTime",
                     ap2_pl_real((double)m->elapsed_ms / 1000.0));
     ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoPlaybackRate",
@@ -1917,8 +1918,6 @@ bool ap2_mrp_build_nowplaying_progress_command(struct ap2_mrp_ctx *m,
     ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoTimestamp",
                     ap2_pl_date(m->elapsed_set_at > 0.0 ? m->elapsed_set_at
                                                         : mrp_cf_now()));
-    ap2_pl_dict_set(info, "kMRMediaRemoteNowPlayingInfoUniqueIdentifier",
-                    ap2_pl_int((int64_t)m->np_uid));
 
     ap2_pl_node *params = ap2_pl_dict();
     ap2_pl_dict_set(params, "type", ap2_pl_string("npi-text"));

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -50,6 +50,7 @@ typedef enum {
 typedef enum {
     AP2_MRP_ARTWORK_NOT_APPLICABLE = 0,
     AP2_MRP_ARTWORK_ACCEPTED,
+    AP2_MRP_ARTWORK_UNCHANGED,
     AP2_MRP_ARTWORK_INVALID_ARGUMENT,
     AP2_MRP_ARTWORK_UNSUPPORTED_TYPE,
     AP2_MRP_ARTWORK_STAGING_LIMIT,
@@ -167,6 +168,11 @@ bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
  * dimension, component, or JPEG-profile limit. Rejected input clears prior
  * MRP artwork so a new track cannot retain stale cover art.
  *
+ * Bytes identical to the retained image are a no-op reported as
+ * AP2_MRP_ARTWORK_UNCHANGED: the ArtworkIdentifier is kept so a redundant
+ * re-send (the server re-pushes artwork around seeks and anchors) cannot make
+ * the receiver invalidate and re-resolve the art it is already showing.
+ *
  * :param mime: image MIME type; must be "image/jpeg".
  * :param data: image bytes (copied).
  * :param len: image byte count.
@@ -247,12 +253,6 @@ int ap2_mrp_event_status(struct ap2_mrp_ctx *m);
  */
 bool ap2_mrp_build_nowplaying_command(struct ap2_mrp_ctx *m,
                                       uint8_t **out, int *out_len);
-
-/* Mark the one-shot artwork bytes as accepted after a successful POST. */
-void ap2_mrp_mark_artwork_sent(struct ap2_mrp_ctx *m);
-uint64_t ap2_mrp_artwork_generation(struct ap2_mrp_ctx *m);
-void ap2_mrp_mark_artwork_sent_if_generation(
-    struct ap2_mrp_ctx *m, uint64_t generation);
 
 /*
  * Build the origin-registration bodies a real iPhone POSTs to /command before

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -152,11 +152,18 @@ void ap2_mrp_stop(struct ap2_mrp_ctx *m);
  * Set the now-playing track metadata. Values are copied; NULL is treated as
  * empty. Takes effect on the next feedback-worker state push.
  *
+ * The now-playing item identity (UniqueIdentifier and retained artwork) is
+ * keyed on item_id when both the stored and incoming ids are non-empty:
+ * title/artist/album changes under the same item_id are tag refinements that
+ * update the existing item in place. Without ids, identity falls back to the
+ * title/artist/album tuple.
+ *
  * :param duration_ms: track duration in milliseconds (0 = unknown/live).
+ * :param item_id: sender's stable per-track identity ("" or NULL = none).
  */
 bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
                           const char *artist, const char *album,
-                          int duration_ms);
+                          int duration_ms, const char *item_id);
 
 /*
  * Set the now-playing artwork.

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -261,6 +261,13 @@ int ap2_mrp_event_status(struct ap2_mrp_ctx *m);
 bool ap2_mrp_build_nowplaying_command(struct ap2_mrp_ctx *m,
                                       uint8_t **out, int *out_len);
 
+/* Build the now-playing body for a pure timeline correction (seek): a
+ * mergePolicy "update" push carrying only the timeline fields, so the
+ * receiver keeps its artwork untouched (a replace push without the bytes
+ * drops it; one with the bytes visibly re-renders it). */
+bool ap2_mrp_build_nowplaying_progress_command(struct ap2_mrp_ctx *m,
+                                               uint8_t **out, int *out_len);
+
 /*
  * Build the origin-registration bodies a real iPhone POSTs to /command before
  * pushing now-playing (DESIGN.md §8), for the same encrypted RTSP channel:

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -381,7 +381,7 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
             raopcl_set_progress_ms(g_raopcl, g_metadata.progress * 1000, g_metadata.duration * 1000);
         } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
             ap2cl_set_progress(g_ap2cl, g_metadata.progress, g_metadata.duration);
-            mrp_status_report(ap2cl_mrp_push(g_ap2cl));
+            mrp_status_report(ap2cl_mrp_push_progress(g_ap2cl));
         }
     } else if (strcmp(key, "ARTWORK") == 0) {
         uint8_t *image = NULL;

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -259,7 +259,9 @@ static void mrp_status_report(int status)
 static void mrp_artwork_status_report(const ap2_mrp_artwork_info_t *info,
                                       int command_status)
 {
-    if (!info || info->result == AP2_MRP_ARTWORK_NOT_APPLICABLE) return;
+    if (!info || info->result == AP2_MRP_ARTWORK_NOT_APPLICABLE ||
+        info->result == AP2_MRP_ARTWORK_UNCHANGED)
+        return;
     if (info->result == AP2_MRP_ARTWORK_ACCEPTED) {
         status_print("[STATUS] mrp artwork=posted status=%d bytes=%zu "
                      "width=%u height=%u precision=%u sof=0x%02x "

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -343,6 +343,7 @@ static struct {
     char *title;    /* owned (strdup'd); NULL until first set */
     char *artist;
     char *album;
+    char *item_id;  /* sender's stable per-track identity (ITEMID key) */
     int duration;
     int progress;
 } g_metadata;
@@ -370,6 +371,8 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         metadata_set(&g_metadata.artist, value);
     } else if (strcmp(key, "ALBUM") == 0) {
         metadata_set(&g_metadata.album, value);
+    } else if (strcmp(key, "ITEMID") == 0) {
+        metadata_set(&g_metadata.item_id, value);
     } else if (strcmp(key, "DURATION") == 0) {
         g_metadata.duration = atoi(value);
     } else if (strcmp(key, "PROGRESS") == 0) {
@@ -498,7 +501,8 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
             ap2cl_set_metadata(g_ap2cl, metadata_str(g_metadata.title),
                                metadata_str(g_metadata.artist),
-                               metadata_str(g_metadata.album), g_metadata.duration);
+                               metadata_str(g_metadata.album), g_metadata.duration,
+                               metadata_str(g_metadata.item_id));
             mrp_status_report(ap2cl_mrp_push(g_ap2cl));
         }
     }
@@ -516,7 +520,8 @@ static void send_initial_metadata(const cli_config_t *cfg)
                         "asal", 's', metadata_str(g_metadata.album), "astn", 'i', 1);
     } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
         ap2cl_set_metadata(g_ap2cl, title, metadata_str(g_metadata.artist),
-                           metadata_str(g_metadata.album), g_metadata.duration);
+                           metadata_str(g_metadata.album), g_metadata.duration,
+                           metadata_str(g_metadata.item_id));
         mrp_status_report(ap2cl_mrp_push(g_ap2cl));
     }
 }

--- a/tests/test_ap2_event.c
+++ b/tests/test_ap2_event.c
@@ -288,7 +288,6 @@ static void test_artwork_snapshot_generation(const uint8_t secret[KEY_SIZE])
 
     assert(ap2_mrp_set_artwork(
         mrp, "image/jpeg", first_art, (int)sizeof(first_art), NULL));
-    uint64_t first_generation = ap2_mrp_artwork_generation(mrp);
     uint8_t *first_snapshot = NULL;
     int first_len = 0;
     assert(ap2_mrp_build_nowplaying_command(
@@ -296,24 +295,26 @@ static void test_artwork_snapshot_generation(const uint8_t secret[KEY_SIZE])
     assert(contains_bytes(
         first_snapshot, first_len, first_art, (int)sizeof(first_art)));
 
+    /* Replacement art replaces the staged bytes... */
     assert(ap2_mrp_set_artwork(
         mrp, "image/jpeg", second_art, (int)sizeof(second_art), NULL));
-    ap2_mrp_mark_artwork_sent_if_generation(mrp, first_generation);
-
     uint8_t *second_snapshot = NULL;
     int second_len = 0;
     assert(ap2_mrp_build_nowplaying_command(
         mrp, &second_snapshot, &second_len));
     assert(contains_bytes(
         second_snapshot, second_len, second_art, (int)sizeof(second_art)));
+    assert(!contains_bytes(
+        second_snapshot, second_len, first_art, (int)sizeof(first_art)));
 
-    uint64_t second_generation = ap2_mrp_artwork_generation(mrp);
-    ap2_mrp_mark_artwork_sent_if_generation(mrp, second_generation);
+    /* ...and the bytes ride every later snapshot too: the npi-text bridge
+     * replaces the receiver's whole now-playing info per push, so a snapshot
+     * without the bytes would drop the receiver's artwork. */
     uint8_t *reference_snapshot = NULL;
     int reference_len = 0;
     assert(ap2_mrp_build_nowplaying_command(
         mrp, &reference_snapshot, &reference_len));
-    assert(!contains_bytes(
+    assert(contains_bytes(
         reference_snapshot, reference_len,
         second_art, (int)sizeof(second_art)));
 

--- a/tests/test_mrp_artwork.c
+++ b/tests/test_mrp_artwork.c
@@ -255,7 +255,8 @@ static bool test_nowplaying_command_payload(void)
         "11111111-1111-1111-1111-111111111111",
         "22222222-2222-2222-2222-222222222222", NULL);
     CHECK(mrp != NULL);
-    CHECK(ap2_mrp_set_metadata(mrp, "Title", "Artist", "Album", 180000));
+    CHECK(ap2_mrp_set_metadata(mrp, "Title", "Artist", "Album", 180000,
+                               "item-1"));
     CHECK(ap2_mrp_set_progress(mrp, 15000, 180000, true));
 
     ap2_mrp_artwork_info_t info;
@@ -306,7 +307,8 @@ static bool test_nowplaying_command_payload(void)
         first, (size_t)first_len,
         "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_first));
     CHECK(uid_first != 0);
-    CHECK(ap2_mrp_set_metadata(mrp, "Title", "Artist", "Album", 180000));
+    CHECK(ap2_mrp_set_metadata(mrp, "Title", "Artist", "Album", 180000,
+                               "item-1"));
     uint8_t *stable = NULL;
     int stable_len = 0;
     CHECK(ap2_mrp_build_nowplaying_command(mrp, &stable, &stable_len));
@@ -320,9 +322,30 @@ static bool test_nowplaying_command_payload(void)
         "kMRMediaRemoteNowPlayingInfoArtworkData"));
     free(stable);
 
-    /* A real track change mints a new uid and drops the stale artwork; the
-     * caller stages the new track's art right after. */
-    CHECK(ap2_mrp_set_metadata(mrp, "Other Title", "Artist", "Album", 200000));
+    /* Tag refinement: the text tuple changes but the item id does not (the
+     * server's library enrichment can settle after playback starts). The
+     * item — uid and retained artwork — must stay, with the new strings. */
+    CHECK(ap2_mrp_set_metadata(mrp, "Title (remastered)", "Artist", "Album",
+                               180000, "item-1"));
+    uint8_t *refined = NULL;
+    int refined_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &refined, &refined_len));
+    uint64_t uid_refined = 0;
+    CHECK(ap2_bplist_find_uint(
+        refined, (size_t)refined_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_refined));
+    CHECK(uid_refined == uid_first);
+    CHECK(bytes_contain_string(refined, (size_t)refined_len,
+                               "Title (remastered)"));
+    CHECK(bytes_contain_string(
+        refined, (size_t)refined_len,
+        "kMRMediaRemoteNowPlayingInfoArtworkData"));
+    free(refined);
+
+    /* A real track change (new item id) mints a new uid and drops the stale
+     * artwork; the caller stages the new track's art right after. */
+    CHECK(ap2_mrp_set_metadata(mrp, "Other Title", "Artist", "Album", 200000,
+                               "item-2"));
     uint8_t *changed = NULL;
     int changed_len = 0;
     CHECK(ap2_mrp_build_nowplaying_command(mrp, &changed, &changed_len));
@@ -334,6 +357,20 @@ static bool test_nowplaying_command_payload(void)
     CHECK(!bytes_contain_string(
         changed, (size_t)changed_len,
         "kMRMediaRemoteNowPlayingInfoArtworkIdentifier"));
+
+    /* Without item ids on either side, identity falls back to the text
+     * tuple: same strings keep the item, different strings change it. */
+    CHECK(ap2_mrp_set_metadata(mrp, "Other Title", "Artist", "Album", 200000,
+                               NULL));
+    uint8_t *legacy = NULL;
+    int legacy_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &legacy, &legacy_len));
+    uint64_t uid_legacy = 0;
+    CHECK(ap2_bplist_find_uint(
+        legacy, (size_t)legacy_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_legacy));
+    CHECK(uid_legacy == uid_changed);
+    free(legacy);
     free(first);
     free(changed);
 

--- a/tests/test_mrp_artwork.c
+++ b/tests/test_mrp_artwork.c
@@ -10,6 +10,7 @@
 
 #include "cross_log.h"
 #include "artwork.h"
+#include "ap2_bplist.h"
 #include "ap2_client.h"
 #include "ap2_mrp_sync.h"
 
@@ -280,16 +281,61 @@ static bool test_nowplaying_command_payload(void)
     CHECK(bytes_contain(first, (size_t)first_len,
                         k_baseline_jpeg, sizeof(k_baseline_jpeg)));
 
-    ap2_mrp_mark_artwork_sent(mrp);
-    uint8_t *cached = NULL;
-    int cached_len = 0;
-    CHECK(ap2_mrp_build_nowplaying_command(mrp, &cached, &cached_len));
-    CHECK(cached_len < first_len);
-    CHECK(!bytes_contain_string(
-        cached, (size_t)cached_len,
+    /* The npi-text bridge replaces the receiver's whole now-playing info on
+     * every push, so the artwork bytes must ride every build (tvOS drops the
+     * art on any push that carries only the identifier). */
+    uint8_t *again = NULL;
+    int again_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &again, &again_len));
+    CHECK(bytes_contain_string(
+        again, (size_t)again_len,
         "kMRMediaRemoteNowPlayingInfoArtworkData"));
+    CHECK(bytes_contain(again, (size_t)again_len,
+                        k_baseline_jpeg, sizeof(k_baseline_jpeg)));
+    free(again);
+
+    /* Re-sending the identical image is a no-op that keeps the identifier. */
+    CHECK(ap2_mrp_set_artwork(mrp, "image/jpeg", k_baseline_jpeg,
+                              (int)sizeof(k_baseline_jpeg), &info));
+    CHECK(info.result == AP2_MRP_ARTWORK_UNCHANGED);
+
+    /* Re-sending the same track keeps the UniqueIdentifier (a fresh uid on a
+     * redundant metadata push would read as a new item and orphan the art). */
+    uint64_t uid_first = 0;
+    CHECK(ap2_bplist_find_uint(
+        first, (size_t)first_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_first));
+    CHECK(uid_first != 0);
+    CHECK(ap2_mrp_set_metadata(mrp, "Title", "Artist", "Album", 180000));
+    uint8_t *stable = NULL;
+    int stable_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &stable, &stable_len));
+    uint64_t uid_stable = 0;
+    CHECK(ap2_bplist_find_uint(
+        stable, (size_t)stable_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_stable));
+    CHECK(uid_stable == uid_first);
+    CHECK(bytes_contain_string(
+        stable, (size_t)stable_len,
+        "kMRMediaRemoteNowPlayingInfoArtworkData"));
+    free(stable);
+
+    /* A real track change mints a new uid and drops the stale artwork; the
+     * caller stages the new track's art right after. */
+    CHECK(ap2_mrp_set_metadata(mrp, "Other Title", "Artist", "Album", 200000));
+    uint8_t *changed = NULL;
+    int changed_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &changed, &changed_len));
+    uint64_t uid_changed = 0;
+    CHECK(ap2_bplist_find_uint(
+        changed, (size_t)changed_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_changed));
+    CHECK(uid_changed != uid_first);
+    CHECK(!bytes_contain_string(
+        changed, (size_t)changed_len,
+        "kMRMediaRemoteNowPlayingInfoArtworkIdentifier"));
     free(first);
-    free(cached);
+    free(changed);
 
     uint8_t *large = make_padded_jpeg(153600);
     CHECK(large != NULL);

--- a/tests/test_mrp_artwork.c
+++ b/tests/test_mrp_artwork.c
@@ -343,9 +343,11 @@ static bool test_nowplaying_command_payload(void)
     free(refined);
 
     /* A pure timeline correction (seek) is a mergePolicy-"update" push with
-     * only the timeline fields: no "replace" and no artwork keys, because a
-     * replace without the bytes drops the receiver's art and one with the
-     * bytes makes it visibly re-render the cover. */
+     * only the timeline fields: no "replace" and no artwork keys (a replace
+     * without the bytes drops the receiver's art; one with the bytes makes
+     * it visibly re-render the cover), and no duration or item identity
+     * either — a changing total or a re-asserted identity re-lays-out the
+     * receiver's Now Playing screen. */
     CHECK(ap2_mrp_set_progress(mrp, 120000, 180000, true));
     uint8_t *progress_cmd = NULL;
     int progress_cmd_len = 0;
@@ -357,11 +359,11 @@ static bool test_nowplaying_command_payload(void)
                                 "replace"));
     CHECK(!bytes_contain_string(progress_cmd, (size_t)progress_cmd_len,
                                 "kMRMediaRemoteNowPlayingInfoArtwork"));
-    uint64_t uid_progress = 0;
-    CHECK(ap2_bplist_find_uint(
+    CHECK(!bytes_contain_string(progress_cmd, (size_t)progress_cmd_len,
+                                "kMRMediaRemoteNowPlayingInfoDuration"));
+    CHECK(!bytes_contain_string(
         progress_cmd, (size_t)progress_cmd_len,
-        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_progress));
-    CHECK(uid_progress == uid_first);
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier"));
     free(progress_cmd);
 
     /* A real track change (new item id) mints a new uid and drops the stale

--- a/tests/test_mrp_artwork.c
+++ b/tests/test_mrp_artwork.c
@@ -342,6 +342,28 @@ static bool test_nowplaying_command_payload(void)
         "kMRMediaRemoteNowPlayingInfoArtworkData"));
     free(refined);
 
+    /* A pure timeline correction (seek) is a mergePolicy-"update" push with
+     * only the timeline fields: no "replace" and no artwork keys, because a
+     * replace without the bytes drops the receiver's art and one with the
+     * bytes makes it visibly re-render the cover. */
+    CHECK(ap2_mrp_set_progress(mrp, 120000, 180000, true));
+    uint8_t *progress_cmd = NULL;
+    int progress_cmd_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_progress_command(
+        mrp, &progress_cmd, &progress_cmd_len));
+    CHECK(bytes_contain_string(progress_cmd, (size_t)progress_cmd_len,
+                               "kMRMediaRemoteNowPlayingInfoElapsedTime"));
+    CHECK(!bytes_contain_string(progress_cmd, (size_t)progress_cmd_len,
+                                "replace"));
+    CHECK(!bytes_contain_string(progress_cmd, (size_t)progress_cmd_len,
+                                "kMRMediaRemoteNowPlayingInfoArtwork"));
+    uint64_t uid_progress = 0;
+    CHECK(ap2_bplist_find_uint(
+        progress_cmd, (size_t)progress_cmd_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_progress));
+    CHECK(uid_progress == uid_first);
+    free(progress_cmd);
+
     /* A real track change (new item id) mints a new uid and drops the stale
      * artwork; the caller stages the new track's art right after. */
     CHECK(ap2_mrp_set_metadata(mrp, "Other Title", "Artist", "Album", 200000,


### PR DESCRIPTION
Seeking on an Apple TV made its now-playing overlay pop up twice — first with cover art, then without — and cover art could go missing after a seek or at the start of a track. Tracing against real hardware showed compounding causes: every metadata re-send presented as a brand-new track, the receiver drops artwork on any full update that doesn't include the image bytes, and every update message makes the TV redraw its screen.

Metadata for a track is now stable for its whole playback, and the TV redraws only when something really changed — once per track change and one brief refresh per seek, the same as AirPlay from an iPhone.

- Now-playing identity is keyed on a stable per-track id from the server, so later tag refinements update the current item instead of presenting as a new track (title/artist/album comparison remains the fallback)
- Cover-art bytes ride every full metadata update (the receiver drops artwork without them), while re-sends of the identical image are ignored entirely
- Seek corrections use a small merge-style update that leaves title and artwork untouched instead of replacing the whole now-playing state
- The duplicate legacy progress message is skipped on sessions with the MediaRemote bridge — it caused an extra screen redraw per seek; receivers without the bridge keep it as their only progress channel
- A changed track starts at 0:00 immediately instead of briefly showing the previous track's position

The paired server change (stable track id + real track duration in the metadata) completes the picture; the binary alone already prevents the artwork loss.