### PR TITLE
Keep corrected late joins in sync by advancing the queued content

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -282,9 +282,14 @@ granted the observed fast bound (third exchange + 250 ms). Enforcement:
   handled by START intent: a `START_JOIN=1` start (a late joiner that must
   land on the group's already-live timeline — the permanent-echo case) is
   moved forward pre-send (a fresh announce over an idle pipeline, the clean
-  session-start shape) and reported as `[STATUS] anchor_corrected
-  requested_unix_ms= from_unix_ms= at_unix_ms=` so the caller re-syncs that
-  member; a group/solo ORIGIN start only logs the shortfall — its receivers
+  session-start shape) **with the queued content advanced by the same
+  amount** — every frame is still held by the pacing gate, so cutting the
+  correction off the head of the prime puts the first retained sample
+  exactly where the group timeline schedules it and the member joins in
+  sync immediately. The cut rides the report (`[STATUS] anchor_corrected
+  requested_unix_ms= from_unix_ms= at_unix_ms= content_cut_ms=`) and the
+  caller only re-bases its reported position by the cut — no re-join, no
+  other action. A group/solo ORIGIN start only logs the shortfall — its receivers
   self-seat a fresh session within ~20 ms, and moving one member of a group
   origin desyncs the group (ear-confirmed). Anchors without runway to act
   (solo starts at the minimum lead) are never armed, and a window that

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -230,6 +230,10 @@ struct ap2cl_s {
     uint32_t splice_pad_frames;   /* silence frames still to send before the
                                      next real sample so it lands exactly on
                                      the commanded splice instant */
+    uint32_t content_skip_bytes;  /* queued input to discard after a corrected
+                                     join, so the retained content lands on
+                                     the group timeline (see
+                                     ap2cl_content_skip_bytes) */
     bool content_paused;          /* splice pause: the content is paused but
                                      the wire stays fed (state remains
                                      AP2_STREAMING), so the MRP playback state
@@ -2806,6 +2810,7 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
     p->start_join_pending = false;
     p->content_paused = false;
     p->content_stopped = false;
+    p->content_skip_bytes = 0;
     uint64_t ntp_start = 0;
     bool clock_cold = false;
     uint64_t floor_ntp =
@@ -2875,6 +2880,7 @@ void ap2cl_standby(struct ap2cl_s *p)
     ap2_clock_verify_disarm(p);
     p->content_paused = false;
     p->content_stopped = false;
+    p->content_skip_bytes = 0;
     if (p->flow != FLOW_NATIVE_AP2) {
         if (p->raopcl) raop_session_standby(p->raopcl);
         p->state = AP2_CONNECTED;
@@ -2920,6 +2926,7 @@ bool ap2cl_flush(struct ap2cl_s *p)
 {
     if (!p || p->state == AP2_DOWN) return false;
     ap2_clock_verify_disarm(p);
+    p->content_skip_bytes = 0;
 
     if (p->flow != FLOW_NATIVE_AP2)
         return raop_session_flush(p->raopcl);
@@ -2973,6 +2980,7 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
     p->start_join_pending = false;
     p->content_paused = false;
     p->content_stopped = false;
+    p->content_skip_bytes = 0;
 
     if (p->flow != FLOW_NATIVE_AP2) {
         ap2_commit_result_t r =
@@ -3357,10 +3365,26 @@ ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
              * caller's ack round-trips. */
             ev->at_unix_ms = ready_ms + AP2_MIN_WARM_LEAD_MS;
             ap2_rebase_pending_anchor(p, ev->at_unix_ms);
+            /* Advance the queued content past the correction: the join's
+             * content was mapped to the original instant, so without the cut
+             * the member would render exactly that far behind the group for
+             * the whole session. Every frame is still unsent (the pacing
+             * gate holds them until anchor minus the window), and the
+             * carrier frame size mirrors the audio loop's input format. */
+            ev->content_cut_ms = ev->at_unix_ms - anchor_ms;
+            uint64_t cut_frames =
+                ev->content_cut_ms * p->format.sample_rate / 1000ULL;
+            int input_bpf =
+                (p->format.bit_depth <= 16 ? 2 : 4) * p->format.channels;
+            p->content_skip_bytes =
+                (uint32_t)(cut_frames * (uint64_t)input_bpf);
             result = AP2_CLOCK_VERIFY_CORRECTED;
             LOG_WARN("[AP2] anchor %" PRIu64 " ms precedes receiver clock "
                      "readiness by %" PRIu64 " ms; corrected forward to %"
-                     PRIu64, anchor_ms, ready_ms - anchor_ms, ev->at_unix_ms);
+                     PRIu64 " and content advanced %" PRIu64 " ms to keep "
+                     "the join on the group timeline",
+                     anchor_ms, ready_ms - anchor_ms, ev->at_unix_ms,
+                     ev->content_cut_ms);
         } else {
             /* Readiness resolved late, after real frames went out: the line
              * cannot move without a stamp jump. The receiver will seat
@@ -3478,6 +3502,7 @@ void ap2cl_stop(struct ap2cl_s *p)
     ap2_clock_verify_disarm(p);
     p->content_paused = false;
     p->content_stopped = false;
+    p->content_skip_bytes = 0;
     if (p->raopcl) raopcl_stop(p->raopcl);
     ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
     p->rt_anchor_valid = false;
@@ -4150,6 +4175,18 @@ void ap2cl_splice_pad_consume(struct ap2cl_s *p, uint32_t frames)
     if (!p) return;
     p->splice_pad_frames = frames < p->splice_pad_frames
                                ? p->splice_pad_frames - frames : 0;
+}
+
+uint32_t ap2cl_content_skip_bytes(struct ap2cl_s *p)
+{
+    return p ? p->content_skip_bytes : 0;
+}
+
+void ap2cl_content_skip_consume(struct ap2cl_s *p, uint32_t bytes)
+{
+    if (!p) return;
+    p->content_skip_bytes = bytes < p->content_skip_bytes
+                                ? p->content_skip_bytes - bytes : 0;
 }
 
 int ap2cl_render_latency_ms(struct ap2cl_s *p) { return p ? p->dev_render_ms : 0; }

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -241,6 +241,8 @@ typedef struct {
     uint64_t from_unix_ms;         /* previously scheduled audible instant */
     uint64_t at_unix_ms;           /* now-scheduled audible instant */
     int64_t margin_ms;             /* readiness margin before the anchor (verified) */
+    uint64_t content_cut_ms;       /* content advanced past the correction so the
+                                      join still lands on the group timeline */
 } ap2_clock_verify_event_t;
 
 /*
@@ -410,6 +412,14 @@ uint64_t ap2cl_splice_head_unix_ms(struct ap2cl_s *p);
  * bitstream stays contiguous, and consumes the pad as it sends. */
 uint32_t ap2cl_splice_pad_frames(struct ap2cl_s *p);
 void ap2cl_splice_pad_consume(struct ap2cl_s *p, uint32_t frames);
+
+/* Input bytes still to be discarded from the head of the queued content
+ * (a corrected late join advances the content by exactly the correction, so
+ * the member's first retained sample is the one the group timeline schedules
+ * at the corrected instant): the audio loop drops them from its session
+ * reads before sending, consuming as it goes. */
+uint32_t ap2cl_content_skip_bytes(struct ap2cl_s *p);
+void ap2cl_content_skip_consume(struct ap2cl_s *p, uint32_t bytes);
 
 /* True while the splice timeline is live on the wire (audio sends legal);
  * gates the idle-window silence keepalive in the audio loop. */

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -67,6 +67,22 @@
  *                                       audible instant of the frozen
  *                                       delivery head as the caller's warm
  *                                       anchor hint.)
+ *   [STATUS] clock_verified margin_ms=<ms>
+ *                                      (a START committed before the
+ *                                       receiver's first clock probe was
+ *                                       verified once its exchange resumed;
+ *                                       informational)
+ *   [STATUS] anchor_corrected requested_unix_ms=<ms> from_unix_ms=<ms>
+ *            at_unix_ms=<ms> content_cut_ms=<ms>
+ *                                      (a join START committed before the
+ *                                       receiver's clock exchange moved to
+ *                                       the verified readiness instant, and
+ *                                       the queued content was advanced by
+ *                                       the same amount so the join still
+ *                                       lands on the group timeline — the
+ *                                       caller re-bases its reported
+ *                                       position by content_cut_ms and
+ *                                       takes no other action)
  *   [STATUS] eof                       (input stream ended)
  *   [STATUS] idle_timeout
  *

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -1316,11 +1316,14 @@ static int run_airplay2(cli_config_t *cfg)
                 }
                 /* Corrected-join content cut: drop the bytes the correction
                  * advanced past, so the first retained sample is the one the
-                 * group timeline schedules at the corrected instant. A
-                 * mid-stream read always returns the full request, so a read
-                 * is either dropped whole, or holds the cut boundary — the
-                 * dropped span is then refilled from the session so the sent
-                 * chunk stays full and no silence lands inside the content. */
+                 * group timeline schedules at the corrected instant. Only
+                 * successful reads get here (a timeout returns 0 and takes
+                 * the starvation path above), and mid-stream those carry the
+                 * full request — so a read is either dropped whole, or holds
+                 * the cut boundary and its dropped span is refilled so the
+                 * sent chunk stays full with no silence inside the content.
+                 * At EOF the refill comes back short (or not at all) and the
+                 * remainder ships as the normal padded final chunk. */
                 uint32_t drop = ap2cl_content_skip_bytes(g_ap2cl);
                 if (drop && n > 0) {
                     if ((uint32_t)n <= drop) {
@@ -1333,6 +1336,12 @@ static int run_airplay2(cli_config_t *cfg)
                     n -= (int)drop;
                     int extra = ap2_session_read(
                         g_session, buf + pad_bytes + n, (int)drop, 250);
+                    if (extra == -2) {
+                        /* Session ended mid-refill: match the main read
+                         * path and stop without sending. */
+                        pthread_mutex_unlock(&g_audio_send_lock);
+                        break;
+                    }
                     if (extra > 0) n += extra;
                     ap2cl_content_skip_consume(g_ap2cl, drop);
                 }

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -217,8 +217,10 @@ static void clock_verify_tick(void)
     switch (ap2cl_clock_verify_poll(g_ap2cl, &ev)) {
     case AP2_CLOCK_VERIFY_CORRECTED:
         status_print("[STATUS] anchor_corrected requested_unix_ms=%" PRIu64
-                     " from_unix_ms=%" PRIu64 " at_unix_ms=%" PRIu64,
-                     ev.requested_unix_ms, ev.from_unix_ms, ev.at_unix_ms);
+                     " from_unix_ms=%" PRIu64 " at_unix_ms=%" PRIu64
+                     " content_cut_ms=%" PRIu64,
+                     ev.requested_unix_ms, ev.from_unix_ms, ev.at_unix_ms,
+                     ev.content_cut_ms);
         break;
     case AP2_CLOCK_VERIFY_VERIFIED:
         status_print("[STATUS] clock_verified margin_ms=%" PRId64,
@@ -1311,6 +1313,28 @@ static int run_airplay2(cli_config_t *cfg)
                     LOG_INFO("[AP2] PCM input recovered after %u ms", stalled_ms);
                     ap2cl_log_diagnostics(g_ap2cl);
                     starving = false;
+                }
+                /* Corrected-join content cut: drop the bytes the correction
+                 * advanced past, so the first retained sample is the one the
+                 * group timeline schedules at the corrected instant. A
+                 * mid-stream read always returns the full request, so a read
+                 * is either dropped whole, or holds the cut boundary — the
+                 * dropped span is then refilled from the session so the sent
+                 * chunk stays full and no silence lands inside the content. */
+                uint32_t drop = ap2cl_content_skip_bytes(g_ap2cl);
+                if (drop && n > 0) {
+                    if ((uint32_t)n <= drop) {
+                        ap2cl_content_skip_consume(g_ap2cl, (uint32_t)n);
+                        pthread_mutex_unlock(&g_audio_send_lock);
+                        continue;
+                    }
+                    memmove(buf + pad_bytes, buf + pad_bytes + drop,
+                            (size_t)((uint32_t)n - drop));
+                    n -= (int)drop;
+                    int extra = ap2_session_read(
+                        g_session, buf + pad_bytes + n, (int)drop, 250);
+                    if (extra > 0) n += extra;
+                    ap2cl_content_skip_consume(g_ap2cl, drop);
                 }
             }
             if (pad_bytes)

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -946,21 +946,35 @@ static void test_clock_verified_anchor(void)
     assert(!ap2cl_test_clock_verify_armed(client));
 
     /* A join-marked start short of readiness moves the still-unsent line
-     * forward by the shortfall plus the retry slack, wire head following. */
+     * forward by the shortfall plus the retry slack (wire head following)
+     * and advances the queued content by exactly the correction, so the
+     * retained content still lands on the group timeline. */
     start_ms = test_now_unix_ms() + 1500;
     ap2cl_set_start_join(client, true);
     assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
     assert(ap2cl_test_clock_verify_armed(client));
+    assert(ap2cl_content_skip_bytes(client) == 0);
     ap2cl_test_inject_clock_exchange(client, 1, 0, 0);
     assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_CORRECTED);
     assert(ev.from_unix_ms == start_ms);
     assert(ev.at_unix_ms > start_ms + 800);
     assert(ev.at_unix_ms < start_ms + 2000);
+    assert(ev.content_cut_ms == ev.at_unix_ms - ev.from_unix_ms);
     uint64_t head_ms_at_rate =
         ap2cl_test_head_ts(client) * 1000ULL / format.sample_rate;
     assert(head_ms_at_rate + 5 > ev.at_unix_ms &&
            head_ms_at_rate < ev.at_unix_ms + 5);
+    /* 16-bit stereo: 4 bytes per input frame. */
+    assert(ap2cl_content_skip_bytes(client) ==
+           ev.content_cut_ms * format.sample_rate / 1000 * 4);
+    ap2cl_content_skip_consume(client, 128);
+    assert(ap2cl_content_skip_bytes(client) ==
+           ev.content_cut_ms * format.sample_rate / 1000 * 4 - 128);
     assert(!ap2cl_test_clock_verify_armed(client));
+
+    /* A new commit clears an undrained cut. */
+    assert(ap2cl_start(client, 0, &at) == AP2_COMMIT_OK);
+    assert(ap2cl_content_skip_bytes(client) == 0);
 
     /* The Apple fast bound (third exchange + settle) verifies an anchor the
      * full lock window would have corrected. */


### PR DESCRIPTION
When a late join's anchor gets corrected forward (receiver clock not ready in time), the queued audio was still mapped to the original instant — the member then played exactly the correction behind the group until the server tore it down and re-joined it, going silent for several seconds in the process.

The correction window is strictly before any audio is sent (the pacing gate holds every frame until anchor minus the pacing window), so the binary can do better: it now cuts exactly the correction off the head of the queued content. The first retained sample is the one the group timeline schedules at the corrected instant, so the member joins in sync immediately — and the cut frames are audio the joiner would never have heard anyway (the group played them before the joiner's clock was ready).

- The `anchor_corrected` status line carries the cut (`content_cut_ms=`); the caller only re-bases its reported position — no re-join, no other reaction.
- The cut drains through the audio loop's session reads; a read holding the cut boundary is refilled so sent chunks stay full and no silence lands inside the content.
- Companion server PR removes the drop-and-re-add resync path this replaces.