### PR TITLE
Verify receiver clock readiness before starting audio on grouped AirPlay players

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -228,7 +228,8 @@ grandmaster — but MA spawns one cliairplay per device. The split
 - **Control channel** — localhost UDP `127.0.0.1:9010` (deliberately not
   nqptp's 9000, so a real nqptp serving receivers on the same host cannot
   collide): `R <ip>` register receiver, `U <ip>` unregister, `?` liveness
-  probe; nqptp's `T`/`B`/`E`/`P` are accepted, with `T` treated as an
+  probe, `Q <ip>` query the receiver's clock-exchange streak (§6, clock
+  readiness); nqptp's `T`/`B`/`E`/`P` are accepted, with `T` treated as an
   additive register (each stream registers its own receiver; the daemon
   aggregates).
 - **Streams with `--ptp-shared`** — probe the daemon, attach the shm
@@ -257,6 +258,38 @@ always reports the true scheduled instant — the caller compares the two, logs
 corrections, and re-aligns a group by re-STARTing every member at the largest
 reported instant. The minimum lead (250 ms; 200 ms on RAOP) covers only the
 commit round-trips since the connection and the feed are already up.
+
+**Receiver clock readiness (clock-verified anchors).** A commanded start is
+only audible on time if the receiver's PTP servo can seat it: a third-party
+receiver seats its render position once, with whatever clock state it has at
+the anchor instant, and keeps that seat for the whole session (measured on a
+rejoining Sonos pair as a permanent echo), while Apple receivers converge a
+still-settling servo onto the line. The timing engine (in-process or daemon)
+tracks each receiver's **probe streak** — the uninterrupted run of
+Delay_Req/Pdelay_Req received from that IP, reset by a 3 s gap — and the
+daemon answers `Q <ip>` with the streak ages. Readiness = streak start
++ 2.3 s (the measured Sonos servo-lock window), with Apple models also
+granted the observed fast bound (third exchange + 250 ms). Enforcement:
+
+- **At commit**, a live streak folds readiness into the feasibility floor,
+  so an anchor before readiness is corrected forward through the normal
+  started-ack contract (which group starts re-converge from as usual).
+- **After a cold commit** (no live streak yet — a rejoining receiver resumes
+  probing only ~0.7-1.5 s AFTER the START ack, so commit-time enforcement is
+  impossible), the audio loop keeps verifying while the pacing gate still
+  holds every frame. Once the streak appears, an anchor at or beyond
+  readiness logs `[STATUS] clock_verified margin_ms=`. One short of it is
+  handled by START intent: a `START_JOIN=1` start (a late joiner that must
+  land on the group's already-live timeline — the permanent-echo case) is
+  moved forward pre-send (a fresh announce over an idle pipeline, the clean
+  session-start shape) and reported as `[STATUS] anchor_corrected
+  requested_unix_ms= from_unix_ms= at_unix_ms=` so the caller re-syncs that
+  member; a group/solo ORIGIN start only logs the shortfall — its receivers
+  self-seat a fresh session within ~20 ms, and moving one member of a group
+  origin desyncs the group (ear-confirmed). Anchors without runway to act
+  (solo starts at the minimum lead) are never armed, and a window that
+  closes without a probe leaves the anchor standing, logged unverified —
+  the legacy behavior.
 
 **Downstream render-latency is informational, not applied.** A receiver whose
 audible output sits behind an external pipeline reports that delay in its

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -84,6 +84,22 @@ extern log_level *loglevel;
  * after the connection and the audio feed are both confirmed, so no setup
  * slack is needed on top. */
 #define AP2_MIN_WARM_LEAD_MS         250
+/* Receiver clock readiness, measured from its PTP probe streak (Delay_Req/
+ * Pdelay_Req RX tracked per peer by the timing engine or the shared daemon).
+ * A third-party receiver seats its render position once, with whatever
+ * servo state it has at the anchor instant, and keeps that seat for the
+ * whole session — so its anchor must clear the full measured servo-lock
+ * window from the streak start (Sonos Era 100: 1.7-2.3 s). Apple receivers
+ * converge a still-settling servo onto the anchor and are ready shortly
+ * after their third exchange. */
+#define AP2_CLOCK_LOCK_MS            2300
+#define AP2_CLOCK_SETTLE_MS          250
+#define AP2_CLOCK_SEAT_EXCHANGES     3
+#define AP2_CLOCK_VERIFY_POLL_MS     250
+/* Verification needs room to act before the initial fill starts releasing
+ * real frames at anchor - pacing depth: anchors closer than the depth plus
+ * one poll round plus slack can never be corrected, so they are not armed. */
+#define AP2_CLOCK_VERIFY_MIN_WINDOW_MS (AP2_SPLICE_PACING_MS + 500)
 /* Receiver queue depth on the splice timeline (§ splice below): the
  * depth IS the audible latency of a warm splice, so it stays shallow. */
 #define AP2_SPLICE_PACING_MS         600
@@ -223,6 +239,28 @@ struct ap2cl_s {
                                      content_paused, published as stopped */
     uint64_t reanchor_shifted_frames; /* cumulative shift since the last start/
                                         * resume, for [STATUS] REANCHOR */
+    /* Clock verification of a start committed before the receiver's first
+     * timing probe (cold clock). clock_verify_lock guards this block plus
+     * the ctrl poller's snapshot; the anchor rebase a correction performs
+     * runs on the audio-loop thread under its send lock, serialized against
+     * a concurrent commit by this lock (commits disarm before touching the
+     * anchor). */
+    pthread_mutex_t clock_verify_lock;
+    bool clock_verify_armed;
+    bool clock_verify_enforce;     /* join start: correct, don't just observe */
+    bool start_join_pending;       /* latched by ap2cl_set_start_join */
+    bool apple_model;              /* model=/am= names an Apple receiver */
+    uint64_t clock_verify_requested_unix_ms;
+    uint64_t clock_verify_anchor_unix_ms;
+    uint64_t clock_verify_packets_at_arm;
+    uint64_t clock_verify_next_poll_ntp;
+    bool clock_verify_have_exchange;
+    struct ap2_ptp_exchange clock_verify_exchange;
+    /* Shared-daemon mode queries the streak over UDP (blocking); this poller
+     * keeps the snapshot fresh so the audio loop never blocks on it. */
+    pthread_t clock_verify_thread;
+    bool clock_verify_thread_started;
+    atomic_bool clock_verify_thread_stop;
     /* Retransmit history and the control-port reader that serves it. The ring
      * is written by the audio thread and read by the reader thread. */
     struct ap2_rtx_slot *rtx_ring;
@@ -290,6 +328,8 @@ static void ap2_mrp_publish_playback(struct ap2cl_s *p,
                                      bool force);
 static bool ap2_set_nonblocking(int fd, const char *name);
 static void ap2_raop_session_cleanup(struct ap2cl_s *p);
+static void ap2_clock_verify_disarm(struct ap2cl_s *p);
+static void ap2_clock_verify_reap_poller(struct ap2cl_s *p);
 
 static void ap2_remote_command_received(
     ap2_remote_command_t command, void *userdata)
@@ -1026,6 +1066,26 @@ static bool ap2_features_has_ptp(const char *txt)
 static bool ap2_splice_denied(const char *txt, const char *am)
 {
     static const char *const prefixes[] = { NULL };
+    const char *model = txt ? strstr(txt, "model=") : NULL;
+    if (model) model += strlen("model=");
+    for (size_t i = 0; prefixes[i]; i++) {
+        size_t len = strlen(prefixes[i]);
+        if (model && strncmp(model, prefixes[i], len) == 0) return true;
+        if (am && strncmp(am, prefixes[i], len) == 0) return true;
+    }
+    return false;
+}
+
+/* Apple receivers, from the `model=` (_airplay TXT) / `am=` (_raop) field.
+ * They converge a still-settling PTP servo onto a committed anchor (solo
+ * Apple TV starts render exactly on anchors well inside the servo-lock
+ * window), so clock readiness grants them the fast observed bound; a
+ * third-party receiver keeps whatever seat it takes at the anchor instant. */
+static bool ap2_apple_model(const char *txt, const char *am)
+{
+    static const char *const prefixes[] = {
+        "AppleTV", "AudioAccessory", "iPhone", "iPad", "iPod", "Mac", NULL,
+    };
     const char *model = txt ? strstr(txt, "model=") : NULL;
     if (model) model += strlen("model=");
     for (size_t i = 0; prefixes[i]; i++) {
@@ -2351,6 +2411,8 @@ struct ap2cl_s *ap2cl_create(
     pthread_mutex_init(&p->mrp_lock, NULL);
     pthread_mutex_init(&p->mrp_publish_lock, NULL);
     pthread_mutex_init(&p->rtx_lock, NULL);
+    pthread_mutex_init(&p->clock_verify_lock, NULL);
+    atomic_init(&p->clock_verify_thread_stop, true);
     atomic_init(&p->rtx_stop, true);
     atomic_init(&p->rtx_requested, 0);
     atomic_init(&p->rtx_answered, 0);
@@ -2390,6 +2452,8 @@ bool ap2cl_destroy(struct ap2cl_s *p)
 {
     if (!p) return false;
     ap2_feedback_stop(p);
+    ap2_clock_verify_disarm(p);
+    ap2_clock_verify_reap_poller(p);
     /* Must join before the control socket closes: the responder polls it. */
     ap2_rtx_stop(p);
     /* Preserve the on-wire shutdown sequence (final MediaRemote stopped state,
@@ -2411,6 +2475,7 @@ bool ap2cl_destroy(struct ap2cl_s *p)
     pthread_mutex_destroy(&p->mrp_lock);
     pthread_mutex_destroy(&p->mrp_publish_lock);
     pthread_mutex_destroy(&p->rtx_lock);
+    pthread_mutex_destroy(&p->clock_verify_lock);
     if (p->data_sock >= 0) close(p->data_sock);
     if (p->ctrl_sock >= 0) close(p->ctrl_sock);
     if (p->events_sock >= 0) close(p->events_sock);
@@ -2464,6 +2529,12 @@ void ap2cl_set_ptp_shared(struct ap2cl_s *p, bool enable)
     LOG_INFO("[AP2] Shared PTP daemon clock %s", enable ? "preferred" : "disabled");
 }
 
+void ap2cl_set_start_join(struct ap2cl_s *p, bool join)
+{
+    if (!p) return;
+    p->start_join_pending = join;
+}
+
 void ap2cl_set_remote_command_callback(
     struct ap2cl_s *p, ap2_remote_command_cb_t callback, void *userdata)
 {
@@ -2492,6 +2563,7 @@ bool ap2cl_connect(struct ap2cl_s *p)
     if (p->flow == FLOW_NATIVE_AP2) {
         p->splice_timeline =
             !ap2_splice_denied(p->device.txt_records, p->am);
+        p->apple_model = ap2_apple_model(p->device.txt_records, p->am);
         if (p->splice_timeline) {
             LOG_INFO("[AP2] splice timeline (discard-free warm path, "
                      "%d ms queue depth)", AP2_SPLICE_PACING_MS);
@@ -2560,6 +2632,137 @@ static uint64_t ap2_ntp_to_unix_ms(uint64_t ntp)
     return (ntp >> 32) * 1000ULL + (((ntp & 0xFFFFFFFFULL) * 1000ULL) >> 32);
 }
 
+/* ---- Receiver clock readiness (PTP probe streak) ---- */
+
+/* Earliest instant (unix ms) the receiver can seat an anchor, from a live
+ * probe-streak snapshot. Third-party receivers get the full servo-lock
+ * window from the streak start; Apple models also honor the observed fast
+ * bound (third exchange + settle), whichever is earlier. */
+static uint64_t ap2_clock_ready_from(const struct ap2cl_s *p,
+                                     const struct ap2_ptp_exchange *ex,
+                                     uint64_t now_unix_ms)
+{
+    uint64_t first_ms = ex->first_ms < now_unix_ms ? ex->first_ms : now_unix_ms;
+    uint64_t ready = now_unix_ms - first_ms + AP2_CLOCK_LOCK_MS;
+    if (p->apple_model && ex->count >= AP2_CLOCK_SEAT_EXCHANGES) {
+        uint64_t third_ms =
+            ex->third_ms < now_unix_ms ? ex->third_ms : now_unix_ms;
+        uint64_t fast = now_unix_ms - third_ms + AP2_CLOCK_SETTLE_MS;
+        if (fast < ready) ready = fast;
+    }
+    return ready;
+}
+
+/* Live probe streak for this session's receiver. Blocks up to the control
+ * timeout in shared-daemon mode, so the audio loop must go through the
+ * poller snapshot instead of calling this. */
+static bool ap2_clock_query(struct ap2cl_s *p, struct ap2_ptp_exchange *ex)
+{
+    return ap2_ptp_peer_exchange(p->ptp, p->device.address, ex);
+}
+
+/* Raise a commit's feasibility floor to the receiver's clock readiness. With
+ * no live streak the clock is cold: the floor is left alone (the receiver
+ * only begins probing after the anchor line is announced, so there is
+ * nothing to measure yet) and *clock_cold tells the commit to arm the
+ * post-commit verification instead. */
+static uint64_t ap2_clock_floor(struct ap2cl_s *p, uint64_t floor_ntp,
+                                bool *clock_cold)
+{
+    *clock_cold = false;
+    if (p->flow != FLOW_NATIVE_AP2 || !p->use_ptp) return floor_ntp;
+    struct ap2_ptp_exchange ex;
+    if (!ap2_clock_query(p, &ex)) {
+        *clock_cold = true;
+        return floor_ntp;
+    }
+    uint64_t now_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
+    uint64_t ready_ms = ap2_clock_ready_from(p, &ex, now_ms);
+    uint64_t ready_ntp = ap2_unix_ms_to_ntp(ready_ms);
+    if (ready_ntp <= floor_ntp) return floor_ntp;
+    LOG_INFO("[AP2] receiver clock floor: probe streak %" PRIu64 " ms old "
+             "(%u exchanges), ready in %" PRIu64 " ms",
+             ex.first_ms, ex.count, ready_ms - now_ms);
+    return ready_ntp;
+}
+
+/* Stop the verification without an event (new commit, flush, teardown). The
+ * poller is signalled here and joined by the next arm or the destroy. */
+static void ap2_clock_verify_disarm(struct ap2cl_s *p)
+{
+    pthread_mutex_lock(&p->clock_verify_lock);
+    p->clock_verify_armed = false;
+    pthread_mutex_unlock(&p->clock_verify_lock);
+    atomic_store(&p->clock_verify_thread_stop, true);
+}
+
+static void ap2_clock_verify_reap_poller(struct ap2cl_s *p)
+{
+    if (!p->clock_verify_thread_started) return;
+    atomic_store(&p->clock_verify_thread_stop, true);
+    pthread_join(p->clock_verify_thread, NULL);
+    p->clock_verify_thread_started = false;
+}
+
+/* Shared-daemon mode: keep the probe-streak snapshot fresh over the control
+ * channel so the audio loop's poll never blocks on UDP. */
+static void *ap2_clock_verify_poller(void *arg)
+{
+    struct ap2cl_s *p = arg;
+    while (!atomic_load(&p->clock_verify_thread_stop)) {
+        struct ap2_ptp_exchange ex;
+        bool have = ap2_clock_query(p, &ex);
+        pthread_mutex_lock(&p->clock_verify_lock);
+        bool armed = p->clock_verify_armed;
+        p->clock_verify_have_exchange = have;
+        if (have) p->clock_verify_exchange = ex;
+        pthread_mutex_unlock(&p->clock_verify_lock);
+        if (!armed) break;
+        for (int i = 0; i < AP2_CLOCK_VERIFY_POLL_MS / 50 &&
+                        !atomic_load(&p->clock_verify_thread_stop); i++)
+            usleep(50000);
+    }
+    return NULL;
+}
+
+/* Arm the post-commit verification for a cold-clock commit: the receiver's
+ * probe streak is expected to begin only after the anchor announce, and the
+ * committed instant must then be checked against the observed readiness.
+ * Only a join-marked start (landing on an already-live group timeline) is
+ * ENFORCED with a forward correction; an origin start is observed and
+ * reported only — its receivers self-seat a fresh session cleanly, and
+ * moving one member of a group origin desyncs the group (ear-confirmed).
+ * Anchors without enough runway to act before the initial fill are not
+ * armed (their fill starts immediately; nothing could be corrected). */
+static void ap2_clock_verify_arm(struct ap2cl_s *p, uint64_t requested_unix_ms,
+                                 uint64_t at_unix_ms, bool enforce)
+{
+    if (!p->splice_timeline || !p->use_ptp) return;
+    uint64_t now_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
+    if (at_unix_ms < now_ms + AP2_CLOCK_VERIFY_MIN_WINDOW_MS) return;
+    pthread_mutex_lock(&p->clock_verify_lock);
+    p->clock_verify_armed = true;
+    p->clock_verify_enforce = enforce;
+    p->clock_verify_requested_unix_ms = requested_unix_ms;
+    p->clock_verify_anchor_unix_ms = at_unix_ms;
+    p->clock_verify_packets_at_arm = p->audio_packets_sent;
+    p->clock_verify_next_poll_ntp = 0;
+    p->clock_verify_have_exchange = false;
+    pthread_mutex_unlock(&p->clock_verify_lock);
+    LOG_INFO("[AP2] clock verification armed (%s): cold receiver clock, "
+             "anchor in %" PRIu64 " ms", enforce ? "join, enforcing" : "observe",
+             at_unix_ms - now_ms);
+    if (ap2_ptp_shared_active(p->ptp)) {
+        ap2_clock_verify_reap_poller(p);
+        atomic_store(&p->clock_verify_thread_stop, false);
+        if (pthread_create(&p->clock_verify_thread, NULL,
+                           ap2_clock_verify_poller, p) == 0)
+            p->clock_verify_thread_started = true;
+        else
+            atomic_store(&p->clock_verify_thread_stop, true);
+    }
+}
+
 /* Resolve a commanded start: a request at or beyond `floor_ntp` is honored
  * exactly; one behind it (or 0) is corrected FORWARD to the floor — audio
  * always flows, never silently misplaced or refused. *ntp_start receives the
@@ -2598,12 +2801,19 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
                                 uint64_t *at_unix_ms)
 {
     if (!p) return AP2_COMMIT_FAILED;
+    ap2_clock_verify_disarm(p);
+    bool join = p->start_join_pending;
+    p->start_join_pending = false;
     p->content_paused = false;
     p->content_stopped = false;
     uint64_t ntp_start = 0;
-    ap2_resolve_start(start_unix_ms,
-                      raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS),
-                      &ntp_start, at_unix_ms);
+    bool clock_cold = false;
+    uint64_t floor_ntp =
+        ap2_clock_floor(p, raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS),
+                        &clock_cold);
+    uint64_t at_local = 0;
+    ap2_resolve_start(start_unix_ms, floor_ntp, &ntp_start, &at_local);
+    if (at_unix_ms) *at_unix_ms = at_local;
     if (p->flow == FLOW_NATIVE_AP2) {
         /* Offset the RTP timeline per process: streams in one group share
          * ntpstart, and with identical pos0 two sessions from one host are
@@ -2640,6 +2850,7 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
             atomic_store(&p->media_healthy, false);
             return AP2_COMMIT_FAILED;
         }
+        if (clock_cold) ap2_clock_verify_arm(p, start_unix_ms, at_local, join);
         return AP2_COMMIT_OK;
     }
     if (!p->raopcl) return AP2_COMMIT_FAILED;
@@ -2661,6 +2872,7 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
 void ap2cl_standby(struct ap2cl_s *p)
 {
     if (!p || p->state == AP2_DOWN) return;
+    ap2_clock_verify_disarm(p);
     p->content_paused = false;
     p->content_stopped = false;
     if (p->flow != FLOW_NATIVE_AP2) {
@@ -2707,6 +2919,7 @@ void ap2cl_standby(struct ap2cl_s *p)
 bool ap2cl_flush(struct ap2cl_s *p)
 {
     if (!p || p->state == AP2_DOWN) return false;
+    ap2_clock_verify_disarm(p);
 
     if (p->flow != FLOW_NATIVE_AP2)
         return raop_session_flush(p->raopcl);
@@ -2755,6 +2968,9 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
                                  uint64_t *at_unix_ms)
 {
     if (!p || p->state == AP2_DOWN) return AP2_COMMIT_FAILED;
+    ap2_clock_verify_disarm(p);
+    bool join = p->start_join_pending;
+    p->start_join_pending = false;
     p->content_paused = false;
     p->content_stopped = false;
 
@@ -2841,8 +3057,12 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
         ap2cl_flush(p);
     }
     uint64_t start_ntp = 0;
-    ap2_resolve_start(start_unix_ms, now_ntp + MS2NTP(AP2_MIN_WARM_LEAD_MS),
-                      &start_ntp, at_unix_ms);
+    bool clock_cold = false;
+    uint64_t floor_ntp =
+        ap2_clock_floor(p, now_ntp + MS2NTP(AP2_MIN_WARM_LEAD_MS), &clock_cold);
+    uint64_t at_local = 0;
+    ap2_resolve_start(start_unix_ms, floor_ntp, &start_ntp, &at_local);
+    if (at_unix_ms) *at_unix_ms = at_local;
     /* Re-base the frozen line: head_ts moves in the scheduling domain, the
      * wire timestamp follows it plus the per-process offset, and the next
      * sync packet freezes the new line from start_ntp. */
@@ -2862,6 +3082,7 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
         atomic_store(&p->media_healthy, false);
         return AP2_COMMIT_FAILED;
     }
+    if (clock_cold) ap2_clock_verify_arm(p, start_unix_ms, at_local, join);
     return AP2_COMMIT_OK;
 }
 
@@ -3056,6 +3277,117 @@ bool ap2cl_recover_delivery_gap(struct ap2cl_s *p)
     return ap2_splice_pad_to_lead(p, now_ts, now_ts, "delivery stall");
 }
 
+/* Move a committed anchor line that has not carried any audio yet onto a
+ * later instant. With a distant anchor the pacing gate holds every frame
+ * until anchor - depth, so the receiver has only seen announces of the old
+ * line and re-seats cleanly on the fresh one (the session-start shape); the
+ * content mapping moves with the line, keeping the first pending sample on
+ * the commanded contract. */
+static void ap2_rebase_pending_anchor(struct ap2cl_s *p, uint64_t at_unix_ms)
+{
+    uint64_t ntp = ap2_unix_ms_to_ntp(at_unix_ms);
+    p->start_ntp = ntp;
+    p->head_ts = NTP2TS(ntp, p->format.sample_rate);
+    p->rtp_timestamp = (uint32_t)p->head_ts + atomic_load(&p->rtp_offset);
+    p->rt_anchor_valid = false;
+    p->first_packet = true;
+    if (p->ctrl_sock >= 0 &&
+        ap2_send_sync_packet_ptp(p, true) == AP2_SEND_FATAL)
+        LOG_WARN("[AP2] corrected-anchor announce failed; the next send "
+                 "retries it");
+}
+
+ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
+                                                  ap2_clock_verify_event_t *ev)
+{
+    if (!p || !ev) return AP2_CLOCK_VERIFY_IDLE;
+    memset(ev, 0, sizeof(*ev));
+    pthread_mutex_lock(&p->clock_verify_lock);
+    if (!p->clock_verify_armed) {
+        pthread_mutex_unlock(&p->clock_verify_lock);
+        return AP2_CLOCK_VERIFY_IDLE;
+    }
+    uint64_t now_ntp = raopcl_get_ntp(NULL);
+    uint64_t now_ms = ap2_ntp_to_unix_ms(now_ntp);
+    uint64_t anchor_ms = p->clock_verify_anchor_unix_ms;
+    bool sent = p->audio_packets_sent != p->clock_verify_packets_at_arm;
+
+    /* Probe-streak snapshot: the poller keeps it fresh in shared-daemon
+     * mode (ages go stale by at most one poll round, which only pushes the
+     * computed readiness later — the safe direction); the in-process engine
+     * is queried directly (its own lock only, never the network). */
+    struct ap2_ptp_exchange ex;
+    bool have = false;
+    if (p->clock_verify_have_exchange) {
+        have = true;
+        ex = p->clock_verify_exchange;
+    } else if (!p->clock_verify_thread_started &&
+               !ap2_ptp_shared_active(p->ptp) &&
+               now_ntp >= p->clock_verify_next_poll_ntp) {
+        p->clock_verify_next_poll_ntp =
+            now_ntp + MS2NTP(AP2_CLOCK_VERIFY_POLL_MS);
+        have = ap2_clock_query(p, &ex);
+    }
+
+    ap2_clock_verify_result_t result = AP2_CLOCK_VERIFY_IDLE;
+    if (have) {
+        uint64_t ready_ms = ap2_clock_ready_from(p, &ex, now_ms);
+        ev->requested_unix_ms = p->clock_verify_requested_unix_ms;
+        ev->from_unix_ms = anchor_ms;
+        if (ready_ms <= anchor_ms) {
+            ev->at_unix_ms = anchor_ms;
+            ev->margin_ms = (int64_t)(anchor_ms - ready_ms);
+            result = AP2_CLOCK_VERIFY_VERIFIED;
+            LOG_INFO("[AP2] clock verified: probe streak began %" PRIu64
+                     " ms before the anchor, readiness margin %" PRId64 " ms",
+                     ex.first_ms, ev->margin_ms);
+        } else if (!p->clock_verify_enforce) {
+            /* Origin start: the shortfall is reported for lead tuning but
+             * the anchor stands — the receiver self-seats a fresh session
+             * (measured within ~20 ms), while moving one member of a group
+             * origin would desync it. */
+            ev->at_unix_ms = anchor_ms;
+            result = AP2_CLOCK_VERIFY_UNVERIFIED;
+            LOG_WARN("[AP2] receiver clock ready %" PRIu64 " ms after the "
+                     "origin anchor; anchor stands (observe only)",
+                     ready_ms - anchor_ms);
+        } else if (!sent) {
+            /* One lead of slack beyond readiness, mirroring every other
+             * forward correction: the instant must still be ahead once the
+             * caller's ack round-trips. */
+            ev->at_unix_ms = ready_ms + AP2_MIN_WARM_LEAD_MS;
+            ap2_rebase_pending_anchor(p, ev->at_unix_ms);
+            result = AP2_CLOCK_VERIFY_CORRECTED;
+            LOG_WARN("[AP2] anchor %" PRIu64 " ms precedes receiver clock "
+                     "readiness by %" PRIu64 " ms; corrected forward to %"
+                     PRIu64, anchor_ms, ready_ms - anchor_ms, ev->at_unix_ms);
+        } else {
+            /* Readiness resolved late, after real frames went out: the line
+             * cannot move without a stamp jump. The receiver will seat
+             * roughly this late; the caller's session-level resync is the
+             * remaining remedy. */
+            ev->at_unix_ms = anchor_ms;
+            result = AP2_CLOCK_VERIFY_UNVERIFIED;
+            LOG_WARN("[AP2] receiver clock ready %" PRIu64 " ms after the "
+                     "anchor with audio already on the wire; expect a late "
+                     "seat", ready_ms - anchor_ms);
+        }
+    } else if (sent || now_ms + AP2_CLOCK_VERIFY_POLL_MS >=
+                           anchor_ms - AP2_SPLICE_PACING_MS) {
+        ev->requested_unix_ms = p->clock_verify_requested_unix_ms;
+        ev->from_unix_ms = anchor_ms;
+        ev->at_unix_ms = anchor_ms;
+        result = AP2_CLOCK_VERIFY_UNVERIFIED;
+        LOG_WARN("[AP2] anchor window closed without a receiver clock probe; "
+                 "anchor stands unverified");
+    }
+    if (result != AP2_CLOCK_VERIFY_IDLE) p->clock_verify_armed = false;
+    pthread_mutex_unlock(&p->clock_verify_lock);
+    if (result != AP2_CLOCK_VERIFY_IDLE)
+        atomic_store(&p->clock_verify_thread_stop, true);
+    return result;
+}
+
 void ap2cl_log_diagnostics(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || *loglevel < lSDEBUG) return;
@@ -3143,6 +3475,7 @@ void ap2cl_play(struct ap2cl_s *p)
 void ap2cl_stop(struct ap2cl_s *p)
 {
     if (!p) return;
+    ap2_clock_verify_disarm(p);
     p->content_paused = false;
     p->content_stopped = false;
     if (p->raopcl) raopcl_stop(p->raopcl);
@@ -3953,5 +4286,47 @@ unsigned long long ap2cl_test_rtx_answered(struct ap2cl_s *p)
 unsigned long long ap2cl_test_rtx_expired(struct ap2cl_s *p)
 {
     return atomic_load(&p->rtx_expired);
+}
+
+void ap2cl_test_set_use_ptp(struct ap2cl_s *p, bool enable)
+{
+    p->use_ptp = enable;
+}
+
+void ap2cl_test_set_apple_model(struct ap2cl_s *p, bool apple)
+{
+    p->apple_model = apple;
+}
+
+bool ap2cl_test_apple_model_default(const char *txt, const char *am)
+{
+    return ap2_apple_model(txt, am);
+}
+
+/* Plant a probe-streak snapshot where the shared-daemon poller would put
+ * one, so the verification poll consumes it on its next call. */
+void ap2cl_test_inject_clock_exchange(struct ap2cl_s *p, uint32_t count,
+                                      uint64_t first_ms, uint64_t third_ms)
+{
+    pthread_mutex_lock(&p->clock_verify_lock);
+    p->clock_verify_have_exchange = true;
+    p->clock_verify_exchange.count = count;
+    p->clock_verify_exchange.first_ms = first_ms;
+    p->clock_verify_exchange.last_ms = 0;
+    p->clock_verify_exchange.third_ms = third_ms;
+    pthread_mutex_unlock(&p->clock_verify_lock);
+}
+
+bool ap2cl_test_clock_verify_armed(struct ap2cl_s *p)
+{
+    pthread_mutex_lock(&p->clock_verify_lock);
+    bool armed = p->clock_verify_armed;
+    pthread_mutex_unlock(&p->clock_verify_lock);
+    return armed;
+}
+
+void ap2cl_test_bump_audio_sent(struct ap2cl_s *p)
+{
+    p->audio_packets_sent++;
 }
 #endif

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -228,6 +228,42 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p);
  * only; call before reading each chunk. Returns true when it padded. */
 bool ap2cl_recover_delivery_gap(struct ap2cl_s *p);
 
+/* Outcome of one clock-verification poll (see ap2cl_clock_verify_poll). */
+typedef enum {
+    AP2_CLOCK_VERIFY_IDLE = 0,     /* nothing armed, or nothing new yet */
+    AP2_CLOCK_VERIFY_VERIFIED,     /* receiver clock ready before the anchor */
+    AP2_CLOCK_VERIFY_CORRECTED,    /* anchor moved forward to readiness */
+    AP2_CLOCK_VERIFY_UNVERIFIED,   /* window closed without a probe streak */
+} ap2_clock_verify_result_t;
+
+typedef struct {
+    uint64_t requested_unix_ms;    /* instant commanded on the START (0 = picked) */
+    uint64_t from_unix_ms;         /* previously scheduled audible instant */
+    uint64_t at_unix_ms;           /* now-scheduled audible instant */
+    int64_t margin_ms;             /* readiness margin before the anchor (verified) */
+} ap2_clock_verify_event_t;
+
+/*
+ * Advance the clock verification of a start that was committed before the
+ * receiver's first timing probe (a rejoining receiver resumes its clock
+ * exchange only after the START is acked). Armed automatically by such
+ * commits; the audio loop calls this every iteration under its send lock and
+ * reports VERIFIED/CORRECTED events on the status channel. On a join-marked
+ * start (ap2cl_set_start_join) a correction moves the still-unsent anchor
+ * line forward to the receiver's verified readiness instant, so *ev carries
+ * the new truth for the caller's ack; other starts only observe and report.
+ */
+ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
+                                                  ap2_clock_verify_event_t *ev);
+
+/* Mark the next commanded start as a late join onto an already-live group
+ * timeline: receiver clock readiness is then ENFORCED — a cold-clock anchor
+ * the receiver cannot be ready for is corrected forward once the probe
+ * streak appears. Cleared by every commit. A group/solo ORIGIN start must
+ * not set it: its receivers self-seat a fresh session cleanly, and moving
+ * one member of a group origin would desync the group. */
+void ap2cl_set_start_join(struct ap2cl_s *p, bool join);
+
 /* Emit native pacing, packet-drop, and anchor diagnostics at debug level 10. */
 void ap2cl_log_diagnostics(struct ap2cl_s *p);
 

--- a/src/ap2_ptp.c
+++ b/src/ap2_ptp.c
@@ -871,6 +871,10 @@ static void ptp_track_exchange(struct ap2_ptp_ctx *ctx, struct in_addr addr, uin
         ctx->exchange[slot].addr = addr;
     }
 
+    /* The unsigned delta wraps huge when CLOCK_REALTIME stepped backwards
+     * past last_ns, deliberately landing in the reset branch: receivers
+     * slave to this clock, so any timebase step makes their servos
+     * re-converge and the streak must restart from it. */
     if (fresh_slot || (rx - ctx->exchange[slot].last_ns) > PTP_EXCHANGE_GAP_NS) {
         ctx->exchange[slot].first_ns = rx;
         ctx->exchange[slot].third_ns = 0;

--- a/src/ap2_ptp.c
+++ b/src/ap2_ptp.c
@@ -100,6 +100,10 @@ extern log_level *loglevel;
 
 #define PTP_MAX_PEERS       8
 
+/* Per-peer exchange-streak slots, deliberately sized above PTP_MAX_PEERS so
+ * evicted history (see ptp_track_exchange) is rare. */
+#define PTP_EXCHANGE_SLOTS  16
+
 /* ---- BMCA / slave tuning ---- */
 
 /* Offset smoothing: fold each new local->master sample as an EMA with gain
@@ -114,6 +118,11 @@ extern log_level *loglevel;
 /* Revert to grandmaster if the elected peer stops announcing for this long
  * (3x the 1 s announce interval, so a couple of dropped Announces don't flap). */
 #define PTP_PEER_SILENCE_NS    3000000000ULL      /* 3 s */
+
+/* A receiver mid-session probes at least ~1 Hz, so 3 s of silence means its
+ * PTP client stopped (session teardown); the next probe then starts a NEW
+ * streak, which is what clock-readiness is measured from. */
+#define PTP_EXCHANGE_GAP_NS    3000000000ULL      /* silence that ends a probe streak */
 
 /* An IEEE-1588 best-master dataset: the grandmaster attributes carried in an
  * Announce (or synthesised for ourselves), enough to run the dataset
@@ -183,6 +192,15 @@ struct ap2_ptp_ctx {
     uint16_t pending_sync_seq;
     uint64_t pending_sync_rx_ns;    /* t2: local reception time of the Sync */
     int64_t pending_sync_corr_ns;   /* correctionField carried on the Sync */
+
+    /* ---- receiver exchange-streak tracking (guarded by lock) ---- */
+    /* Per-peer probe-streak state; see PTP_EXCHANGE_GAP_NS and
+     * ptp_track_exchange(). addr.s_addr == 0 marks a free slot. */
+    struct {
+        struct in_addr addr;
+        uint64_t first_ns, third_ns, last_ns;
+        uint32_t count;
+    } exchange[PTP_EXCHANGE_SLOTS];
 
     /* ---- shared daemon clock (streaming side, --ptp-shared) ---- */
     /* When shm_active, the master getters below read the elected clock from the
@@ -832,6 +850,40 @@ static void ptp_handle_follow_up(struct ap2_ptp_ctx *ctx, const uint8_t *buf, in
               " -> off=%" PRId64 "ns", seq, t1, t2, corr_sync + corr_fup, offset);
 }
 
+/* Record one Delay_Req/Pdelay_Req probe from `addr` into its exchange-streak
+ * slot: extends the streak if the gap since the last probe is within
+ * PTP_EXCHANGE_GAP_NS, otherwise starts a fresh one. Tracked in any BMCA role,
+ * independent of whether we currently answer as grandmaster. */
+static void ptp_track_exchange(struct ap2_ptp_ctx *ctx, struct in_addr addr, uint64_t rx)
+{
+    pthread_mutex_lock(&ctx->lock);
+
+    int slot = -1, free_slot = -1, oldest = -1;
+    for (int i = 0; i < PTP_EXCHANGE_SLOTS; i++) {
+        if (ctx->exchange[i].addr.s_addr == addr.s_addr) { slot = i; break; }
+        if (ctx->exchange[i].addr.s_addr == 0 && free_slot < 0) free_slot = i;
+        if (oldest < 0 || ctx->exchange[i].last_ns < ctx->exchange[oldest].last_ns) oldest = i;
+    }
+
+    bool fresh_slot = (slot < 0);
+    if (fresh_slot) {
+        slot = (free_slot >= 0) ? free_slot : oldest;
+        ctx->exchange[slot].addr = addr;
+    }
+
+    if (fresh_slot || (rx - ctx->exchange[slot].last_ns) > PTP_EXCHANGE_GAP_NS) {
+        ctx->exchange[slot].first_ns = rx;
+        ctx->exchange[slot].third_ns = 0;
+        ctx->exchange[slot].count = 1;
+    } else if (ctx->exchange[slot].count < UINT32_MAX) {
+        ctx->exchange[slot].count++;
+        if (ctx->exchange[slot].count == 3) ctx->exchange[slot].third_ns = rx;
+    }
+    ctx->exchange[slot].last_ns = rx;
+
+    pthread_mutex_unlock(&ctx->lock);
+}
+
 static void *ptp_thread_func(void *arg)
 {
     struct ap2_ptp_ctx *ctx = (struct ap2_ptp_ctx *)arg;
@@ -905,6 +957,7 @@ static void *ptp_thread_func(void *arg)
 
             switch (msg_type) {
             case PTP_MSG_DELAY_REQ:
+                ptp_track_exchange(ctx, src.sin_addr, rx);
                 /* Only the grandmaster answers Delay_Req. */
                 if (gm && n >= PTP_HDR_LEN + 10) {
                     LOG_DEBUG("[PTP] RX Delay_Req from %s", srcip);
@@ -912,6 +965,7 @@ static void *ptp_thread_func(void *arg)
                 }
                 break;
             case PTP_MSG_PDELAY_REQ:
+                ptp_track_exchange(ctx, src.sin_addr, rx);
                 /* Peer-delay is answered in ANY role (grandmaster, slave or
                  * holding): it is a link-local measurement, not master-scoped,
                  * and an ignored probe can cost us asCapable status. */
@@ -1271,6 +1325,62 @@ uint64_t ap2_ptp_master_now_ns(struct ap2_ptp_ctx *ctx)
     return (uint64_t)((int64_t)local + off);
 }
 
+bool ap2_ptp_peer_exchange(struct ap2_ptp_ctx *ctx, const char *ip, struct ap2_ptp_exchange *out)
+{
+    if (out) memset(out, 0, sizeof(*out));
+    if (!ctx || !ip || !*ip || !out) return false;
+
+    if (ctx->shm_active) {
+        /* Query the daemon over the control channel; it holds the tracking
+         * table since streaming processes never see the Delay_Req/Pdelay_Req
+         * traffic themselves in shared mode. */
+        char cmd[64];
+        snprintf(cmd, sizeof(cmd), "Q %s", ip);
+        char ack[256] = {0};
+        if (!ap2_ptp_ctrl_send(cmd, 250, ack, sizeof(ack))) return false;
+
+        unsigned int count = 0;
+        unsigned long long first_ms = 0, last_ms = 0, third_ms = 0;
+        int got = sscanf(ack, "OK ip=%*s count=%u first_ms=%llu last_ms=%llu third_ms=%llu",
+                         &count, &first_ms, &last_ms, &third_ms);
+        if (got != 4 || count == 0) return false;
+
+        out->count = count;
+        out->first_ms = first_ms;
+        out->last_ms = last_ms;
+        out->third_ms = third_ms;
+        return true;
+    }
+
+    struct in_addr addr;
+    if (inet_pton(AF_INET, ip, &addr) != 1) return false;
+
+    pthread_mutex_lock(&ctx->lock);
+    uint64_t now = ap2_ptp_now_ns(ctx);
+    int slot = -1;
+    for (int i = 0; i < PTP_EXCHANGE_SLOTS; i++) {
+        if (ctx->exchange[i].addr.s_addr == addr.s_addr) { slot = i; break; }
+    }
+    bool ok = false;
+    if (slot >= 0 && ctx->exchange[slot].count > 0) {
+        /* A streak older than the gap is a cold clock, not a live one — it
+         * will start fresh on the next probe anyway. */
+        uint64_t last_ns = ctx->exchange[slot].last_ns;
+        uint64_t age_ns = (now > last_ns) ? now - last_ns : 0;
+        if (age_ns <= PTP_EXCHANGE_GAP_NS) {
+            uint64_t first_ns = ctx->exchange[slot].first_ns;
+            uint64_t third_ns = ctx->exchange[slot].third_ns;
+            out->count = ctx->exchange[slot].count;
+            out->first_ms = ((now > first_ns) ? now - first_ns : 0) / 1000000ULL;
+            out->last_ms = age_ns / 1000000ULL;
+            out->third_ms = (out->count >= 3 && now > third_ns) ? (now - third_ns) / 1000000ULL : 0;
+            ok = true;
+        }
+    }
+    pthread_mutex_unlock(&ctx->lock);
+    return ok;
+}
+
 /* ---- shared daemon clock: streaming-side attach + peer registration ---- */
 
 bool ap2_ptp_shared_active(struct ap2_ptp_ctx *ctx)
@@ -1435,6 +1545,26 @@ static void daemon_handle_ctrl(int sock, struct ptp_peerset *ps, struct ap2_ptp_
             changed = true;
         }
         break;
+    }
+    case 'Q': {  /* query a receiver's exchange streak */
+        char *ip = strtok_r(NULL, " \t\r\n", &save);
+        struct in_addr tmp;
+        if (!ip || inet_pton(AF_INET, ip, &tmp) != 1) {
+            const char *err = "ERR usage: Q <ip>";
+            sendto(sock, err, strlen(err), 0, (struct sockaddr *)&src, sl);
+            return;
+        }
+        /* ctx is the daemon's own engine context (shm_active is always false
+         * here), so this takes ap2_ptp_peer_exchange()'s in-process branch. */
+        struct ap2_ptp_exchange ex;
+        ap2_ptp_peer_exchange(ctx, ip, &ex);
+        char qack[160];
+        int qn = snprintf(qack, sizeof(qack),
+                          "OK ip=%s count=%u first_ms=%" PRIu64 " last_ms=%" PRIu64
+                          " third_ms=%" PRIu64, ip, ex.count, ex.first_ms, ex.last_ms,
+                          ex.third_ms);
+        sendto(sock, qack, qn, 0, (struct sockaddr *)&src, sl);
+        return;
     }
     case 'K': /* session is active: send timing to current peers immediately */
         pthread_mutex_lock(&ctx->lock);

--- a/src/ap2_ptp.h
+++ b/src/ap2_ptp.h
@@ -123,6 +123,33 @@ uint64_t ap2_ptp_master_clock_id(struct ap2_ptp_ctx *ctx);
  */
 uint64_t ap2_ptp_master_now_ns(struct ap2_ptp_ctx *ctx);
 
+/*
+ * Snapshot of a receiver's clock-exchange streak: the uninterrupted run of
+ * Delay_Req/Pdelay_Req timing probes received from that IP by this engine
+ * (or by the shared daemon). Ages are milliseconds before now. count==0
+ * means the clock is cold: no probe ever seen, or the most recent one is
+ * older than the streak gap.
+ */
+struct ap2_ptp_exchange {
+    uint32_t count;      /* probes in the current uninterrupted streak */
+    uint64_t first_ms;   /* age of the streak's first probe */
+    uint64_t last_ms;    /* age of the most recent probe */
+    uint64_t third_ms;   /* age of the streak's third probe (0 while count < 3) */
+};
+
+/*
+ * Report the live clock-exchange streak for receiver `ip`: read from this
+ * engine directly, or queried from the shared daemon over the control channel
+ * (Q verb) when this context is attached to one — the caller does not need to
+ * know which.
+ *
+ * :param ip: receiver IP to look up.
+ * :param out: receives the streak snapshot; zeroed when this returns false.
+ * :returns: false if the peer has no live streak (cold clock) or the shared
+ *           daemon is unreachable.
+ */
+bool ap2_ptp_peer_exchange(struct ap2_ptp_ctx *ctx, const char *ip, struct ap2_ptp_exchange *out);
+
 /* ---- shared daemon clock (multi-room: one engine, many streams) ---- */
 
 /*

--- a/src/ap2_ptp_shm.h
+++ b/src/ap2_ptp_shm.h
@@ -136,8 +136,11 @@ void ap2_ptp_shm_reader_close(struct ap2_ptp_shm_reader *r);
  *   T <ip> [<ip> ...]   nqptp-compatible alias for register (ADD; see note)
  *   B | E | P           begin / end / pause (accepted + acked; no-op for a sender)
  *   ? | PING            liveness probe
+ *   Q <ip>              query the receiver's clock-exchange streak
  * The daemon replies to the datagram's source with a short ack, e.g.
  *   "OK peers=2 gm=0123456789abcdef role=grandmaster"
+ * except Q, whose ack carries the streak snapshot instead (zeros = cold clock):
+ *   "OK ip=10.0.0.5 count=7 first_ms=6400 last_ms=120 third_ms=4400"
  *
  * NOTE: nqptp's "T" REPLACES its peer list; ours ADDS, because each streaming
  * process registers its own receiver independently and the daemon aggregates

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -36,6 +36,18 @@
  * Command pipe verbs (newline-terminated KEY=VALUE, existing verbs unchanged):
  *   START_UNIX_MS=<ms|0>      audible start instant; 0 = ASAP at the minimum
  *                             warm lead
+ *   START_JOIN=<0|1>          the next START lands on an already-live group
+ *                             timeline (a late joiner): the transport must
+ *                             ENFORCE receiver clock readiness — fold it into
+ *                             the feasibility floor and correct a committed
+ *                             anchor forward if the receiver's clock cannot
+ *                             be ready for it (`[STATUS] anchor_corrected`).
+ *                             Without it a fresh start is the group/solo
+ *                             origin: readiness is observed and reported but
+ *                             never enforced (the receivers self-seat a
+ *                             fresh session cleanly; moving one member of a
+ *                             group origin would desync it). Cleared after
+ *                             each START.
  *   ACTION=START|FLUSH|STANDBY|DISCONNECT
  *
  * Status lines (stderr):

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -172,6 +172,7 @@ static struct ap2_session_s *g_session = NULL;
 static pthread_mutex_t g_audio_send_lock = PTHREAD_MUTEX_INITIALIZER;
 static bool g_first_start_done = false;
 static uint64_t g_pend_start_unix_ms = 0;
+static bool g_pend_start_join = false;
 
 static void session_quiesce(void *transport)
 {
@@ -203,6 +204,29 @@ static void status_eof(void)
 static void status_error(const char *msg)
 {
     status_print("[ERROR] %s", msg);
+}
+
+/* Advance the receiver-clock verification of a cold-clock START (armed by
+ * the client when it commits before the receiver's first timing probe) and
+ * surface the outcome. A correction reports the new audible instant so the
+ * caller re-aligns the group; a verification only confirms the ack already
+ * sent. Called from the audio loop under g_audio_send_lock. */
+static void clock_verify_tick(void)
+{
+    ap2_clock_verify_event_t ev;
+    switch (ap2cl_clock_verify_poll(g_ap2cl, &ev)) {
+    case AP2_CLOCK_VERIFY_CORRECTED:
+        status_print("[STATUS] anchor_corrected requested_unix_ms=%" PRIu64
+                     " from_unix_ms=%" PRIu64 " at_unix_ms=%" PRIu64,
+                     ev.requested_unix_ms, ev.from_unix_ms, ev.at_unix_ms);
+        break;
+    case AP2_CLOCK_VERIFY_VERIFIED:
+        status_print("[STATUS] clock_verified margin_ms=%" PRId64,
+                     ev.margin_ms);
+        break;
+    default:
+        break;
+    }
 }
 
 /* Machine-readable failure codes Music Assistant matches on. */
@@ -424,6 +448,8 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         }
     } else if (strcmp(key, "START_UNIX_MS") == 0) {
         g_pend_start_unix_ms = strtoull(value, NULL, 10);
+    } else if (strcmp(key, "START_JOIN") == 0) {
+        g_pend_start_join = atoi(value) != 0;
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "START") == 0) {
         /* The verified start contract: the ack always reports the true
          * scheduled instant, so the caller compares it with the request,
@@ -441,6 +467,7 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
             status_error("START failed");
         }
         g_pend_start_unix_ms = 0;
+        g_pend_start_join = false;
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "FLUSH") == 0) {
         if (!g_session || !ap2_session_flush(g_session))
             status_error("FLUSH failed");
@@ -547,6 +574,7 @@ static ap2_commit_result_t session_commit(void *transport,
     } else {
         struct ap2cl_s *client = g_ap2cl;
         if (!client) return AP2_COMMIT_FAILED;
+        ap2cl_set_start_join(client, g_pend_start_join);
         committed = !g_first_start_done
             ? ap2cl_start(client, start_unix_ms, at_unix_ms)
             : ap2cl_resume(client, start_unix_ms, at_unix_ms);
@@ -1197,8 +1225,17 @@ static int run_airplay2(cli_config_t *cfg)
         /* Send audio chunk */
         if (g_status == STATUS_PLAYING) {
             pthread_mutex_lock(&g_audio_send_lock);
-            if (g_status != STATUS_PLAYING ||
-                !ap2cl_accept_frames(g_ap2cl)) {
+            if (g_status != STATUS_PLAYING) {
+                pthread_mutex_unlock(&g_audio_send_lock);
+                usleep(1000);
+                continue;
+            }
+            /* Before the pacing gate: a distant anchor keeps the gate closed
+             * until anchor minus the pacing window, and the verification of
+             * a cold-clock START must keep advancing through exactly that
+             * quiet stretch. */
+            clock_verify_tick();
+            if (!ap2cl_accept_frames(g_ap2cl)) {
                 pthread_mutex_unlock(&g_audio_send_lock);
                 usleep(1000);
                 continue;

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -45,6 +45,13 @@ void ap2cl_test_rtx_store(struct ap2cl_s *p, uint16_t seq,
                           const uint8_t *pkt, int len);
 unsigned long long ap2cl_test_rtx_answered(struct ap2cl_s *p);
 unsigned long long ap2cl_test_rtx_expired(struct ap2cl_s *p);
+void ap2cl_test_set_use_ptp(struct ap2cl_s *p, bool enable);
+void ap2cl_test_set_apple_model(struct ap2cl_s *p, bool apple);
+bool ap2cl_test_apple_model_default(const char *txt, const char *am);
+void ap2cl_test_inject_clock_exchange(struct ap2cl_s *p, uint32_t count,
+                                      uint64_t first_ms, uint64_t third_ms);
+bool ap2cl_test_clock_verify_armed(struct ap2cl_s *p);
+void ap2cl_test_bump_audio_sent(struct ap2cl_s *p);
 
 typedef struct {
     int fd;
@@ -866,6 +873,139 @@ static void test_retransmit_responder(void)
     puts("ap2_client retransmit responder tests passed");
 }
 
+static uint64_t test_now_unix_ms(void)
+{
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (uint64_t)tv.tv_sec * 1000ULL + (uint64_t)tv.tv_usec / 1000ULL;
+}
+
+static void test_apple_model_resolution(void)
+{
+    assert(ap2cl_test_apple_model_default(
+        "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE", NULL));
+    assert(ap2cl_test_apple_model_default(NULL, "AudioAccessory5,1"));
+    assert(ap2cl_test_apple_model_default("model=Mac16,10", NULL));
+    assert(!ap2cl_test_apple_model_default("model=Era 100", NULL));
+    assert(!ap2cl_test_apple_model_default("model=HW-LS60D", NULL));
+    assert(!ap2cl_test_apple_model_default(NULL, "Era 100"));
+    assert(!ap2cl_test_apple_model_default(NULL, NULL));
+    puts("ap2_client apple model resolution tests passed");
+}
+
+/* A start committed before the receiver's first timing probe arms the
+ * post-commit verification; the poll then verifies, corrects forward, or
+ * closes the window, exactly once per commit. */
+static void test_clock_verified_anchor(void)
+{
+    ap2_device_info_t device = {
+        .name = "clock test",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "model=Era 100",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_set_splice(client, true);
+    ap2cl_test_set_use_ptp(client, true);
+    ap2_clock_verify_event_t ev;
+
+    /* Cold clock at commit: the commanded instant stands, verification arms. */
+    uint64_t start_ms = test_now_unix_ms() + 5000;
+    uint64_t at = 0;
+    assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    assert(at == start_ms);
+    assert(ap2cl_test_clock_verify_armed(client));
+
+    /* No probe yet and a wide-open window: nothing to report. */
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_IDLE);
+    assert(ap2cl_test_clock_verify_armed(client));
+
+    /* A streak whose lock window ends before the anchor verifies it. */
+    ap2cl_test_inject_clock_exchange(client, 2, 100, 0);
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_VERIFIED);
+    assert(ev.margin_ms > 2000 && ev.margin_ms < 3500);
+    assert(!ap2cl_test_clock_verify_armed(client));
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_IDLE);
+
+    /* An origin start short of readiness is observed, never moved. */
+    start_ms = test_now_unix_ms() + 1500;
+    assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    assert(ap2cl_test_clock_verify_armed(client));
+    uint64_t origin_head = ap2cl_test_head_ts(client);
+    ap2cl_test_inject_clock_exchange(client, 1, 0, 0);
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_UNVERIFIED);
+    assert(ap2cl_test_head_ts(client) == origin_head);
+    assert(!ap2cl_test_clock_verify_armed(client));
+
+    /* A join-marked start short of readiness moves the still-unsent line
+     * forward by the shortfall plus the retry slack, wire head following. */
+    start_ms = test_now_unix_ms() + 1500;
+    ap2cl_set_start_join(client, true);
+    assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    assert(ap2cl_test_clock_verify_armed(client));
+    ap2cl_test_inject_clock_exchange(client, 1, 0, 0);
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_CORRECTED);
+    assert(ev.from_unix_ms == start_ms);
+    assert(ev.at_unix_ms > start_ms + 800);
+    assert(ev.at_unix_ms < start_ms + 2000);
+    uint64_t head_ms_at_rate =
+        ap2cl_test_head_ts(client) * 1000ULL / format.sample_rate;
+    assert(head_ms_at_rate + 5 > ev.at_unix_ms &&
+           head_ms_at_rate < ev.at_unix_ms + 5);
+    assert(!ap2cl_test_clock_verify_armed(client));
+
+    /* The Apple fast bound (third exchange + settle) verifies an anchor the
+     * full lock window would have corrected. */
+    ap2cl_test_set_apple_model(client, true);
+    start_ms = test_now_unix_ms() + 1500;
+    assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    ap2cl_test_inject_clock_exchange(client, 3, 400, 200);
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_VERIFIED);
+    assert(!ap2cl_test_clock_verify_armed(client));
+    ap2cl_test_set_apple_model(client, false);
+
+    /* Audio already on the wire closes the window: without a probe the
+     * anchor stands unverified... */
+    start_ms = test_now_unix_ms() + 5000;
+    assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    ap2cl_test_bump_audio_sent(client);
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_UNVERIFIED);
+    assert(!ap2cl_test_clock_verify_armed(client));
+
+    /* ...and even a join cannot move a line with audio already on it. */
+    start_ms = test_now_unix_ms() + 1500;
+    ap2cl_set_start_join(client, true);
+    assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    uint64_t head_before = ap2cl_test_head_ts(client);
+    ap2cl_test_bump_audio_sent(client);
+    ap2cl_test_inject_clock_exchange(client, 1, 0, 0);
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_UNVERIFIED);
+    assert(ap2cl_test_head_ts(client) == head_before);
+    assert(!ap2cl_test_clock_verify_armed(client));
+
+    /* An anchor without room to act before the fill never arms. */
+    assert(ap2cl_start(client, 0, &at) == AP2_COMMIT_OK);
+    assert(!ap2cl_test_clock_verify_armed(client));
+
+    /* A flush disarms a pending verification. */
+    start_ms = test_now_unix_ms() + 5000;
+    assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    assert(ap2cl_test_clock_verify_armed(client));
+    assert(ap2cl_flush(client));
+    assert(!ap2cl_test_clock_verify_armed(client));
+
+    ap2cl_destroy(client);
+    puts("ap2_client clock verified anchor tests passed");
+}
+
 int main(void)
 {
     test_retransmit_responder();
@@ -879,6 +1019,8 @@ int main(void)
     test_splice_delivery_gap_recovery();
     test_splice_pause_keeps_line_hot();
     test_feedback_miss_tolerated_then_recovered();
+    test_apple_model_resolution();
+    test_clock_verified_anchor();
 
     ap2_device_info_t device = {
         .name = "test",


### PR DESCRIPTION
A speaker that rejoins a playing group only resumes measuring our clock after the start command is already acknowledged. If its start instant lands before its clock servo has locked, the miss is permanent on the frozen timeline and the member plays behind the group. Until now the server papered over this with a fixed 4-second join headroom — a guess that usually holds but has no verification.

The timing engine now observes each receiver's clock exchange directly and the start contract verifies against it:

- The PTP engine (daemon and in-process) tracks per-receiver probe streaks (Delay_Req/Pdelay_Req per IP); the daemon control channel answers `Q <ip>` with the streak ages.
- Commits fold the observed clock readiness into the commanded-start feasibility floor (Apple models get the faster observed bound they demonstrably handle).
- A join-marked START (`START_JOIN=1`, sent by MA for late joiners) committed before the receiver's exchange resumed is re-verified once it does: a feasible anchor logs its margin (`[STATUS] clock_verified`), an infeasible one is corrected forward before any audio is sent and reported as `[STATUS] anchor_corrected` so the server re-syncs that member.
- Group and solo origin starts observe and report only — their receivers self-seat a fresh session cleanly, and the readiness margins now logged are the data for tuning the server's fixed leads down later.

Hardware-validated against an Apple TV 4K + Sonos Era 100 pair: rejoin cycles arm and verify with ~1.3 s margin under the current 4 s join headroom, solo and group starts are byte-for-byte unchanged, and the observe/enforce split was ear-checked (an enforced correction on a group origin is audibly wrong, which is exactly why only joins enforce).

