### PR TITLE
Fix noise bursts on Apple devices when pausing and after network dropouts

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -635,7 +635,15 @@ capture.
   on an Apple TV 4K, tvOS 27, 2026-07-30: the only clean warm transitions
   were a natural drain and a bitstream-continuous splice (Apple senders never
   exercise this corner — realtime streams are live and music seeks ride the
-  buffered lane). The 2026-07-31 fleet A/B validated the same mechanism on
+  buffered lane). A further ear-measured trigger (Apple TV 4K, 2026-07-31):
+  a queue UNDERRUN while the session stays armed pops as well — heard as a
+  burst at the pause press — while a teardown with audio still queued is
+  clean. An armed splice line is therefore never allowed to run dry: the
+  idle-primed FLUSH→START gap, a content pause, and the post-EOF drain/idle
+  window each keep the wire fed with encoded silence, and a delivery stall
+  longer than the pacing depth splice-pads the timeline forward (reported as
+  REANCHOR) instead of bursting the queued content on past timestamps when
+  sending resumes. The 2026-07-31 fleet A/B validated the same mechanism on
   the third-party park (Sonos Era 100 pair and solo, Sonos Bookshelf, WiiM
   Pro, Edifier MS50A, Samsung HW-LS60D:
   cold/seek/next/pause/park/keepalive/late-join/group runs plus

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2706,6 +2706,42 @@ bool ap2cl_accept_frames(struct ap2cl_s *p)
     return raopcl_accept_frames(p->raopcl);
 }
 
+/* Shared splice-pad recovery (input starvation and delivery stalls): queue
+ * silence padding from the EFFECTIVE head — the frozen head plus any pad
+ * already owed — up to now plus the recovery lead, on the same immutable
+ * line. The audio loop sends the pad as ordinary encoded chunks, so the wire
+ * stays bitstream-continuous through the stall (a stamp jump, a line move
+ * and late frames are each an audible noise trigger). Playback shifts later
+ * by the pad, reported as REANCHOR so MA keeps tracking the drift. Gating on
+ * the effective head makes repeated calls idempotent while a queued pad
+ * drains: once silence covering the gap is owed, the timeline is already
+ * recovered and another call must not stack a second shift on top. Fires
+ * only when the effective head is at or behind `lapse_ts` (each caller's
+ * notion of "too late"). */
+static bool ap2_splice_pad_to_lead(struct ap2cl_s *p, uint64_t now_ts,
+                                   uint64_t lapse_ts, const char *cause)
+{
+    uint64_t window = ap2_pacing_window_frames(p);
+    uint64_t latency = MS2TS(p->latency_ms, p->format.sample_rate);
+    uint64_t recovery_lead = latency < window ? latency : window;
+    uint64_t effective_head = p->head_ts + p->splice_pad_frames;
+    if (effective_head > lapse_ts) return false;
+    uint64_t target = now_ts + recovery_lead;
+    if (target <= effective_head) return false;
+    uint64_t pad = target - effective_head;
+    p->splice_pad_frames += (uint32_t)pad;
+    p->timeline_reanchors++;
+    p->reanchor_shifted_frames += pad;
+    LOG_WARN("[AP2] Splice-padded after %s: shifted_frames="
+             "%" PRIu64 " lead_frames=%" PRIu64 " count=%" PRIu64,
+             cause, pad, recovery_lead, p->timeline_reanchors);
+    fprintf(stderr, "[STATUS] REANCHOR shifted_frames=%" PRIu64
+            " total_shifted_frames=%" PRIu64 " sample_rate=%d\n",
+            pad, p->reanchor_shifted_frames, p->format.sample_rate);
+    fflush(stderr);
+    return true;
+}
+
 bool ap2cl_recover_input_gap(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->state != AP2_STREAMING)
@@ -2718,27 +2754,11 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p)
     uint64_t recovery_lead = latency < window ? latency : window;
 
     if (p->splice_timeline) {
-        /* Splice recovery, same immutable-line rule as seek/resume: when the
-         * input stalls long enough that the head falls inside the minimum
-         * lead, queue silence padding up to now plus the recovery lead. The
-         * audio loop sends it as ordinary encoded chunks, so the wire stays
-         * bitstream-continuous through the stall (a stamp jump, a line move
-         * and late frames are each an audible noise trigger). Playback shifts
-         * later by the pad, reported as REANCHOR exactly like the stock path
-         * so MA keeps tracking the drift. */
-        if (p->head_ts > now_ts + floor) return false;
-        uint64_t pad = now_ts + recovery_lead - p->head_ts;
-        p->splice_pad_frames += (uint32_t)pad;
-        p->timeline_reanchors++;
-        p->reanchor_shifted_frames += pad;
-        LOG_WARN("[AP2] Splice-padded after PCM starvation: shifted_frames="
-                 "%" PRIu64 " lead_frames=%" PRIu64 " count=%" PRIu64,
-                 pad, recovery_lead, p->timeline_reanchors);
-        fprintf(stderr, "[STATUS] REANCHOR shifted_frames=%" PRIu64
-                " total_shifted_frames=%" PRIu64 " sample_rate=%d\n",
-                pad, p->reanchor_shifted_frames, p->format.sample_rate);
-        fflush(stderr);
-        return true;
+        /* Input is dry, so the recovery is anticipatory: pad as soon as the
+         * head falls inside the minimum lead — with nothing left to send the
+         * lapse is otherwise inevitable. */
+        return ap2_splice_pad_to_lead(p, now_ts, now_ts + floor,
+                                      "PCM starvation");
     }
 
     ap2_timeline_recovery_t recovery;
@@ -2776,6 +2796,33 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p)
             p->format.sample_rate);
     fflush(stderr);
     return true;
+}
+
+bool ap2cl_recover_delivery_gap(struct ap2cl_s *p)
+{
+    if (!p || p->flow != FLOW_NATIVE_AP2 || p->state != AP2_STREAMING ||
+        !p->splice_timeline)
+        return false;
+
+    /* DELIVERY stalled (process freeze, network dropout) longer than the
+     * shallow pacing depth: the head lapsed behind the wall clock while the
+     * input ring still holds audio, so the starvation recovery above never
+     * sees it — and without this guard the audio loop bursts the queued
+     * content on past timestamps until the head catches back up (late-frame
+     * delivery, an audible noise trigger on Apple receivers; log signature
+     * "TX PTP sync ... ahead=-N"). Pad the timeline forward instead, exactly
+     * like the starvation recovery.
+     *
+     * Unlike that recovery this trigger is strictly "behind now", not the
+     * anticipatory minimum-lead floor: content is still queued here, and a
+     * stall shorter than the pacing depth leaves the head between now and
+     * the depth — the receiver's queue never ran dry and the pending frames
+     * are on time, so padding would insert an audible silence gap into
+     * otherwise unbroken audio. It also keeps this guard, which runs every
+     * send iteration, quiet in the moments after a start resolved to the
+     * feasibility floor (head sits just under now + floor by construction). */
+    uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
+    return ap2_splice_pad_to_lead(p, now_ts, now_ts, "delivery stall");
 }
 
 void ap2cl_log_diagnostics(struct ap2cl_s *p)
@@ -3586,6 +3633,20 @@ bool ap2cl_test_anchor_valid(struct ap2cl_s *p)
 uint64_t ap2cl_test_head_ts(struct ap2cl_s *p)
 {
     return p->head_ts;
+}
+
+/* Move the delivery head as a stall would find it: the wire timestamp stays
+ * locked to the head (they advance together in the send path), so the
+ * head<->rtp invariant survives the manipulation. */
+void ap2cl_test_set_head_ts(struct ap2cl_s *p, uint64_t head)
+{
+    p->head_ts = head;
+    p->rtp_timestamp = (uint32_t)head + atomic_load(&p->rtp_offset);
+}
+
+uint64_t ap2cl_test_timeline_reanchors(struct ap2cl_s *p)
+{
+    return p->timeline_reanchors;
 }
 
 uint32_t ap2cl_test_rtp_timestamp(struct ap2cl_s *p)

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -188,6 +188,10 @@ struct ap2cl_s {
     uint32_t splice_pad_frames;   /* silence frames still to send before the
                                      next real sample so it lands exactly on
                                      the commanded splice instant */
+    bool content_paused;          /* splice pause: the content is paused but
+                                     the wire stays fed (state remains
+                                     AP2_STREAMING), so the MRP playback state
+                                     needs its own truth */
     uint64_t reanchor_shifted_frames; /* cumulative shift since the last start/
                                         * resume, for [STATUS] REANCHOR */
 
@@ -2388,6 +2392,7 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
                                 uint64_t *at_unix_ms)
 {
     if (!p) return AP2_COMMIT_FAILED;
+    p->content_paused = false;
     uint64_t ntp_start = 0;
     ap2_resolve_start(start_unix_ms,
                       raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS),
@@ -2443,6 +2448,7 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
 void ap2cl_standby(struct ap2cl_s *p)
 {
     if (!p || p->state == AP2_DOWN) return;
+    p->content_paused = false;
     if (p->flow != FLOW_NATIVE_AP2) {
         if (p->raopcl) raop_session_standby(p->raopcl);
         p->state = AP2_CONNECTED;
@@ -2535,6 +2541,7 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
                                  uint64_t *at_unix_ms)
 {
     if (!p || p->state == AP2_DOWN) return AP2_COMMIT_FAILED;
+    p->content_paused = false;
 
     if (p->flow != FLOW_NATIVE_AP2) {
         ap2_commit_result_t r =
@@ -2846,10 +2853,22 @@ void ap2cl_pause(struct ap2cl_s *p)
 {
     if (!p) return;
     if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
-    /* Splice mode: the immutable line must survive the pause — the un-pause
-     * skips stamps forward on it. Elsewhere resume re-anchors a fresh line. */
-    if (!p->splice_timeline)
-        p->rt_anchor_valid = false;
+    if (p->splice_timeline) {
+        /* Splice pause stops the CONTENT, never the wire: an Apple receiver
+         * whose queue underruns while the session stays armed emits a noise
+         * burst (measured at the pause press, ear A/B 2026-07-31 — the same
+         * pop whether or not the pause is announced over MRP; a teardown
+         * with audio still queued is clean). The client therefore stays in
+         * AP2_STREAMING and the audio loop keeps the line fed with encoded
+         * silence; the un-pause splices the content back in on the hot line
+         * and the immutable anchor survives by construction. content_paused
+         * keeps the published now-playing state truthful meanwhile. */
+        p->content_paused = true;
+        ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_PAUSED, true);
+        return;
+    }
+    /* Stock timeline: park the stream; resume re-anchors a fresh line. */
+    p->rt_anchor_valid = false;
     p->state = AP2_PAUSED;
     ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_PAUSED, true);
 }
@@ -2857,6 +2876,7 @@ void ap2cl_pause(struct ap2cl_s *p)
 void ap2cl_play(struct ap2cl_s *p)
 {
     if (!p) return;
+    p->content_paused = false;
     if (p->raopcl) {
         int lat = raopcl_latency(p->raopcl);
         uint64_t now = raopcl_get_ntp(NULL);
@@ -2897,6 +2917,7 @@ void ap2cl_play(struct ap2cl_s *p)
 void ap2cl_stop(struct ap2cl_s *p)
 {
     if (!p) return;
+    p->content_paused = false;
     if (p->raopcl) raopcl_stop(p->raopcl);
     ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
     p->rt_anchor_valid = false;
@@ -3188,9 +3209,9 @@ static void ap2_mrp_publish_playback(struct ap2cl_s *p,
 static int ap2_mrp_send_extended_registration(struct ap2cl_s *p)
 {
     ap2_mrp_playback_state_t state =
+        p->state == AP2_PAUSED || p->content_paused ? AP2_MRP_PLAYBACK_PAUSED :
         p->state == AP2_STREAMING ? AP2_MRP_PLAYBACK_PLAYING :
-        p->state == AP2_PAUSED ? AP2_MRP_PLAYBACK_PAUSED :
-                                 AP2_MRP_PLAYBACK_STOPPED;
+                                    AP2_MRP_PLAYBACK_STOPPED;
 
     int st_cmd = ap2_mrp_post_command(
         p, ap2_mrp_build_supportedcommands_command,
@@ -3240,9 +3261,10 @@ static ap2_mrp_push_result_t ap2cl_mrp_push_serialized_with(
         ext_status = ap2_mrp_send_extended_registration(p);
     } else {
         ap2_mrp_playback_state_t state =
+            p->state == AP2_PAUSED || p->content_paused
+                ? AP2_MRP_PLAYBACK_PAUSED :
             p->state == AP2_STREAMING ? AP2_MRP_PLAYBACK_PLAYING :
-            p->state == AP2_PAUSED ? AP2_MRP_PLAYBACK_PAUSED :
-                                     AP2_MRP_PLAYBACK_STOPPED;
+                                        AP2_MRP_PLAYBACK_STOPPED;
         ext_status = ap2_mrp_send_playback_state(p, state, false);
     }
     if (!ap2_mrp_status_ok(ext_status)) result.overall_status = ext_status;

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -219,6 +219,12 @@ bool ap2cl_accept_frames(struct ap2cl_s *p);
 /* Re-anchor a realtime stream after PCM starvation exhausts its pacing lead. */
 bool ap2cl_recover_input_gap(struct ap2cl_s *p);
 
+/* Splice-pad a realtime stream whose delivery head lapsed behind the wall
+ * clock (a delivery stall longer than the pacing depth, with input still
+ * queued) so the loop never sends frames on past timestamps. Splice timeline
+ * only; call before reading each chunk. Returns true when it padded. */
+bool ap2cl_recover_delivery_gap(struct ap2cl_s *p);
+
 /* Emit native pacing, packet-drop, and anchor diagnostics at debug level 10. */
 void ap2cl_log_diagnostics(struct ap2cl_s *p);
 

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -976,6 +976,23 @@ static int run_raop(cli_config_t *cfg)
 
 /* ---- AirPlay 2 playback loop ---- */
 
+/* One chunk of encoded silence on the live splice line — the keepalive for
+ * every armed window without content (idle-primed FLUSH->START gap, content
+ * pause, post-EOF drain/idle). The wire stays bitstream-continuous and the
+ * receiver's queue never underruns. Returns false on a fatal send failure. */
+static bool ap2_send_silence_chunk(const cli_config_t *cfg, uint8_t *buf,
+                                   uint8_t *alac_buf, int input_bpf)
+{
+    memset(buf, 0, (size_t)AP2_FRAMES_PER_CHUNK * input_bpf);
+    uint8_t *send = buf;
+    if (alac_buf && cfg->bit_depth > 16) {
+        truncate_32to24(buf, AP2_FRAMES_PER_CHUNK * input_bpf, alac_buf);
+        send = alac_buf;
+    }
+    return ap2cl_send_chunk(g_ap2cl, send, AP2_FRAMES_PER_CHUNK) !=
+           AP2_SEND_FATAL;
+}
+
 static int run_airplay2(cli_config_t *cfg)
 {
     ap2_device_info_t device = {
@@ -1144,15 +1161,36 @@ static int run_airplay2(cli_config_t *cfg)
         }
 
         if (input_ended) {
-            /* Input consumed: let the receiver drain, report once, then idle
-             * awaiting the next START or the idle timeout. */
+            /* Input consumed: the content drains on schedule and eof is
+             * reported once; then idle awaiting the next START or the idle
+             * timeout. An armed splice line keeps carrying silence through
+             * the drain and the idle wait: a receiver whose queue underruns
+             * while the session stays armed pops audibly (the end-of-playback
+             * burst on Apple receivers), while a later teardown with silence
+             * still queued is clean. */
             bool drained = !ap2cl_is_playing(g_ap2cl) ||
                            now - eof_time > MS2NTP(cfg->latency_ms + 2000);
             if (drained && !eof_reported) {
                 eof_reported = true;
                 status_eof();
             }
-            usleep(drained ? 50000 : 10000);
+            if (cfg->protocol == PROTO_AIRPLAY2 &&
+                ap2cl_splice_hot(g_ap2cl)) {
+                pthread_mutex_lock(&g_audio_send_lock);
+                if (ap2cl_splice_hot(g_ap2cl) &&
+                    ap2cl_accept_frames(g_ap2cl) &&
+                    !ap2_send_silence_chunk(cfg, buf, ap2_alac_buf,
+                                            ap2_input_bpf)) {
+                    status_error("AirPlay 2 realtime send failed");
+                    playback_failed = true;
+                    pthread_mutex_unlock(&g_audio_send_lock);
+                    break;
+                }
+                pthread_mutex_unlock(&g_audio_send_lock);
+                usleep(1000);
+            } else {
+                usleep(drained ? 50000 : 10000);
+            }
             continue;
         }
 
@@ -1265,38 +1303,28 @@ static int run_airplay2(cli_config_t *cfg)
             pthread_mutex_unlock(&g_audio_send_lock);
         } else {
             /* Paused, or connected and awaiting the commanded first START.
-             * On the splice timeline the idle-primed window between a FLUSH
-             * and the next START keeps sending silence: if the wire went
-             * quiet here, a slow next-track spin-up would lapse the line and
-             * force a fresh re-anchor — an audible noise trigger on Apple
-             * receivers (the track-transition blip). Contiguous silence keeps
-             * every boundary a hot splice; the resume pad still lands the new
-             * content on the commanded instant. Pause and standby park the
-             * client out of AP2_STREAMING, so they drain as before. */
+             * On the splice timeline every armed window keeps sending
+             * silence: the idle-primed gap between a FLUSH and the next
+             * START (a slow next-track spin-up must not lapse the line —
+             * the track-transition blip), and a content pause (a receiver
+             * whose queue underruns while the session stays armed pops at
+             * the pause press — measured by ear A/B on an Apple TV 4K,
+             * 2026-07-31). Contiguous silence keeps every boundary a hot
+             * splice; the resume pad still lands the new content on the
+             * commanded instant. Standby and stop park the client out of
+             * AP2_STREAMING, so they drain as before. */
             if (g_first_start_done && cfg->protocol == PROTO_AIRPLAY2 &&
-                ap2_session_state(g_session) == AP2_SESSION_IDLE &&
                 ap2cl_splice_hot(g_ap2cl)) {
                 pthread_mutex_lock(&g_audio_send_lock);
-                if (ap2_session_state(g_session) == AP2_SESSION_IDLE &&
+                if (g_status == STATUS_PAUSED &&
                     ap2cl_splice_hot(g_ap2cl) &&
-                    ap2cl_accept_frames(g_ap2cl)) {
-                    memset(buf, 0,
-                           (size_t)AP2_FRAMES_PER_CHUNK * ap2_input_bpf);
-                    uint8_t *send = buf;
-                    if (ap2_alac_buf && cfg->bit_depth > 16) {
-                        truncate_32to24(
-                            buf, AP2_FRAMES_PER_CHUNK * ap2_input_bpf,
-                            ap2_alac_buf);
-                        send = ap2_alac_buf;
-                    }
-                    if (ap2cl_send_chunk(g_ap2cl, send,
-                                         AP2_FRAMES_PER_CHUNK) ==
-                        AP2_SEND_FATAL) {
-                        status_error("AirPlay 2 realtime send failed");
-                        playback_failed = true;
-                        pthread_mutex_unlock(&g_audio_send_lock);
-                        break;
-                    }
+                    ap2cl_accept_frames(g_ap2cl) &&
+                    !ap2_send_silence_chunk(cfg, buf, ap2_alac_buf,
+                                            ap2_input_bpf)) {
+                    status_error("AirPlay 2 realtime send failed");
+                    playback_failed = true;
+                    pthread_mutex_unlock(&g_audio_send_lock);
+                    break;
                 }
                 pthread_mutex_unlock(&g_audio_send_lock);
             }

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -1173,6 +1173,16 @@ static int run_airplay2(cli_config_t *cfg)
                 eof_reported = false;
                 eof_time = 0;
             }
+            /* Delivery-stall guard (splice timeline): a stall longer than
+             * the pacing depth — process freeze, network dropout — leaves
+             * the head behind the wall clock with input still queued, which
+             * the zero-read starvation recovery below can never see. Pad the
+             * timeline forward before reading, or this iteration would send
+             * real content on past timestamps (an audible noise trigger on
+             * Apple receivers). Gated like that recovery: a frozen head
+             * outside session-PLAYING is a parked timeline, not a stall. */
+            if (ap2_session_state(g_session) == AP2_SESSION_PLAYING)
+                ap2cl_recover_delivery_gap(g_ap2cl);
             /* Splice pad (splice timeline): silence owed to the wire
              * before the next real sample, sent as ordinary encoded chunks so
              * sequence numbers and timestamps stay contiguous (any stamp jump

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -610,6 +610,79 @@ static void test_splice_delivery_gap_recovery(void)
     puts("ap2_client splice delivery-gap recovery tests passed");
 }
 
+/* A splice pause stops the content, never the wire: the client must stay in
+ * AP2_STREAMING with the line hot (the audio loop keeps feeding silence), so
+ * a receiver whose queue would otherwise underrun while the session stays
+ * armed never pops (the pause-press burst, ear-measured on an Apple TV 4K).
+ * The un-pause splices back in on the same line — no stamp move, no
+ * re-anchor. The stock timeline keeps its parked pause. */
+static void test_splice_pause_keeps_line_hot(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    assert(fcntl(sockets[1], F_SETFL, O_NONBLOCK) == 0);
+
+    ap2_device_info_t device = {
+        .name = "pause keepalive test",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+    ap2cl_test_set_splice(client, true);
+    assert(ap2cl_start(client, 0, NULL) == AP2_COMMIT_OK);
+    ap2cl_test_set_first_packet(client, false);
+    ap2cl_test_set_anchor_valid(client, true);
+    uint64_t head_before = ap2cl_test_head_ts(client);
+    uint32_t rtp_before = ap2cl_test_rtp_timestamp(client);
+
+    ap2cl_pause(client);
+    assert(ap2cl_state(client) == AP2_STREAMING);
+    assert(ap2cl_is_playing(client));
+    assert(ap2cl_splice_hot(client));
+    assert(ap2cl_test_anchor_valid(client));
+    assert(ap2cl_test_head_ts(client) == head_before);
+    assert(ap2cl_test_rtp_timestamp(client) == rtp_before);
+    assert(ap2cl_splice_pad_frames(client) == 0);
+
+    ap2cl_play(client);
+    assert(ap2cl_state(client) == AP2_STREAMING);
+    assert(!ap2cl_test_first_packet(client));
+    assert(ap2cl_test_anchor_valid(client));
+    assert(ap2cl_test_head_ts(client) == head_before);
+    assert(ap2cl_test_rtp_timestamp(client) == rtp_before);
+    /* A hot un-pause may owe silence up to the minimum lead, never more —
+     * and never moves a stamp. */
+    assert(ap2cl_splice_pad_frames(client) < 22050);
+
+    /* The stock (deny-listed) timeline keeps the parked pause. */
+    ap2cl_test_set_splice(client, false);
+    ap2cl_pause(client);
+    assert(ap2cl_state(client) == AP2_PAUSED);
+    assert(!ap2cl_is_playing(client));
+    assert(!ap2cl_test_anchor_valid(client));
+
+    /* Neither pause shape touches the RTSP socket. */
+    char scratch[16];
+    assert(recv(sockets[1], scratch, sizeof(scratch), 0) == -1);
+    assert(errno == EAGAIN || errno == EWOULDBLOCK);
+
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+    puts("ap2_client splice pause keepalive tests passed");
+}
+
 /* An explicit --protocol airplay2 reaches the native flow on exactly the same
  * terms as auto, so an AirPlay-2-only receiver (no _raop service to fall back
  * on) is not routed into a RAOP-compatible flow it cannot answer. Only a real
@@ -710,6 +783,7 @@ int main(void)
     test_splice_default_resolution();
     test_splice_timeline_warm_path();
     test_splice_delivery_gap_recovery();
+    test_splice_pause_keeps_line_hot();
     test_feedback_miss_tolerated_then_recovered();
 
     ap2_device_info_t device = {

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -559,10 +559,13 @@ static void test_splice_delivery_gap_recovery(void)
     assert(close(capture[0]) == 0);
 
     assert(padded);
-    /* ~1.75 s of lapse plus the 600 ms recovery lead, with slack for the
-     * wall clock advancing between start and guard. */
+    /* ~1.75 s of lapse plus the 600 ms recovery lead. The wall clock keeps
+     * advancing between start and guard, so the upper bound is a loose
+     * sanity rail (a doubled shift would be ~207k frames — and the refire
+     * check below pins stacking exactly); the lower bound is the
+     * deterministic minimum. */
     uint32_t pad = ap2cl_splice_pad_frames(client);
-    assert(pad > 103000 && pad < 110000);
+    assert(pad > 103000 && pad < 176400);
     assert(ap2cl_test_timeline_reanchors(client) == 1);
     /* Bitstream continuity: the pad is queued, the stamps never move and the
      * anchor line stays frozen. */

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -33,6 +33,8 @@ bool ap2cl_test_splice_default(const char *txt, const char *am);
 void ap2cl_test_set_anchor_valid(struct ap2cl_s *p, bool valid);
 bool ap2cl_test_anchor_valid(struct ap2cl_s *p);
 uint64_t ap2cl_test_head_ts(struct ap2cl_s *p);
+void ap2cl_test_set_head_ts(struct ap2cl_s *p, uint64_t head);
+uint64_t ap2cl_test_timeline_reanchors(struct ap2cl_s *p);
 uint32_t ap2cl_test_rtp_timestamp(struct ap2cl_s *p);
 
 typedef struct {
@@ -494,6 +496,120 @@ static void test_splice_timeline_warm_path(void)
     assert(ap2cl_destroy(client));
 }
 
+/* A delivery stall longer than the pacing depth (process freeze, network
+ * dropout) leaves the head behind the wall clock with input still queued.
+ * The guard must splice-pad the timeline forward — silence on the immutable
+ * line, no stamp jump, no RTSP verb — and report the shift as a REANCHOR,
+ * instead of letting the loop burst real frames on past timestamps (an
+ * audible noise trigger on Apple receivers). A healthy head, a pending pad,
+ * a non-splice stream and a parked session must each leave it silent. */
+static void test_splice_delivery_gap_recovery(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    assert(fcntl(sockets[1], F_SETFL, O_NONBLOCK) == 0);
+
+    ap2_device_info_t device = {
+        .name = "delivery gap test",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+    ap2cl_test_set_splice(client, true);
+    assert(ap2cl_start(client, 0, NULL) == AP2_COMMIT_OK);
+    ap2cl_test_set_first_packet(client, false);
+    ap2cl_test_set_anchor_valid(client, true);
+
+    /* Fresh start: the head sits just under now + the feasibility floor by
+     * construction. The guard runs every send iteration, so it must read
+     * that as healthy, not as a lapse. */
+    assert(!ap2cl_recover_delivery_gap(client));
+    assert(ap2cl_splice_pad_frames(client) == 0);
+    assert(ap2cl_test_timeline_reanchors(client) == 0);
+
+    /* Stall: drag the head 2 s back (a freeze longer than the 600 ms pacing
+     * depth leaves it ~1.75 s behind the wall clock), then capture stderr
+     * around the guard to pin the machine-readable REANCHOR line. */
+    uint64_t lapsed = ap2cl_test_head_ts(client) - 2 * 44100;
+    ap2cl_test_set_head_ts(client, lapsed);
+    uint32_t rtp_before = ap2cl_test_rtp_timestamp(client);
+    fflush(stderr);
+    int saved_stderr = dup(2);
+    int capture[2];
+    assert(saved_stderr >= 0 && pipe(capture) == 0);
+    assert(dup2(capture[1], 2) == 2);
+    assert(close(capture[1]) == 0);
+    bool padded = ap2cl_recover_delivery_gap(client);
+    fflush(stderr);
+    assert(dup2(saved_stderr, 2) == 2);
+    assert(close(saved_stderr) == 0);
+    char captured[512] = {0};
+    ssize_t captured_len =
+        read(capture[0], captured, sizeof(captured) - 1);
+    assert(close(capture[0]) == 0);
+
+    assert(padded);
+    /* ~1.75 s of lapse plus the 600 ms recovery lead, with slack for the
+     * wall clock advancing between start and guard. */
+    uint32_t pad = ap2cl_splice_pad_frames(client);
+    assert(pad > 103000 && pad < 110000);
+    assert(ap2cl_test_timeline_reanchors(client) == 1);
+    /* Bitstream continuity: the pad is queued, the stamps never move and the
+     * anchor line stays frozen. */
+    assert(ap2cl_test_head_ts(client) == lapsed);
+    assert(ap2cl_test_rtp_timestamp(client) == rtp_before);
+    assert(ap2cl_test_anchor_valid(client));
+    assert(captured_len > 0);
+    assert(strstr(captured, "[STATUS] REANCHOR shifted_frames="));
+    assert(strstr(captured, "sample_rate=44100"));
+
+    /* While the queued pad drains, the timeline is already recovered: an
+     * immediate re-check must not stack a second shift on top. */
+    assert(!ap2cl_recover_delivery_gap(client));
+    assert(ap2cl_splice_pad_frames(client) == pad);
+    assert(ap2cl_test_timeline_reanchors(client) == 1);
+
+    /* Pad fully sent (the head advances as the loop delivers it): healthy. */
+    ap2cl_test_set_head_ts(client, lapsed + pad);
+    ap2cl_splice_pad_consume(client, pad);
+    assert(!ap2cl_recover_delivery_gap(client));
+    assert(ap2cl_test_timeline_reanchors(client) == 1);
+
+    /* The stock (deny-listed) timeline keeps today's delivery behavior. */
+    ap2cl_test_set_head_ts(client, lapsed);
+    ap2cl_test_set_splice(client, false);
+    assert(!ap2cl_recover_delivery_gap(client));
+    assert(ap2cl_splice_pad_frames(client) == 0);
+    ap2cl_test_set_splice(client, true);
+
+    /* A parked session is a frozen timeline by design, not a stall. */
+    ap2cl_standby(client);
+    assert(ap2cl_state(client) == AP2_CONNECTED);
+    assert(!ap2cl_recover_delivery_gap(client));
+    assert(ap2cl_test_timeline_reanchors(client) == 1);
+
+    /* The whole recovery put nothing on the RTSP socket. */
+    char scratch[16];
+    assert(recv(sockets[1], scratch, sizeof(scratch), 0) == -1);
+    assert(errno == EAGAIN || errno == EWOULDBLOCK);
+
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+    puts("ap2_client splice delivery-gap recovery tests passed");
+}
+
 /* An explicit --protocol airplay2 reaches the native flow on exactly the same
  * terms as auto, so an AirPlay-2-only receiver (no _raop service to fall back
  * on) is not routed into a RAOP-compatible flow it cannot answer. Only a real
@@ -593,6 +709,7 @@ int main(void)
     test_native_flush_rejects_receiver_error();
     test_splice_default_resolution();
     test_splice_timeline_warm_path();
+    test_splice_delivery_gap_recovery();
     test_feedback_miss_tolerated_then_recovered();
 
     ap2_device_info_t device = {


### PR DESCRIPTION
Apple receivers emit a short static burst whenever their realtime audio queue underruns while the session is still armed — ear-measured on an Apple TV 4K: the burst users hear when pressing pause, and again at the end of playback, while a teardown with audio still queued is clean. Separately, a delivery stall longer than the 600 ms pacing depth (network dropout, sender freeze) left the timeline head behind the wall clock, and the sender then burst the queued audio on past timestamps — late-frame delivery is another measured noise trigger.

- Pause on the splice timeline now stops only the content, never the wire: the audio loop keeps feeding encoded silence on the hot line and un-pause splices the content back in (no stamp move, no re-anchor); the published now-playing state still reports paused
- The post-EOF drain/idle window keeps the wire fed the same way until the next START, STOP or the idle timeout, removing the end-of-playback burst
- A wall-clock guard on the splice send path detects a lapsed head at send time and pads the timeline forward with silence — bitstream-continuous, reported via the machine-readable [STATUS] REANCHOR line — instead of delivering late frames
- Shared splice-pad recovery helper for the starvation and delivery-stall paths, computing from the effective head so repeated checks never stack shifts
- Unit tests for the delivery-stall guard and the hot pause; validated on hardware (Apple TV 4K SIGSTOP/SIGCONT ladder 0.3/1.0/2.5 s, pause/seek/park regression runs, Sonos netstall spot-check)