### PR TITLE
Answer a late join with the instant the receiver can actually seat

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -257,7 +257,12 @@ wall clock), and the `[STATUS] started requested_unix_ms= at_unix_ms=` ack
 always reports the true scheduled instant — the caller compares the two, logs
 corrections, and re-aligns a group by re-STARTing every member at the largest
 reported instant. The minimum lead (250 ms; 200 ms on RAOP) covers only the
-commit round-trips since the connection and the feed are already up.
+commit round-trips since the connection and the feed are already up. One start
+acks late by design: a `START_JOIN=1` first START onto a cold receiver clock
+WITHHOLDS its ack until the clock verification below resolves, so the instant
+it reports is one the receiver can actually seat. Exactly one ack still leaves
+per START — every way the verification can end emits it, including the
+outcomes that leave the anchor exactly where it was committed.
 
 **Receiver clock readiness (clock-verified anchors).** A commanded start is
 only audible on time if the receiver's PTP servo can seat it: a third-party
@@ -281,20 +286,52 @@ granted the observed fast bound (third exchange + 250 ms). Enforcement:
   readiness logs `[STATUS] clock_verified margin_ms=`. One short of it is
   handled by START intent: a `START_JOIN=1` start (a late joiner that must
   land on the group's already-live timeline — the permanent-echo case) is
-  moved forward pre-send (a fresh announce over an idle pipeline, the clean
-  session-start shape) **with the queued content advanced by the same
-  amount** — every frame is still held by the pacing gate, so cutting the
-  correction off the head of the prime puts the first retained sample
-  exactly where the group timeline schedules it and the member joins in
-  sync immediately. The cut rides the report (`[STATUS] anchor_corrected
-  requested_unix_ms= from_unix_ms= at_unix_ms= content_cut_ms=`) and the
-  caller only re-bases its reported position by the cut — no re-join, no
-  other action. A group/solo ORIGIN start only logs the shortfall — its receivers
+  moved forward pre-send onto the readiness instant exactly — this correction
+  commits nothing back to the caller, so it carries none of the round-trip
+  slack the commit-path corrections do, and every millisecond of lead is
+  content the join would otherwise have to give up — as a fresh announce over
+  an idle pipeline, the clean session-start shape. Every frame is still held
+  by the pacing gate, so the move costs nothing already on the wire.
+
+  **Who absorbs the move depends on whether the ack has gone out**, and the
+  two are mutually exclusive by construction:
+
+  - **Ack withheld** (a join committed through the FIRST START, the cold-clock
+    case). No ack was sent, so nothing downstream is mapped yet: the
+    verification emits `[STATUS] started` itself, carrying the corrected
+    instant, and the caller maps its content straight onto it. **No content is
+    cut** — cutting on top of a mapping made against the same correction would
+    advance the content twice and put the joiner EARLY by exactly the cut.
+  - **Ack already out** (a join re-anchored through a warm `START` after a
+    `FLUSH`). The caller mapped its content to the acked instant, so the
+    correction is absorbed here instead: the report `[STATUS] anchor_corrected
+    requested_unix_ms= from_unix_ms= at_unix_ms= content_cut_ms=` rides it and
+    the caller only re-bases its reported position by the cut — no re-join, no
+    other action. **The queued content is advanced by the same amount**, so
+    the first retained sample lands exactly where the group timeline schedules
+    it and the member joins in sync immediately.
+
+  The cut is taken off the queued input **above** the pacing
+  gate — discarded bytes never reach the wire, so the whole quiet stretch the
+  correction opens drains them instead of only the last window before the
+  anchor — and nothing is sent until the debt is settled. What was ACTUALLY
+  taken is then reported on its own line, `[STATUS] content_cut requested_ms=
+  cut_ms= cut_bytes= drain_ms=`: the `anchor_corrected` figure is arithmetic
+  on two instants, computed before a byte is examined, so only this one can
+  confirm it. `cut_ms` falls short of `requested_ms` when the input ran out
+  inside the cut, or when a commit superseded the corrected timeline with the
+  debt still outstanding — which is logged loudly wherever it happens.
+  A group/solo ORIGIN start only logs the shortfall — its receivers
   self-seat a fresh session within ~20 ms, and moving one member of a group
   origin desyncs the group (ear-confirmed). Anchors without runway to act
-  (solo starts at the minimum lead) are never armed, and a window that
+  (solo starts at the minimum lead) are never armed — and never withhold an
+  ack, since nothing would be left to emit it — and a window that
   closes without a probe leaves the anchor standing, logged unverified —
-  the legacy behavior.
+  the legacy behavior. Those terminal outcomes still emit a withheld ack, at
+  the instant that stands: the window is bounded by the anchor itself (the
+  verification goes terminal once it can no longer act before it), so the
+  caller never waits on a timeout of its own. A commit, flush or park that
+  disarms the verification mid-flight releases the ack the same way.
 
 **Downstream render-latency is informational, not applied.** A receiver whose
 audible output sits behind an external pipeline reports that delay in its
@@ -336,9 +373,9 @@ capped to the receiver's buffer. Frame f is audible at its frame-clock
 position, so its deadline is f itself; a frame delivered more than the
 receiver's `latencyMax` early overflows the buffer and is dropped (Sonos:
 88200 frames = 2.0 s). Release therefore runs up to `window` ahead of the
-deadline — the device-reported window when known, else 77175 frames (1.75 s,
-inside every AirPlay receiver's standard 2 s) — which fills the receiver's
-buffer before a scheduled start no matter how far ahead T lies.
+deadline — the device-reported window less a 250 ms margin when known, else
+1.75 s (inside every AirPlay receiver's standard 2 s) — which fills the
+receiver's buffer before a scheduled start no matter how far ahead T lies.
 
 **Per-process timeline offsets**: streams in one group share T, and with
 identical RTP positions two sessions from one host are wire-identical twins

--- a/README.md
+++ b/README.md
@@ -200,7 +200,11 @@ stdin, the single persistent audio input for the whole process lifetime.
   `[STATUS] started requested_unix_ms=<ms> at_unix_ms=<ms>` always carries the
   true scheduled instant — the caller compares the two, logs any correction,
   and re-aligns a sync group by re-STARTing every member at the largest
-  reported instant.
+  reported instant. `START_JOIN=1` marks a late join onto an already-live group
+  timeline; on the first START to a receiver whose clock is still cold the ack
+  is withheld until that clock is measured (up to the anchor, never longer) so
+  it reports an instant the receiver can actually seat. Wait for the ack rather
+  than assuming it is immediate; exactly one arrives per START.
 - `ACTION=FLUSH` — in-place warm flush for seek/next: flush the receiver (RTSP
   FLUSH), discard the internal ring, and drain stdin to empty; after the receiver
   accepts the flush, acks with `[STATUS] flushed` and keeps buffering the next

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -103,6 +103,14 @@ extern log_level *loglevel;
 /* Receiver queue depth on the splice timeline (§ splice below): the
  * depth IS the audible latency of a warm splice, so it stays shallow. */
 #define AP2_SPLICE_PACING_MS         600
+/* Delivery pacing depth (§ pacing below). A frame handed over more than the
+ * receiver's buffer ahead of its deadline overflows that buffer and is
+ * dropped, so delivery runs at most the reported latencyMax less a margin
+ * ahead. Receivers that report no latencyMax get the standard AirPlay buffer
+ * as the assumed depth, leaving the same margin. Both are held in ms and
+ * scaled to the stream rate at use: the frame counts differ per rate. */
+#define AP2_PACING_MARGIN_MS         250
+#define AP2_PACING_DEFAULT_BUFFER_MS 2000
 /* Raw bytes kept from a failed exchange for the auth diagnostics dump: enough
  * for a full header block plus the start of a TLV/plist body. */
 #define AP2_DIAG_RESPONSE_MAX        1536
@@ -110,8 +118,8 @@ extern log_level *loglevel;
 /* Retransmit history. Receivers ask for lost audio on the RTP control port
  * (type 0x55 request / 0x56 response, marker bit set). A request is only worth
  * answering while the packet is still ahead of the receiver's play point, so
- * the ring only has to outlast the send window (77175 frames = 1.75 s): 512
- * packets is 4.1 s at 352 frames/packet, comfortably more. */
+ * the ring only has to outlast the send window (1.75 s at its default): 512
+ * packets is 4.1 s at 352 frames/packet and 44.1 kHz, comfortably more. */
 #define AP2_RTX_RING_SLOTS           512
 #define AP2_RTX_MAX_PKT              2048
 #define AP2_RTX_CTRL_POLL_MS         200
@@ -252,6 +260,10 @@ struct ap2cl_s {
     pthread_mutex_t clock_verify_lock;
     bool clock_verify_armed;
     bool clock_verify_enforce;     /* join start: correct, don't just observe */
+    bool start_ack_deferred;       /* the join's [STATUS] started is withheld
+                                      for this verification to answer, so the
+                                      correction owes no content cut (see
+                                      ap2cl_clock_verify_poll) */
     bool start_join_pending;       /* latched by ap2cl_set_start_join */
     bool apple_model;              /* model=/am= names an Apple receiver */
     uint64_t clock_verify_requested_unix_ms;
@@ -2696,6 +2708,10 @@ static void ap2_clock_verify_disarm(struct ap2cl_s *p)
 {
     pthread_mutex_lock(&p->clock_verify_lock);
     p->clock_verify_armed = false;
+    /* A withheld ack falls due the moment the verification can no longer
+     * answer it: the caller sees both flags drop together and emits it with
+     * the instant that stands. */
+    p->start_ack_deferred = false;
     pthread_mutex_unlock(&p->clock_verify_lock);
     atomic_store(&p->clock_verify_thread_stop, true);
 }
@@ -2801,6 +2817,24 @@ static void ap2_resolve_start(uint64_t start_unix_ms, uint64_t floor_ntp,
     if (at_unix_ms) *at_unix_ms = ap2_ntp_to_unix_ms(floor_ntp);
 }
 
+/* Drop a corrected join's content cut. A new commit, a park, or a teardown
+ * legitimately supersedes the corrected timeline, so the debt goes with it —
+ * but never silently: bytes still outstanding are content the audio loop
+ * retained past the correction, and on a timeline that still stands they
+ * render exactly that late. */
+static void ap2_content_skip_reset(struct ap2cl_s *p, const char *cause)
+{
+    if (p->content_skip_bytes) {
+        int input_bpf =
+            (p->format.bit_depth <= 16 ? 2 : 4) * p->format.channels;
+        uint64_t rate = (uint64_t)input_bpf * p->format.sample_rate;
+        LOG_WARN("[AP2] %s drops %u bytes (%" PRIu64 " ms) of an undrained "
+                 "corrected-join content cut", cause, p->content_skip_bytes,
+                 rate ? (uint64_t)p->content_skip_bytes * 1000ULL / rate : 0);
+    }
+    p->content_skip_bytes = 0;
+}
+
 ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
                                 uint64_t *at_unix_ms)
 {
@@ -2810,7 +2844,7 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
     p->start_join_pending = false;
     p->content_paused = false;
     p->content_stopped = false;
-    p->content_skip_bytes = 0;
+    ap2_content_skip_reset(p, "START");
     uint64_t ntp_start = 0;
     bool clock_cold = false;
     uint64_t floor_ntp =
@@ -2855,7 +2889,18 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
             atomic_store(&p->media_healthy, false);
             return AP2_COMMIT_FAILED;
         }
-        if (clock_cold) ap2_clock_verify_arm(p, start_unix_ms, at_local, join);
+        if (clock_cold) {
+            ap2_clock_verify_arm(p, start_unix_ms, at_local, join);
+            /* Withhold the join's ack for that verification to answer: this
+             * anchor can still move, and an ack carrying the moved instant
+             * lets the caller map its content straight onto it instead of
+             * mapping to a guess and being corrected afterwards. Only where
+             * the verification actually armed — nothing else would ever
+             * emit it. */
+            pthread_mutex_lock(&p->clock_verify_lock);
+            p->start_ack_deferred = join && p->clock_verify_armed;
+            pthread_mutex_unlock(&p->clock_verify_lock);
+        }
         return AP2_COMMIT_OK;
     }
     if (!p->raopcl) return AP2_COMMIT_FAILED;
@@ -2880,7 +2925,7 @@ void ap2cl_standby(struct ap2cl_s *p)
     ap2_clock_verify_disarm(p);
     p->content_paused = false;
     p->content_stopped = false;
-    p->content_skip_bytes = 0;
+    ap2_content_skip_reset(p, "standby");
     if (p->flow != FLOW_NATIVE_AP2) {
         if (p->raopcl) raop_session_standby(p->raopcl);
         p->state = AP2_CONNECTED;
@@ -2926,7 +2971,7 @@ bool ap2cl_flush(struct ap2cl_s *p)
 {
     if (!p || p->state == AP2_DOWN) return false;
     ap2_clock_verify_disarm(p);
-    p->content_skip_bytes = 0;
+    ap2_content_skip_reset(p, "FLUSH");
 
     if (p->flow != FLOW_NATIVE_AP2)
         return raop_session_flush(p->raopcl);
@@ -2980,7 +3025,7 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
     p->start_join_pending = false;
     p->content_paused = false;
     p->content_stopped = false;
-    p->content_skip_bytes = 0;
+    ap2_content_skip_reset(p, "resume");
 
     if (p->flow != FLOW_NATIVE_AP2) {
         ap2_commit_result_t r =
@@ -3117,8 +3162,14 @@ ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample,
 
 static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
 {
+    /* Frame counts, so every term is scaled to the stream rate: a receiver
+     * reports latencyMax in frames at the rate it is being fed. */
+    uint64_t margin = MS2TS(AP2_PACING_MARGIN_MS, p->format.sample_rate);
     uint64_t window =
-        p->dev_latency_max > 11025 ? p->dev_latency_max - 11025 : 77175;
+        p->dev_latency_max > margin
+            ? p->dev_latency_max - margin
+            : MS2TS(AP2_PACING_DEFAULT_BUFFER_MS - AP2_PACING_MARGIN_MS,
+                    p->format.sample_rate);
     /* The splice timeline keeps the receiver queue shallow: with warm
      * boundaries expressed as content splices on one immutable line, the
      * queue depth IS the audible latency of every seek/next. Apple receivers
@@ -3142,8 +3193,8 @@ bool ap2cl_accept_frames(struct ap2cl_s *p)
          * line starts one lead early), so f's deadline IS f. A frame delivered
          * more than the receiver's latencyMax before its deadline overflows
          * its buffer and is dropped (Sonos: 88200 = 2.0s) — release at most
-         * `window` ahead: the reported window when known, else 77175 (1.75s,
-         * inside every AirPlay receiver's standard 2s). Delivery therefore
+         * `window` ahead: the reported window when known, else 1.75s (inside
+         * every AirPlay receiver's standard 2s). Delivery therefore
          * runs up to ~window AHEAD of playback from the very first sample —
          * the receiver's buffer is filled before the scheduled start and the
          * start cannot underrun — while scheduled group starts stay safe no
@@ -3338,6 +3389,14 @@ ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
     }
 
     ap2_clock_verify_result_t result = AP2_CLOCK_VERIFY_IDLE;
+    /* Read once for the whole poll. A withheld ack and a content cut are two
+     * ways to answer the same correction and are mutually exclusive BY
+     * CONSTRUCTION here: this single flag either sends the correction out as
+     * the ack (the caller maps its content onto the acked instant itself) or
+     * takes the cut (the caller already mapped to the old instant). Doing both
+     * would advance the content twice and put the joiner early by exactly the
+     * cut. */
+    bool ack_deferred = p->start_ack_deferred;
     if (have) {
         uint64_t ready_ms = ap2_clock_ready_from(p, &ex, now_ms);
         ev->requested_unix_ms = p->clock_verify_requested_unix_ms;
@@ -3360,31 +3419,37 @@ ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
                      "origin anchor; anchor stands (observe only)",
                      ready_ms - anchor_ms);
         } else if (!sent) {
-            /* One lead of slack beyond readiness, mirroring every other
-             * forward correction: the instant must still be ahead once the
-             * caller's ack round-trips. */
-            ev->at_unix_ms = ready_ms + AP2_MIN_WARM_LEAD_MS;
+            /* Readiness itself, with no slack on top: unlike the forward
+             * corrections on the commit paths, this one asks nothing of the
+             * caller — it re-bases the reported position and commits nothing
+             * back — so there is no ack round-trip to stay ahead of, and every
+             * millisecond of lead here is content the join has to cut. */
+            ev->at_unix_ms = ready_ms;
             ap2_rebase_pending_anchor(p, ev->at_unix_ms);
-            /* Advance the queued content past the correction: the join's
-             * content was mapped to the original instant, so without the cut
-             * the member would render exactly that far behind the group for
-             * the whole session. Every frame is still unsent (the pacing
-             * gate holds them until anchor minus the window), and the
-             * carrier frame size mirrors the audio loop's input format. */
-            ev->content_cut_ms = ev->at_unix_ms - anchor_ms;
-            uint64_t cut_frames =
-                ev->content_cut_ms * p->format.sample_rate / 1000ULL;
-            int input_bpf =
-                (p->format.bit_depth <= 16 ? 2 : 4) * p->format.channels;
-            p->content_skip_bytes =
-                (uint32_t)(cut_frames * (uint64_t)input_bpf);
+            if (!ack_deferred) {
+                /* Advance the queued content past the correction: the ack has
+                 * already gone out on the original instant, so the caller
+                 * mapped its content there and without the cut the member
+                 * would render exactly that far behind the group for the whole
+                 * session. Every frame is still unsent (the pacing gate holds
+                 * them until anchor minus the window), and the carrier frame
+                 * size mirrors the audio loop's input format. */
+                ev->content_cut_ms = ev->at_unix_ms - anchor_ms;
+                uint64_t cut_frames =
+                    ev->content_cut_ms * p->format.sample_rate / 1000ULL;
+                int input_bpf =
+                    (p->format.bit_depth <= 16 ? 2 : 4) * p->format.channels;
+                p->content_skip_bytes =
+                    (uint32_t)(cut_frames * (uint64_t)input_bpf);
+            }
             result = AP2_CLOCK_VERIFY_CORRECTED;
             LOG_WARN("[AP2] anchor %" PRIu64 " ms precedes receiver clock "
                      "readiness by %" PRIu64 " ms; corrected forward to %"
-                     PRIu64 " and content advanced %" PRIu64 " ms to keep "
-                     "the join on the group timeline",
+                     PRIu64 " and %s to keep the join on the group timeline",
                      anchor_ms, ready_ms - anchor_ms, ev->at_unix_ms,
-                     ev->content_cut_ms);
+                     ack_deferred ? "acked there, the caller mapping its "
+                                    "content onto it"
+                                  : "content advanced by the same amount");
         } else {
             /* Readiness resolved late, after real frames went out: the line
              * cannot move without a stamp jump. The receiver will seat
@@ -3405,11 +3470,36 @@ ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
         LOG_WARN("[AP2] anchor window closed without a receiver clock probe; "
                  "anchor stands unverified");
     }
-    if (result != AP2_CLOCK_VERIFY_IDLE) p->clock_verify_armed = false;
+    if (result != AP2_CLOCK_VERIFY_IDLE) {
+        p->clock_verify_armed = false;
+        /* Every outcome answers the withheld ack — including the two that
+         * leave the anchor standing — and consuming the flag here, at the one
+         * point a result is produced, is what makes it exactly once. */
+        ev->start_ack = ack_deferred;
+        p->start_ack_deferred = false;
+    }
     pthread_mutex_unlock(&p->clock_verify_lock);
     if (result != AP2_CLOCK_VERIFY_IDLE)
         atomic_store(&p->clock_verify_thread_stop, true);
     return result;
+}
+
+bool ap2cl_clock_verify_armed(struct ap2cl_s *p)
+{
+    if (!p) return false;
+    pthread_mutex_lock(&p->clock_verify_lock);
+    bool armed = p->clock_verify_armed;
+    pthread_mutex_unlock(&p->clock_verify_lock);
+    return armed;
+}
+
+bool ap2cl_start_ack_deferred(struct ap2cl_s *p)
+{
+    if (!p) return false;
+    pthread_mutex_lock(&p->clock_verify_lock);
+    bool deferred = p->start_ack_deferred;
+    pthread_mutex_unlock(&p->clock_verify_lock);
+    return deferred;
 }
 
 void ap2cl_log_diagnostics(struct ap2cl_s *p)
@@ -3502,7 +3592,7 @@ void ap2cl_stop(struct ap2cl_s *p)
     ap2_clock_verify_disarm(p);
     p->content_paused = false;
     p->content_stopped = false;
-    p->content_skip_bytes = 0;
+    ap2_content_skip_reset(p, "stop");
     if (p->raopcl) raopcl_stop(p->raopcl);
     ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
     p->rt_anchor_valid = false;
@@ -4354,16 +4444,18 @@ void ap2cl_test_inject_clock_exchange(struct ap2cl_s *p, uint32_t count,
     pthread_mutex_unlock(&p->clock_verify_lock);
 }
 
-bool ap2cl_test_clock_verify_armed(struct ap2cl_s *p)
-{
-    pthread_mutex_lock(&p->clock_verify_lock);
-    bool armed = p->clock_verify_armed;
-    pthread_mutex_unlock(&p->clock_verify_lock);
-    return armed;
-}
-
 void ap2cl_test_bump_audio_sent(struct ap2cl_s *p)
 {
     p->audio_packets_sent++;
+}
+
+void ap2cl_test_set_dev_latency_max(struct ap2cl_s *p, uint32_t frames)
+{
+    p->dev_latency_max = frames;
+}
+
+uint64_t ap2cl_test_pacing_window_frames(struct ap2cl_s *p)
+{
+    return ap2_pacing_window_frames(p);
 }
 #endif

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -243,6 +243,10 @@ typedef struct {
     int64_t margin_ms;             /* readiness margin before the anchor (verified) */
     uint64_t content_cut_ms;       /* content advanced past the correction so the
                                       join still lands on the group timeline */
+    bool start_ack;                /* this event carries the join's withheld
+                                      [STATUS] started (see
+                                      ap2cl_start_ack_deferred); then no content
+                                      was cut, the two being exclusive */
 } ap2_clock_verify_event_t;
 
 /*
@@ -257,6 +261,19 @@ typedef struct {
  */
 ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
                                                   ap2_clock_verify_event_t *ev);
+
+/* True while a cold-clock verification can still produce a result. It goes
+ * false on the resolving poll and on every disarm (commit, flush, park,
+ * teardown), which is how a caller holding a withheld ack knows the
+ * verification will never answer it and emits it itself. */
+bool ap2cl_clock_verify_armed(struct ap2cl_s *p);
+
+/* True when the commit just made withheld the join's [STATUS] started for its
+ * verification to answer: a cold-clock join committed through ap2cl_start can
+ * still have its anchor moved, and an ack carrying the moved instant lets the
+ * caller map its content straight onto it — which is why no content cut is
+ * taken on that path. Cleared by the resolving poll and by every disarm. */
+bool ap2cl_start_ack_deferred(struct ap2cl_s *p);
 
 /* Mark the next commanded start as a late join onto an already-live group
  * timeline: receiver clock readiness is then ENFORCED — a cold-clock anchor

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -100,6 +100,16 @@ static size_t sring_pop(sring_t *r, uint8_t *buf, size_t want)
     return n;
 }
 
+/* Advance past queued bytes without copying them out (see
+ * ap2_session_discard). */
+static size_t sring_drop(sring_t *r, size_t want)
+{
+    size_t n = want < r->fill ? want : r->fill;
+    r->rd = (r->rd + n) % r->cap;
+    r->fill -= n;
+    return n;
+}
+
 static size_t sring_push(sring_t *r, const uint8_t *buf, size_t len)
 {
     size_t space = r->cap - r->fill;
@@ -457,6 +467,48 @@ int ap2_session_read(struct ap2_session_s *s, uint8_t *buf, int len,
             if (s->ring.fill >= (size_t)len ||
                 (s->ring.eof && s->ring.fill > 0)) {
                 size_t n = sring_pop(&s->ring, buf, (size_t)len);
+                pthread_cond_broadcast(&s->can_write);
+                pthread_mutex_unlock(&s->lock);
+                return (int)n;
+            }
+            if (s->ring.eof) {
+                pthread_mutex_unlock(&s->lock);
+                return -1;   /* input stream fully consumed */
+            }
+        }
+        uint64_t now = ap2_io_monotonic_ms();
+        if (now >= deadline) {
+            pthread_mutex_unlock(&s->lock);
+            return 0;
+        }
+        uint64_t wait_ms = deadline - now;
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += (time_t)(wait_ms / 1000);
+        ts.tv_nsec += (long)(wait_ms % 1000) * 1000000L;
+        if (ts.tv_nsec >= 1000000000L) {
+            ts.tv_sec += 1;
+            ts.tv_nsec -= 1000000000L;
+        }
+        pthread_cond_timedwait(&s->can_read, &s->lock, &ts);
+    }
+}
+
+int ap2_session_discard(struct ap2_session_s *s, int len, int timeout_ms)
+{
+    if (!s || len <= 0) return -2;
+    uint64_t deadline =
+        ap2_io_monotonic_ms() + (timeout_ms > 0 ? (uint64_t)timeout_ms : 0);
+
+    pthread_mutex_lock(&s->lock);
+    for (;;) {
+        if (s->state == AP2_SESSION_ENDED) {
+            pthread_mutex_unlock(&s->lock);
+            return -2;
+        }
+        if (s->state == AP2_SESSION_PLAYING) {
+            if (s->ring.fill > 0) {
+                size_t n = sring_drop(&s->ring, (size_t)len);
                 pthread_cond_broadcast(&s->can_write);
                 pthread_mutex_unlock(&s->lock);
                 return (int)n;

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -188,7 +188,8 @@ int ap2_session_read(struct ap2_session_s *s, uint8_t *buf, int len,
  * waiting for a complete chunk would only stall the caller — and blocks only
  * while the ring is empty. Returns the number of bytes dropped (0 when the
  * timeout passes with nothing queued), -1 once the input is fully consumed,
- * and -2 when the session ended.
+ * and -2 when the session ended or the arguments are invalid — the same
+ * overload `read` uses, so both are handled by one caller-side check.
  *
  * :param len: Upper bound on the bytes to drop.
  * :param timeout_ms: How long to wait for input before returning 0.

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -182,6 +182,18 @@ void ap2_session_end(struct ap2_session_s *s);
  * calls `poll` once per iteration so the engine can run the idle timeout. */
 int ap2_session_read(struct ap2_session_s *s, uint8_t *buf, int len,
                      int timeout_ms);
+/*
+ * Drop up to len bytes of queued input without delivering them. Unlike `read`
+ * this takes whatever the ring holds right now — the bytes are discarded, so
+ * waiting for a complete chunk would only stall the caller — and blocks only
+ * while the ring is empty. Returns the number of bytes dropped (0 when the
+ * timeout passes with nothing queued), -1 once the input is fully consumed,
+ * and -2 when the session ended.
+ *
+ * :param len: Upper bound on the bytes to drop.
+ * :param timeout_ms: How long to wait for input before returning 0.
+ */
+int ap2_session_discard(struct ap2_session_s *s, int len, int timeout_ms);
 void ap2_session_poll(struct ap2_session_s *s);
 
 ap2_session_state_t ap2_session_state(struct ap2_session_s *s);

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -206,21 +206,86 @@ static void status_error(const char *msg)
     status_print("[ERROR] %s", msg);
 }
 
+/* The join's [STATUS] started, withheld at commit so the receiver-clock
+ * verification can answer it with the instant the receiver can actually seat
+ * (see ap2cl_start_ack_deferred). Exactly one ack leaves per START: the commit
+ * either prints it outright or latches it here, and every way the verification
+ * can end — a result, a disarm, a superseding commit, the loop ending — funnels
+ * through the single emission in start_ack_flush(). All of it runs under
+ * g_audio_send_lock, which the commit holds through the session engine's
+ * quiesce bracket. */
+static bool g_start_ack_pending = false;
+static uint64_t g_start_ack_requested_ms = 0;
+static uint64_t g_start_ack_at_ms = 0;
+/* Set by session_commit, read by the START handler that drove it — both on the
+ * command thread, so it never races the verification emitting the same ack. */
+static bool g_start_ack_withheld = false;
+
+static void status_started(uint64_t requested_ms, uint64_t at_ms)
+{
+    status_print("[STATUS] started requested_unix_ms=%" PRIu64
+                 " at_unix_ms=%" PRIu64, requested_ms, at_ms);
+}
+
+/* Emit a withheld ack with the instant that stands. A no-op when none is held,
+ * so every path out of the verification can call it unconditionally. */
+static void start_ack_flush(void)
+{
+    if (!g_start_ack_pending) return;
+    g_start_ack_pending = false;
+    status_started(g_start_ack_requested_ms, g_start_ack_at_ms);
+}
+
+/* Corrected-join content cut, tracked from the correction until the debt is
+ * settled. `anchor_corrected` reports the cut the correction ASKED for —
+ * arithmetic on two instants, computed before a single byte is examined — so
+ * the amount actually taken off the queued content is reported separately once
+ * the last byte is discarded. The two disagree only when the cut ends short
+ * (the input ran out, or a new commit superseded the corrected timeline). */
+static bool g_content_cut_active = false;
+static uint64_t g_content_cut_requested_ms = 0;
+static uint32_t g_content_cut_dropped = 0;
+static uint64_t g_content_cut_started_ntp = 0;
+
+static void content_cut_report(unsigned input_byte_rate)
+{
+    if (!g_content_cut_active) return;
+    g_content_cut_active = false;
+    uint64_t cut_ms = input_byte_rate
+        ? (uint64_t)g_content_cut_dropped * 1000ULL / input_byte_rate : 0;
+    status_print("[STATUS] content_cut requested_ms=%" PRIu64 " cut_ms=%" PRIu64
+                 " cut_bytes=%u drain_ms=%" PRIu64,
+                 g_content_cut_requested_ms, cut_ms, g_content_cut_dropped,
+                 (uint64_t)NTP2MS(raopcl_get_ntp(NULL) -
+                                  g_content_cut_started_ntp));
+}
+
 /* Advance the receiver-clock verification of a cold-clock START (armed by
  * the client when it commits before the receiver's first timing probe) and
- * surface the outcome. A correction reports the new audible instant so the
- * caller re-aligns the group; a verification only confirms the ack already
- * sent. Called from the audio loop under g_audio_send_lock. */
+ * surface the outcome. A join whose ack was withheld is acked here with the
+ * instant the verification settled on, and takes no content cut: the caller
+ * maps its content onto the acked instant itself. Where the ack already went
+ * out, a correction instead reports the new instant and the cut that keeps the
+ * member on the group timeline; a verification only confirms the ack sent.
+ * Called from the audio loop under g_audio_send_lock. */
 static void clock_verify_tick(void)
 {
     ap2_clock_verify_event_t ev;
-    switch (ap2cl_clock_verify_poll(g_ap2cl, &ev)) {
+    ap2_clock_verify_result_t result = ap2cl_clock_verify_poll(g_ap2cl, &ev);
+    if (result == AP2_CLOCK_VERIFY_IDLE) return;
+    switch (result) {
     case AP2_CLOCK_VERIFY_CORRECTED:
-        status_print("[STATUS] anchor_corrected requested_unix_ms=%" PRIu64
-                     " from_unix_ms=%" PRIu64 " at_unix_ms=%" PRIu64
-                     " content_cut_ms=%" PRIu64,
-                     ev.requested_unix_ms, ev.from_unix_ms, ev.at_unix_ms,
-                     ev.content_cut_ms);
+        if (!ev.start_ack) {
+            status_print("[STATUS] anchor_corrected requested_unix_ms=%" PRIu64
+                         " from_unix_ms=%" PRIu64 " at_unix_ms=%" PRIu64
+                         " content_cut_ms=%" PRIu64,
+                         ev.requested_unix_ms, ev.from_unix_ms, ev.at_unix_ms,
+                         ev.content_cut_ms);
+            g_content_cut_active = true;
+            g_content_cut_requested_ms = ev.content_cut_ms;
+            g_content_cut_dropped = 0;
+            g_content_cut_started_ntp = raopcl_get_ntp(NULL);
+        }
         break;
     case AP2_CLOCK_VERIFY_VERIFIED:
         status_print("[STATUS] clock_verified margin_ms=%" PRId64,
@@ -228,6 +293,10 @@ static void clock_verify_tick(void)
         break;
     default:
         break;
+    }
+    if (ev.start_ack) {
+        g_start_ack_at_ms = ev.at_unix_ms;
+        start_ack_flush();
     }
 }
 
@@ -462,9 +531,12 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
             ? ap2_session_start(g_session, g_pend_start_unix_ms, &at_ms)
             : AP2_COMMIT_FAILED;
         if (started == AP2_COMMIT_OK) {
-            status_print("[STATUS] started requested_unix_ms=%" PRIu64
-                         " at_unix_ms=%" PRIu64,
-                         g_pend_start_unix_ms, at_ms);
+            /* A cold-clock join withholds its ack for the verification to
+             * answer with the instant the receiver can seat. The commit
+             * latched that decision, so read it rather than the pending flag:
+             * the verification can resolve — and emit — before this line. */
+            if (!g_start_ack_withheld)
+                status_started(g_pend_start_unix_ms, at_ms);
         } else {
             status_error("START failed");
         }
@@ -563,6 +635,11 @@ static ap2_commit_result_t session_commit(void *transport,
 {
     cli_config_t *cfg = transport;
     ap2_commit_result_t committed;
+    /* One ack per START: a previous join's withheld ack is answered with the
+     * instant that stood, before this commit replaces the timeline it
+     * described. */
+    start_ack_flush();
+    g_start_ack_withheld = false;
     /* The first START begins the session; a START after a FLUSH re-anchors the
      * flushed stream (no second receiver flush, no crypto/sequence reset). An
      * infeasible instant is corrected forward by the transport, which reports
@@ -582,6 +659,16 @@ static ap2_commit_result_t session_commit(void *transport,
             : ap2cl_resume(client, start_unix_ms, at_unix_ms);
     }
     if (committed != AP2_COMMIT_OK) return committed;
+
+    /* Latch a withheld ack here, inside the session engine's quiesce bracket:
+     * the audio loop is held off, so the verification cannot resolve between
+     * the commit arming it and the ack being owed. */
+    if (cfg->protocol != PROTO_RAOP && ap2cl_start_ack_deferred(g_ap2cl)) {
+        g_start_ack_withheld = true;
+        g_start_ack_pending = true;
+        g_start_ack_requested_ms = start_unix_ms;
+        g_start_ack_at_ms = at_unix_ms ? *at_unix_ms : start_unix_ms;
+    }
 
     /* Metadata-gated receivers must receive a placeholder before audio. */
     if (!g_first_start_done) send_initial_metadata(cfg);
@@ -1137,6 +1224,8 @@ static int run_airplay2(cli_config_t *cfg)
      * pipe thread anchors playback on the first START after connection setup. */
     int ap2_input_bpf = (cfg->bit_depth <= 16 ? 2 : 4) * cfg->channels;
     int ap2_alac_bpf = (cfg->bit_depth <= 16 ? 2 : 3) * cfg->channels;
+    unsigned ap2_input_byte_rate =
+        (unsigned)cfg->sample_rate * (unsigned)ap2_input_bpf;
     if (!start_stream_session(
             cfg, ap2_input_bpf, AP2_FRAMES_PER_CHUNK))
         return 1;
@@ -1176,6 +1265,19 @@ static int run_airplay2(cli_config_t *cfg)
             eof_reported = false;
             eof_time = 0;
         }
+
+        /* Receiver-clock verification of a cold-clock START, driven on every
+         * iteration whatever the playback status and whatever the input is
+         * doing: a join's ack is withheld until this resolves, so a pause, a
+         * park, or an input that ends before the anchor must not strand it.
+         * Once the verification can no longer answer — it resolved, or a
+         * commit, flush or park disarmed it — the withheld ack falls due here.
+         * The send lock is held because a correction rebases the anchor line
+         * the send path reads. */
+        pthread_mutex_lock(&g_audio_send_lock);
+        clock_verify_tick();
+        if (!ap2cl_clock_verify_armed(g_ap2cl)) start_ack_flush();
+        pthread_mutex_unlock(&g_audio_send_lock);
 
         /* Periodic status reporting (only while playing, so a pause does not keep
            emitting a "playing" status that would revive the sender's play state) */
@@ -1232,11 +1334,40 @@ static int run_airplay2(cli_config_t *cfg)
                 usleep(1000);
                 continue;
             }
-            /* Before the pacing gate: a distant anchor keeps the gate closed
-             * until anchor minus the pacing window, and the verification of
-             * a cold-clock START must keep advancing through exactly that
-             * quiet stretch. */
-            clock_verify_tick();
+            /* Corrected-join content debt: discard the queued input the
+             * correction advanced past, so the first retained sample is the
+             * one the group timeline schedules at the corrected instant.
+             * Serviced above the pacing gate — discarded bytes never reach
+             * the wire, so the gate has no business throttling them and the
+             * debt pays down across the whole quiet stretch the correction
+             * opens instead of the last window before the anchor. Nothing is
+             * sent until it is settled: every retained sample belongs after
+             * the corrected instant. */
+            uint32_t debt = ap2cl_content_skip_bytes(g_ap2cl);
+            if (debt) {
+                int dropped = ap2_session_discard(g_session, (int)debt, 250);
+                if (dropped == -2) {
+                    pthread_mutex_unlock(&g_audio_send_lock);
+                    break;
+                }
+                if (dropped > 0) {
+                    g_content_cut_dropped += (uint32_t)dropped;
+                    ap2cl_content_skip_consume(g_ap2cl, (uint32_t)dropped);
+                }
+                if (dropped == -1) {
+                    /* The input ended inside the cut: what is left of the debt
+                     * has no content to take, so the cut settles short here
+                     * rather than outliving the stream it belonged to. */
+                    LOG_INFO("End of AirPlay 2 input stream, draining buffer...");
+                    input_ended = true;
+                    eof_time = raopcl_get_ntp(NULL);
+                    ap2cl_content_skip_consume(g_ap2cl, debt);
+                    content_cut_report(ap2_input_byte_rate);
+                }
+                pthread_mutex_unlock(&g_audio_send_lock);
+                continue;
+            }
+            content_cut_report(ap2_input_byte_rate);
             if (!ap2cl_accept_frames(g_ap2cl)) {
                 pthread_mutex_unlock(&g_audio_send_lock);
                 usleep(1000);
@@ -1314,37 +1445,6 @@ static int run_airplay2(cli_config_t *cfg)
                     ap2cl_log_diagnostics(g_ap2cl);
                     starving = false;
                 }
-                /* Corrected-join content cut: drop the bytes the correction
-                 * advanced past, so the first retained sample is the one the
-                 * group timeline schedules at the corrected instant. Only
-                 * successful reads get here (a timeout returns 0 and takes
-                 * the starvation path above), and mid-stream those carry the
-                 * full request — so a read is either dropped whole, or holds
-                 * the cut boundary and its dropped span is refilled so the
-                 * sent chunk stays full with no silence inside the content.
-                 * At EOF the refill comes back short (or not at all) and the
-                 * remainder ships as the normal padded final chunk. */
-                uint32_t drop = ap2cl_content_skip_bytes(g_ap2cl);
-                if (drop && n > 0) {
-                    if ((uint32_t)n <= drop) {
-                        ap2cl_content_skip_consume(g_ap2cl, (uint32_t)n);
-                        pthread_mutex_unlock(&g_audio_send_lock);
-                        continue;
-                    }
-                    memmove(buf + pad_bytes, buf + pad_bytes + drop,
-                            (size_t)((uint32_t)n - drop));
-                    n -= (int)drop;
-                    int extra = ap2_session_read(
-                        g_session, buf + pad_bytes + n, (int)drop, 250);
-                    if (extra == -2) {
-                        /* Session ended mid-refill: match the main read
-                         * path and stop without sending. */
-                        pthread_mutex_unlock(&g_audio_send_lock);
-                        break;
-                    }
-                    if (extra > 0) n += extra;
-                    ap2cl_content_skip_consume(g_ap2cl, drop);
-                }
             }
             if (pad_bytes)
                 memset(buf, 0, (size_t)pad_bytes);
@@ -1404,6 +1504,9 @@ static int run_airplay2(cli_config_t *cfg)
         }
     }
 
+    /* The loop ends on teardown, and a join whose verification never resolved
+     * is still owed its one ack. */
+    start_ack_flush();
     request_command_stop();
     bool command_joined = join_command_thread();
     ap2_session_destroy(g_session);

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -1505,8 +1505,10 @@ static int run_airplay2(cli_config_t *cfg)
     }
 
     /* The loop ends on teardown, and a join whose verification never resolved
-     * is still owed its one ack. */
+     * is still owed its one ack. A cut caught mid-drain is settled short by
+     * the teardown, so it reports what it managed to take. */
     start_ack_flush();
+    content_cut_report(ap2_input_byte_rate);
     request_command_stop();
     bool command_joined = join_command_thread();
     ap2_session_destroy(g_session);

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -50,8 +50,9 @@ void ap2cl_test_set_apple_model(struct ap2cl_s *p, bool apple);
 bool ap2cl_test_apple_model_default(const char *txt, const char *am);
 void ap2cl_test_inject_clock_exchange(struct ap2cl_s *p, uint32_t count,
                                       uint64_t first_ms, uint64_t third_ms);
-bool ap2cl_test_clock_verify_armed(struct ap2cl_s *p);
 void ap2cl_test_bump_audio_sent(struct ap2cl_s *p);
+void ap2cl_test_set_dev_latency_max(struct ap2cl_s *p, uint32_t frames);
+uint64_t ap2cl_test_pacing_window_frames(struct ap2cl_s *p);
 
 typedef struct {
     int fd;
@@ -893,6 +894,70 @@ static void test_apple_model_resolution(void)
     puts("ap2_client apple model resolution tests passed");
 }
 
+/* The pacing window is a duration, so every term scales with the stream rate:
+ * the margin held back from the receiver's reported buffer, the default that
+ * stands in for a buffer it never reported, and the splice depth that caps
+ * both. Same frame counts at 44.1 kHz, ~8.8% more at 48 kHz. */
+static void test_pacing_window_rate_scaling(void)
+{
+    static const struct {
+        int rate;
+        uint64_t unreported;    /* no latencyMax echoed: the 1.75 s default */
+        uint32_t reported;      /* a 2.0 s receiver buffer, in frames */
+        uint64_t windowed;      /* that buffer less the 250 ms margin */
+        uint32_t under_margin;  /* a buffer no deeper than the margin */
+        uint32_t shallow;       /* an 800 ms buffer: under the splice depth */
+        uint64_t shallow_win;
+        uint64_t splice_depth;  /* 600 ms, the cap on the splice timeline */
+    } cases[] = {
+        {44100, 77175, 88200, 77175, 4410, 35280, 24255, 26460},
+        {48000, 84000, 96000, 84000, 4800, 38400, 26400, 28800},
+    };
+
+    ap2_device_info_t device = {
+        .name = "pacing test",
+        .address = "127.0.0.1",
+        .port = 7000,
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        ap2_audio_format_t format = {
+            .sample_rate = cases[i].rate,
+            .bit_depth = 16,
+            .channels = 2,
+        };
+        struct ap2cl_s *client = ap2cl_create(
+            &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+        assert(client);
+        ap2cl_force_native(client);
+
+        /* Receiver echoes no latencyMax (Sonos, and both Samsung sets in the
+         * late-join field logs): the assumed buffer less the margin. */
+        assert(ap2cl_test_pacing_window_frames(client) == cases[i].unreported);
+
+        /* A reported buffer: the margin held back scales with the rate too. */
+        ap2cl_test_set_dev_latency_max(client, cases[i].reported);
+        assert(ap2cl_test_pacing_window_frames(client) == cases[i].windowed);
+
+        /* A buffer inside the margin leaves nothing to hold back, so the
+         * default stands rather than underflowing the subtraction. */
+        ap2cl_test_set_dev_latency_max(client, cases[i].under_margin);
+        assert(ap2cl_test_pacing_window_frames(client) == cases[i].unreported);
+
+        /* On the splice timeline the shallow queue depth caps the window —
+         * unless the receiver reports a buffer shallower still, which then
+         * caps the room a corrected late join's content skip has to drain. */
+        ap2cl_test_set_splice(client, true);
+        ap2cl_test_set_dev_latency_max(client, cases[i].reported);
+        assert(ap2cl_test_pacing_window_frames(client) == cases[i].splice_depth);
+        ap2cl_test_set_dev_latency_max(client, cases[i].shallow);
+        assert(ap2cl_test_pacing_window_frames(client) == cases[i].shallow_win);
+
+        assert(ap2cl_destroy(client));
+    }
+    puts("ap2_client pacing window rate scaling tests passed");
+}
+
 /* A start committed before the receiver's first timing probe arms the
  * post-commit verification; the poll then verifies, corrects forward, or
  * closes the window, exactly once per commit. */
@@ -922,59 +987,116 @@ static void test_clock_verified_anchor(void)
     uint64_t at = 0;
     assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
     assert(at == start_ms);
-    assert(ap2cl_test_clock_verify_armed(client));
+    assert(ap2cl_clock_verify_armed(client));
 
     /* No probe yet and a wide-open window: nothing to report. */
     assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_IDLE);
-    assert(ap2cl_test_clock_verify_armed(client));
+    assert(ap2cl_clock_verify_armed(client));
 
     /* A streak whose lock window ends before the anchor verifies it. */
     ap2cl_test_inject_clock_exchange(client, 2, 100, 0);
     assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_VERIFIED);
     assert(ev.margin_ms > 2000 && ev.margin_ms < 3500);
-    assert(!ap2cl_test_clock_verify_armed(client));
+    assert(!ap2cl_clock_verify_armed(client));
     assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_IDLE);
 
     /* An origin start short of readiness is observed, never moved. */
     start_ms = test_now_unix_ms() + 1500;
     assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
-    assert(ap2cl_test_clock_verify_armed(client));
+    assert(ap2cl_clock_verify_armed(client));
     uint64_t origin_head = ap2cl_test_head_ts(client);
     ap2cl_test_inject_clock_exchange(client, 1, 0, 0);
     assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_UNVERIFIED);
     assert(ap2cl_test_head_ts(client) == origin_head);
-    assert(!ap2cl_test_clock_verify_armed(client));
+    assert(!ap2cl_clock_verify_armed(client));
 
-    /* A join-marked start short of readiness moves the still-unsent line
-     * forward by the shortfall plus the retry slack (wire head following)
-     * and advances the queued content by exactly the correction, so the
-     * retained content still lands on the group timeline. */
+    /* A join-marked start short of readiness withholds its ack and moves the
+     * still-unsent line forward onto readiness exactly — no round-trip slack
+     * on top, since the caller commits nothing back — with the wire head
+     * following. The event carries the ack, so the caller maps its content
+     * onto the acked instant and NO cut is taken: doing both would advance the
+     * content twice. The 1.5 s anchor falls 800 ms short of the 2.3 s lock
+     * window the injected streak starts. */
     start_ms = test_now_unix_ms() + 1500;
     ap2cl_set_start_join(client, true);
     assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
-    assert(ap2cl_test_clock_verify_armed(client));
+    assert(at == start_ms);
+    assert(ap2cl_clock_verify_armed(client));
+    assert(ap2cl_start_ack_deferred(client));
     assert(ap2cl_content_skip_bytes(client) == 0);
     ap2cl_test_inject_clock_exchange(client, 1, 0, 0);
     assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_CORRECTED);
+    assert(ev.start_ack);
     assert(ev.from_unix_ms == start_ms);
-    assert(ev.at_unix_ms > start_ms + 800);
-    assert(ev.at_unix_ms < start_ms + 2000);
-    assert(ev.content_cut_ms == ev.at_unix_ms - ev.from_unix_ms);
+    assert(ev.at_unix_ms >= start_ms + 800);
+    assert(ev.at_unix_ms < start_ms + 900);
+    assert(ev.content_cut_ms == 0);
+    assert(ap2cl_content_skip_bytes(client) == 0);
     uint64_t head_ms_at_rate =
         ap2cl_test_head_ts(client) * 1000ULL / format.sample_rate;
     assert(head_ms_at_rate + 5 > ev.at_unix_ms &&
            head_ms_at_rate < ev.at_unix_ms + 5);
+    /* Answered exactly once: the flag is consumed with the result, so a second
+     * poll can neither re-deliver it nor produce another event. */
+    assert(!ap2cl_start_ack_deferred(client));
+    assert(!ap2cl_clock_verify_armed(client));
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_IDLE);
+    assert(!ev.start_ack);
+
+    /* The fallback: a join re-anchored through resume acks at commit, so a
+     * later correction takes the cut instead — the caller already mapped its
+     * content to the instant it was acked. */
+    start_ms = test_now_unix_ms() + 1500;
+    ap2cl_set_start_join(client, true);
+    assert(ap2cl_resume(client, start_ms, &at) == AP2_COMMIT_OK);
+    assert(ap2cl_clock_verify_armed(client));
+    assert(!ap2cl_start_ack_deferred(client));
+    ap2cl_test_inject_clock_exchange(client, 1, 0, 0);
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_CORRECTED);
+    assert(!ev.start_ack);
+    assert(ev.content_cut_ms == ev.at_unix_ms - ev.from_unix_ms);
     /* 16-bit stereo: 4 bytes per input frame. */
     assert(ap2cl_content_skip_bytes(client) ==
            ev.content_cut_ms * format.sample_rate / 1000 * 4);
     ap2cl_content_skip_consume(client, 128);
     assert(ap2cl_content_skip_bytes(client) ==
            ev.content_cut_ms * format.sample_rate / 1000 * 4 - 128);
-    assert(!ap2cl_test_clock_verify_armed(client));
 
     /* A new commit clears an undrained cut. */
     assert(ap2cl_start(client, 0, &at) == AP2_COMMIT_OK);
     assert(ap2cl_content_skip_bytes(client) == 0);
+
+    /* So does a flush, and every other reset of the corrected timeline. */
+    start_ms = test_now_unix_ms() + 1500;
+    ap2cl_set_start_join(client, true);
+    assert(ap2cl_resume(client, start_ms, &at) == AP2_COMMIT_OK);
+    ap2cl_test_inject_clock_exchange(client, 1, 0, 0);
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_CORRECTED);
+    assert(ap2cl_content_skip_bytes(client) > 0);
+    assert(ap2cl_flush(client));
+    assert(ap2cl_content_skip_bytes(client) == 0);
+
+    /* A disarm before the verification resolves drops both flags together:
+     * that is how the audio loop knows the withheld ack will never be
+     * answered and must emit it with the instant that stands. */
+    start_ms = test_now_unix_ms() + 1500;
+    ap2cl_set_start_join(client, true);
+    assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    assert(ap2cl_clock_verify_armed(client));
+    assert(ap2cl_start_ack_deferred(client));
+    assert(ap2cl_flush(client));
+    assert(!ap2cl_clock_verify_armed(client));
+    assert(!ap2cl_start_ack_deferred(client));
+
+    /* An origin start never withholds its ack: it is acked at commit and the
+     * verification only observes. */
+    start_ms = test_now_unix_ms() + 1500;
+    assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    assert(ap2cl_clock_verify_armed(client));
+    assert(!ap2cl_start_ack_deferred(client));
+    ap2cl_test_inject_clock_exchange(client, 1, 0, 0);
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_UNVERIFIED);
+    assert(!ev.start_ack);
 
     /* The Apple fast bound (third exchange + settle) verifies an anchor the
      * full lock window would have corrected. */
@@ -983,7 +1105,22 @@ static void test_clock_verified_anchor(void)
     assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
     ap2cl_test_inject_clock_exchange(client, 3, 400, 200);
     assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_VERIFIED);
-    assert(!ap2cl_test_clock_verify_armed(client));
+    assert(!ap2cl_clock_verify_armed(client));
+    ap2cl_test_set_apple_model(client, false);
+
+    /* A join whose anchor the receiver can already seat is acked at the
+     * instant it committed to — the ack is withheld for the answer, not for a
+     * correction. */
+    ap2cl_test_set_apple_model(client, true);
+    start_ms = test_now_unix_ms() + 1500;
+    ap2cl_set_start_join(client, true);
+    assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    assert(ap2cl_start_ack_deferred(client));
+    ap2cl_test_inject_clock_exchange(client, 3, 400, 200);
+    assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_VERIFIED);
+    assert(ev.start_ack);
+    assert(ev.at_unix_ms == start_ms);
+    assert(ap2cl_content_skip_bytes(client) == 0);
     ap2cl_test_set_apple_model(client, false);
 
     /* Audio already on the wire closes the window: without a probe the
@@ -992,29 +1129,38 @@ static void test_clock_verified_anchor(void)
     assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
     ap2cl_test_bump_audio_sent(client);
     assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_UNVERIFIED);
-    assert(!ap2cl_test_clock_verify_armed(client));
+    assert(!ap2cl_clock_verify_armed(client));
 
-    /* ...and even a join cannot move a line with audio already on it. */
+    /* ...and even a join cannot move a line with audio already on it. That
+     * terminal outcome still answers the withheld ack, with the instant that
+     * stands, so the caller is never left waiting on it. */
     start_ms = test_now_unix_ms() + 1500;
     ap2cl_set_start_join(client, true);
     assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
+    assert(ap2cl_start_ack_deferred(client));
     uint64_t head_before = ap2cl_test_head_ts(client);
     ap2cl_test_bump_audio_sent(client);
     ap2cl_test_inject_clock_exchange(client, 1, 0, 0);
     assert(ap2cl_clock_verify_poll(client, &ev) == AP2_CLOCK_VERIFY_UNVERIFIED);
+    assert(ev.start_ack);
+    assert(ev.at_unix_ms == start_ms);
     assert(ap2cl_test_head_ts(client) == head_before);
-    assert(!ap2cl_test_clock_verify_armed(client));
+    assert(ap2cl_content_skip_bytes(client) == 0);
+    assert(!ap2cl_clock_verify_armed(client));
 
-    /* An anchor without room to act before the fill never arms. */
+    /* An anchor without room to act before the fill never arms — and a join
+     * that never arms never withholds its ack, or nothing would emit it. */
+    ap2cl_set_start_join(client, true);
     assert(ap2cl_start(client, 0, &at) == AP2_COMMIT_OK);
-    assert(!ap2cl_test_clock_verify_armed(client));
+    assert(!ap2cl_clock_verify_armed(client));
+    assert(!ap2cl_start_ack_deferred(client));
 
     /* A flush disarms a pending verification. */
     start_ms = test_now_unix_ms() + 5000;
     assert(ap2cl_start(client, start_ms, &at) == AP2_COMMIT_OK);
-    assert(ap2cl_test_clock_verify_armed(client));
+    assert(ap2cl_clock_verify_armed(client));
     assert(ap2cl_flush(client));
-    assert(!ap2cl_test_clock_verify_armed(client));
+    assert(!ap2cl_clock_verify_armed(client));
 
     ap2cl_destroy(client);
     puts("ap2_client clock verified anchor tests passed");
@@ -1034,6 +1180,7 @@ int main(void)
     test_splice_pause_keeps_line_hot();
     test_feedback_miss_tolerated_then_recovered();
     test_apple_model_resolution();
+    test_pacing_window_rate_scaling();
     test_clock_verified_anchor();
 
     ap2_device_info_t device = {

--- a/tests/test_ap2_session.c
+++ b/tests/test_ap2_session.c
@@ -247,6 +247,60 @@ static void test_short_read_is_released_at_eof(void)
     status_state = NULL;
 }
 
+/* Discard pays down a corrected join's content cut: whole reads vanish, the
+ * byte after the cut is the first one delivered, a debt bigger than the queue
+ * is paid in instalments, and the input running out inside the cut ends it. */
+static void test_discard_drops_queued_input(void)
+{
+    static const uint8_t audio[] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60};
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 0, &write_fd);
+
+    feed(write_fd, audio, sizeof(audio));
+    assert(wait_for_count(&state.audio_status, 1, 1000));
+    assert(ap2_session_start(session, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
+
+    /* A debt covering less than the queue stops on its boundary: the next read
+     * starts at the byte the cut ended on, nothing in between is delivered. */
+    assert(ap2_session_discard(session, 2, 1000) == 2);
+    read_exact(session, audio + 2, sizeof(audio) - 2);
+
+    /* A debt covering the whole queue takes it whole, leaving nothing to read. */
+    feed(write_fd, audio, sizeof(audio));
+    uint8_t got[sizeof(audio)];
+    int taken = 0;
+    uint64_t deadline = ap2_io_monotonic_ms() + 2000;
+    while (taken < (int)sizeof(audio) && ap2_io_monotonic_ms() < deadline) {
+        int n = ap2_session_discard(session, (int)sizeof(audio) - taken, 200);
+        assert(n >= 0);
+        taken += n;
+    }
+    assert(taken == (int)sizeof(audio));
+    assert(ap2_session_read(session, got, sizeof(got), 50) == 0);
+
+    /* A debt outliving the queue takes what is there and carries the rest:
+     * the instalment is short, and the bytes fed afterwards pay the balance. */
+    feed(write_fd, audio, 2);
+    usleep(50000);
+    assert(ap2_session_discard(session, 4, 1000) == 2);
+    feed(write_fd, audio + 2, 2);
+    usleep(50000);
+    assert(ap2_session_discard(session, 2, 1000) == 2);
+    assert(ap2_session_discard(session, 4, 50) == 0);   /* nothing queued */
+
+    /* The input ending inside a debt ends the cut short. */
+    assert(close(write_fd) == 0);
+    assert(ap2_session_discard(session, 4, 1000) == -1);
+
+    /* An ended session is reported apart from a consumed input. */
+    ap2_session_end(session);
+    assert(ap2_session_discard(session, 4, 50) == -2);
+
+    ap2_session_destroy(session);
+    status_state = NULL;
+}
+
 /* The headline test: FLUSH drains the ring AND any undelivered stdin bytes and
  * acks with [STATUS] flushed; the next START re-anchors and resumes cleanly from
  * only the post-flush audio. */
@@ -453,6 +507,7 @@ int main(void)
     test_flush_ack_carries_warm_head();
     test_ready_and_reads_wait_for_a_complete_packet();
     test_short_read_is_released_at_eof();
+    test_discard_drops_queued_input();
     test_flush_drains_and_reanchors();
     test_flush_while_idle_before_start();
     test_failed_flush_preserves_pending_audio();


### PR DESCRIPTION
A speaker that joins an already-playing group could end up audibly behind the
others, and stopping and rejoining it was the only reliable fix.

A freshly connected speaker has not yet locked onto the shared clock, so the
instant we commit a join to is often one it cannot honour. Until now we told
the server that instant anyway, then moved it and tried to compensate by
throwing away a matching amount of queued audio — audio that, on a join, has
usually not arrived yet. Now the join simply waits: its start is answered with
the instant the speaker can actually play at, and the server lines its audio up
with that.

- Hold a late join's start acknowledgement until the speaker's clock is
  verified, then answer with the instant it can really seat
- Skip the content cut entirely on that path, so the correction is never
  applied twice
- Keep the cut for a re-anchor whose acknowledgement already went out, and
  drain it as soon as it is ordered rather than in the last moments before the
  anchor
- Report how much was actually cut, and never discard an outstanding cut
  silently
- Correct a join onto the speaker's readiness exactly, without the extra
  quarter second of slack the other correction paths need

- Scale the pacing window to the stream rate: the two frame counts it used were
  calibrated for 44.1 kHz only, and that window also bounds how long the cut
  above has to drain (values unchanged at 44.1 kHz)
