### PR TITLE
Fix the static pop when pausing grouped playback on Apple devices

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -639,8 +639,9 @@ capture.
   a queue UNDERRUN while the session stays armed pops as well — heard as a
   burst at the pause press — while a teardown with audio still queued is
   clean. An armed splice line is therefore never allowed to run dry: the
-  idle-primed FLUSH→START gap, a content pause, and the post-EOF drain/idle
-  window each keep the wire fed with encoded silence, and a delivery stall
+  idle-primed FLUSH→START gap, a content pause, a standby park (a group
+  pause parks members through standby), and the post-EOF drain/idle window
+  each keep the wire fed with encoded silence, and a delivery stall
   longer than the pacing depth splice-pads the timeline forward (reported as
   REANCHOR) instead of bursting the queued content on past timestamps when
   sending resumes. The 2026-07-31 fleet A/B validated the same mechanism on

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -218,6 +218,9 @@ struct ap2cl_s {
                                      the wire stays fed (state remains
                                      AP2_STREAMING), so the MRP playback state
                                      needs its own truth */
+    bool content_stopped;         /* splice standby: the content is stopped
+                                     (parked) on the same armed-line shape as
+                                     content_paused, published as stopped */
     uint64_t reanchor_shifted_frames; /* cumulative shift since the last start/
                                         * resume, for [STATUS] REANCHOR */
     /* Retransmit history and the control-port reader that serves it. The ring
@@ -2596,6 +2599,7 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
 {
     if (!p) return AP2_COMMIT_FAILED;
     p->content_paused = false;
+    p->content_stopped = false;
     uint64_t ntp_start = 0;
     ap2_resolve_start(start_unix_ms,
                       raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS),
@@ -2645,28 +2649,35 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
     return AP2_COMMIT_OK;
 }
 
-/* Silence the receiver but keep the session warm (persistent standby):
- * discard buffered audio with an RTSP FLUSH, publish the stopped playback
- * state, and drop back to CONNECTED so a later warm flush can restart. */
+/* Park the stream but keep the session warm (persistent standby). On the
+ * splice timeline the CONTENT stops while the armed line keeps carrying
+ * silence: a queue underrun while the session stays armed is an audible
+ * noise burst on Apple receivers (measured at the group pause press, which
+ * parks members through standby), and a line kept hot makes the next resume
+ * a splice instead of a fresh anchor. The stock path discards buffered audio
+ * with an RTSP FLUSH and drops back to CONNECTED so a later warm flush can
+ * restart. Both publish the stopped playback state; the session engine's
+ * idle timeout still ends a park nothing ever resumes. */
 void ap2cl_standby(struct ap2cl_s *p)
 {
     if (!p || p->state == AP2_DOWN) return;
     p->content_paused = false;
+    p->content_stopped = false;
     if (p->flow != FLOW_NATIVE_AP2) {
         if (p->raopcl) raop_session_standby(p->raopcl);
         p->state = AP2_CONNECTED;
         return;
     }
     if (p->splice_timeline) {
-        /* Splice park: stop delivering and let the shallow queue drain
-         * naturally — the flush verb is the noise trigger, and a starved
-         * receiver pads silence cleanly (the end-of-playback burst users
-         * reported was this FLUSH). The frozen anchor line survives the park;
-         * the splice resume skips forward on it. */
-        LOG_INFO("[AP2] splice standby: draining the queue, keeping the line");
+        /* Splice park: the client stays AP2_STREAMING and the audio loop
+         * keeps the line fed with encoded silence — draining the shallow
+         * queue here is the underrun noise trigger. content_stopped keeps
+         * the published now-playing state truthful meanwhile; the frozen
+         * anchor line survives the park for a hot-splice resume. */
+        LOG_INFO("[AP2] splice standby: content stopped, keeping the line fed");
+        p->content_stopped = true;
         p->splice_pad_frames = 0;
         ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
-        p->state = AP2_CONNECTED;
         return;
     }
     if (!atomic_load(&p->rtsp_dead)) {
@@ -2745,6 +2756,7 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
 {
     if (!p || p->state == AP2_DOWN) return AP2_COMMIT_FAILED;
     p->content_paused = false;
+    p->content_stopped = false;
 
     if (p->flow != FLOW_NATIVE_AP2) {
         ap2_commit_result_t r =
@@ -3064,6 +3076,7 @@ void ap2cl_log_diagnostics(struct ap2cl_s *p)
 void ap2cl_pause(struct ap2cl_s *p)
 {
     if (!p) return;
+    p->content_stopped = false;
     if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
     if (p->splice_timeline) {
         /* Splice pause stops the CONTENT, never the wire: an Apple receiver
@@ -3089,6 +3102,7 @@ void ap2cl_play(struct ap2cl_s *p)
 {
     if (!p) return;
     p->content_paused = false;
+    p->content_stopped = false;
     if (p->raopcl) {
         int lat = raopcl_latency(p->raopcl);
         uint64_t now = raopcl_get_ntp(NULL);
@@ -3130,6 +3144,7 @@ void ap2cl_stop(struct ap2cl_s *p)
 {
     if (!p) return;
     p->content_paused = false;
+    p->content_stopped = false;
     if (p->raopcl) raopcl_stop(p->raopcl);
     ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
     p->rt_anchor_valid = false;
@@ -3296,6 +3311,19 @@ static bool ap2_native_send_metadata(struct ap2cl_s *p, const char *title,
     return status >= 200 && status < 300;
 }
 
+/* Playback state to publish: the splice keepalive keeps the client
+ * AP2_STREAMING through content pauses and standby parks, so the published
+ * state follows the content flags, not the wire. */
+static ap2_mrp_playback_state_t ap2_mrp_current_playback_state(
+    struct ap2cl_s *p)
+{
+    if (p->content_stopped) return AP2_MRP_PLAYBACK_STOPPED;
+    if (p->state == AP2_PAUSED || p->content_paused)
+        return AP2_MRP_PLAYBACK_PAUSED;
+    return p->state == AP2_STREAMING ? AP2_MRP_PLAYBACK_PLAYING
+                                     : AP2_MRP_PLAYBACK_STOPPED;
+}
+
 /* Lazily create MediaRemote for pair-verified native sessions and attach the
  * encrypted reverse event channel before advertising any controllable state.
  * Transient-paired third-party speakers never receive these Apple-specific
@@ -3324,7 +3352,11 @@ static void ap2_mrp_ready(struct ap2cl_s *p)
         return;
     }
     p->events_sock = -1;
-    ap2_mrp_set_playing(p->mrp, p->state == AP2_STREAMING);
+    ap2_mrp_playback_state_t state = ap2_mrp_current_playback_state(p);
+    if (state == AP2_MRP_PLAYBACK_STOPPED)
+        ap2_mrp_set_stopped(p->mrp);
+    else
+        ap2_mrp_set_playing(p->mrp, state == AP2_MRP_PLAYBACK_PLAYING);
     atomic_store(&p->mrp_event_health, ap2_mrp_event_status(p->mrp));
 }
 
@@ -3420,10 +3452,7 @@ static void ap2_mrp_publish_playback(struct ap2cl_s *p,
  * keeping it detached from its system now-playing player when these are absent. */
 static int ap2_mrp_send_extended_registration(struct ap2cl_s *p)
 {
-    ap2_mrp_playback_state_t state =
-        p->state == AP2_PAUSED || p->content_paused ? AP2_MRP_PLAYBACK_PAUSED :
-        p->state == AP2_STREAMING ? AP2_MRP_PLAYBACK_PLAYING :
-                                    AP2_MRP_PLAYBACK_STOPPED;
+    ap2_mrp_playback_state_t state = ap2_mrp_current_playback_state(p);
 
     int st_cmd = ap2_mrp_post_command(
         p, ap2_mrp_build_supportedcommands_command,
@@ -3472,12 +3501,8 @@ static ap2_mrp_push_result_t ap2cl_mrp_push_serialized_with(
     if (!p->mrp_extended_registered) {
         ext_status = ap2_mrp_send_extended_registration(p);
     } else {
-        ap2_mrp_playback_state_t state =
-            p->state == AP2_PAUSED || p->content_paused
-                ? AP2_MRP_PLAYBACK_PAUSED :
-            p->state == AP2_STREAMING ? AP2_MRP_PLAYBACK_PLAYING :
-                                        AP2_MRP_PLAYBACK_STOPPED;
-        ext_status = ap2_mrp_send_playback_state(p, state, false);
+        ext_status = ap2_mrp_send_playback_state(
+            p, ap2_mrp_current_playback_state(p), false);
     }
     if (!ap2_mrp_status_ok(ext_status)) result.overall_status = ext_status;
     return result;

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2657,7 +2657,7 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
  * a splice instead of a fresh anchor. The stock path discards buffered audio
  * with an RTSP FLUSH and drops back to CONNECTED so a later warm flush can
  * restart. Both publish the stopped playback state; the session engine's
- * idle timeout still ends a park nothing ever resumes. */
+ * idle timeout still ends a park that nothing ever resumes. */
 void ap2cl_standby(struct ap2cl_s *p)
 {
     if (!p || p->state == AP2_DOWN) return;

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -200,8 +200,11 @@ bool ap2cl_flush(struct ap2cl_s *p);
 ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
                                  uint64_t *at_unix_ms);
 
-/* Silence the receiver but keep the session warm: discard buffered audio,
- * publish the stopped state, drop to CONNECTED awaiting the next warm flush. */
+/* Park the stream but keep the session warm: the splice timeline stops the
+ * content while the armed line keeps carrying silence (an underrun while
+ * armed is an audible noise trigger); the stock path discards buffered audio
+ * and drops to CONNECTED awaiting the next warm flush. Both publish the
+ * stopped playback state. */
 void ap2cl_standby(struct ap2cl_s *p);
 
 /* Send a chunk of PCM audio data.

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -1302,17 +1302,19 @@ static int run_airplay2(cli_config_t *cfg)
             frames += af - (int)pad_frames_now;
             pthread_mutex_unlock(&g_audio_send_lock);
         } else {
-            /* Paused, or connected and awaiting the commanded first START.
-             * On the splice timeline every armed window keeps sending
-             * silence: the idle-primed gap between a FLUSH and the next
-             * START (a slow next-track spin-up must not lapse the line —
-             * the track-transition blip), and a content pause (a receiver
-             * whose queue underruns while the session stays armed pops at
-             * the pause press — measured by ear A/B on an Apple TV 4K,
-             * 2026-07-31). Contiguous silence keeps every boundary a hot
-             * splice; the resume pad still lands the new content on the
-             * commanded instant. Standby and stop park the client out of
-             * AP2_STREAMING, so they drain as before. */
+            /* Paused, parked in standby, or connected and awaiting the
+             * commanded first START. On the splice timeline every armed
+             * window keeps sending silence: the idle-primed gap between a
+             * FLUSH and the next START (a slow next-track spin-up must not
+             * lapse the line — the track-transition blip), a content pause,
+             * and a standby park (MA's group pause parks members through
+             * standby — a receiver whose queue underruns while the session
+             * stays armed pops at the pause press, measured by ear A/B on
+             * an Apple TV 4K, 2026-07-31). Contiguous silence keeps every
+             * boundary a hot splice; the resume pad still lands the new
+             * content on the commanded instant. Stop and teardown end the
+             * feed — a teardown with audio still queued is clean — and the
+             * session engine's idle timeout still ends a forgotten park. */
             if (g_first_start_done && cfg->protocol == PROTO_AIRPLAY2 &&
                 ap2cl_splice_hot(g_ap2cl)) {
                 pthread_mutex_lock(&g_audio_send_lock);

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -487,12 +487,23 @@ static void test_splice_timeline_warm_path(void)
     ap2cl_splice_pad_consume(client, pad);
     assert(ap2cl_splice_pad_frames(client) == 0);
 
-    /* Park: no flush verb either; the line survives for the next resume. */
+    /* Park: no flush verb either, and the client stays ARMED — a queue
+     * underrun while the session stays armed is itself an audible noise
+     * trigger on Apple receivers (the pop at a group pause press, which
+     * parks members through standby), so the audio loop must keep feeding
+     * the line silence; only the published playback state stops. */
     ap2cl_standby(client);
-    assert(ap2cl_state(client) == AP2_CONNECTED);
+    assert(ap2cl_state(client) == AP2_STREAMING);
+    assert(ap2cl_splice_hot(client));
     assert(ap2cl_test_anchor_valid(client));
+    assert(ap2cl_test_head_ts(client) == head_before);
+    assert(ap2cl_test_rtp_timestamp(client) == rtp_before);
+    /* The resume splices on the hot line: stamps continue, no re-anchor. */
     assert(ap2cl_resume(client, 0, NULL) == AP2_COMMIT_OK);
     assert(ap2cl_state(client) == AP2_STREAMING);
+    assert(!ap2cl_test_first_packet(client));
+    assert(ap2cl_test_head_ts(client) == head_before);
+    assert(ap2cl_test_rtp_timestamp(client) == rtp_before);
 
     /* The whole warm path put nothing on the RTSP socket. */
     char scratch[16];
@@ -510,8 +521,10 @@ static void test_splice_timeline_warm_path(void)
  * The guard must splice-pad the timeline forward — silence on the immutable
  * line, no stamp jump, no RTSP verb — and report the shift as a REANCHOR,
  * instead of letting the loop burst real frames on past timestamps (an
- * audible noise trigger on Apple receivers). A healthy head, a pending pad,
- * a non-splice stream and a parked session must each leave it silent. */
+ * audible noise trigger on Apple receivers). A healthy head, a pending pad
+ * and a non-splice stream must each leave it silent; a parked (standby)
+ * window never consults it — the audio loop gates the guard on the session
+ * engine's PLAYING state while its keepalive keeps the armed line fed. */
 static void test_splice_delivery_gap_recovery(void)
 {
     int sockets[2];
@@ -604,10 +617,13 @@ static void test_splice_delivery_gap_recovery(void)
     assert(ap2cl_splice_pad_frames(client) == 0);
     ap2cl_test_set_splice(client, true);
 
-    /* A parked session is a frozen timeline by design, not a stall. */
+    /* A standby park keeps the session armed so the audio loop can keep the
+     * line fed with silence — an underrun while armed is itself an audible
+     * noise trigger. The guard is never consulted while parked (the loop
+     * gates it on the session engine's PLAYING state). */
     ap2cl_standby(client);
-    assert(ap2cl_state(client) == AP2_CONNECTED);
-    assert(!ap2cl_recover_delivery_gap(client));
+    assert(ap2cl_state(client) == AP2_STREAMING);
+    assert(ap2cl_splice_hot(client));
     assert(ap2cl_test_timeline_reanchors(client) == 1);
 
     /* The whole recovery put nothing on the RTSP socket. */


### PR DESCRIPTION
Pausing synced playback with an Apple TV or HomePod in the group produced a short static pop at the pause press. A group pause parks members through session standby, and the standby path still let the receiver's queue run dry while the session stayed armed — the same underrun mechanism behind the solo pause pop fixed in #33.

- A standby park now keeps the armed splice line fed with encoded silence, like pause and the idle windows, so the receiver's queue can never underrun while parked
- The device UI still shows stopped while parked (new content-stopped state next to the existing content-paused one)
- A parked line stays hot, so resuming a paused group is now an in-place splice instead of a fresh re-anchor
- The 120 s idle safety net and teardown behavior are unchanged

Verified on hardware (Apple TV 4K, Sonos Era 100): 8 s parks resume as hot splices with the delivery head still pinned one pacing window ahead, a 30 s park plus disconnect tears down cleanly, and the idle timeout still fires at exactly 120 s.