### PR TITLE
Report when a receiver's clock becomes usable

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -274,13 +274,28 @@ tracks each receiver's **probe streak** — the uninterrupted run of
 Delay_Req/Pdelay_Req received from that IP, reset by a 3 s gap — and the
 daemon answers `Q <ip>` with the streak ages. Readiness = streak start
 + 2.3 s (the measured Sonos servo-lock window), with Apple models also
-granted the observed fast bound (third exchange + 250 ms). Enforcement:
+granted the observed fast bound (third exchange + 250 ms).
+
+**Probing starts at CONNECT, not at the anchor announce.** A receiver begins
+sending Delay_Req about a second after the session connects, on its own
+schedule, with no anchor ever announced and no START ever sent — measured on a
+Samsung Music Frame (HW-LS60D): SETPEERS at T+0.00, first Delay_Req at
+T+1.078, then 187 probes over 24 s of pure idle. A cold-join field log agrees
+independently (streak began 1.04 s after SETPEERS, before which the anchor
+announce at T+0.20 had already gone out and changed nothing). So the ~1.05 s is
+the device's own latency and a START does not accelerate it. That makes
+readiness measurable BEFORE the first start, which is what
+`[STATUS] clock_ready` reports (below) — a caller that waits for it never has to
+guess a join headroom. Readiness is a property of the device (~1.08 s to the
+first probe plus the 2.3 s lock window ≈ 3.4 s after connect), so any fixed
+headroom is either too short to catch a probe or needlessly slow. Enforcement,
+for callers that start before readiness anyway:
 
 - **At commit**, a live streak folds readiness into the feasibility floor,
   so an anchor before readiness is corrected forward through the normal
   started-ack contract (which group starts re-converge from as usual).
-- **After a cold commit** (no live streak yet — a rejoining receiver resumes
-  probing only ~0.7-1.5 s AFTER the START ack, so commit-time enforcement is
+- **After a cold commit** (no live streak yet — a start committed within about
+  a second of connecting has nothing to measure, so commit-time enforcement is
   impossible), the audio loop keeps verifying while the pacing gate still
   holds every frame. Once the streak appears, an anchor at or beyond
   readiness logs `[STATUS] clock_verified margin_ms=`. One short of it is
@@ -332,6 +347,40 @@ granted the observed fast bound (third exchange + 250 ms). Enforcement:
   verification goes terminal once it can no longer act before it), so the
   caller never waits on a timeout of its own. A commit, flush or park that
   disarms the verification mid-flight releases the ack the same way.
+
+**Readiness pushed from connect.** Because probing starts at connect, the
+binary reports what it measures instead of leaving the caller to guess:
+
+```
+[STATUS] clock_ready mode=<ptp|ntp> state=<cold|probing|ready> streak_ms=<u64> exchanges=<u32> ready_in_ms=<u64> ready_at_unix_ms=<u64>
+```
+
+- `mode` is the **effective** timing, not the route intent: a PTP session that
+  fell back to the NTP responder because 319/320 could not be bound reports
+  `ntp`, which tells the caller readiness is not measurable here and it must
+  not wait for it. Legacy RAOP reports `ntp` too.
+- `state=cold` — no probe recorded yet. `ready_in_ms`/`ready_at_unix_ms` are 0
+  and mean nothing; ignore them. A receiver past the engine's peer limit
+  (`PTP_MAX_PEERS`, 8) gets no unicast timing and stays cold forever, so a
+  caller waiting on readiness needs its own timeout for that case.
+- `state=probing` — a live streak; `ready_at_unix_ms` is the projected
+  readiness instant to plan the anchor against.
+- `state=ready` — the projection has passed.
+- `streak_ms`/`exchanges` are the streak's first-probe age and probe count,
+  the same two numbers the commit-time floor logs, so field reports compare
+  directly.
+
+The first line is emitted immediately after `[STATUS] connected`,
+unconditionally and whatever the state, so a caller can always distinguish
+"not ready yet" from "this binary will never tell me". After that only a
+material change is reported — the state, or the projected instant a caller
+would plan against; the exchange count rides along as telemetry but never
+triggers a line by itself — sampled at most every 250 ms, ending at the first
+`state=ready`. `FLUSH` and `START` re-arm it for the next cycle. The projection
+is recomputed per emission and never cached. In shared-daemon mode the snapshot
+comes from the poller thread, started at connect, because the daemon's `Q`
+round-trip blocks and the audio loop must never make it inline; the in-process
+engine is queried directly under its own lock.
 
 **Downstream render-latency is informational, not applied.** A receiver whose
 audible output sits behind an external pipeline reports that delay in its

--- a/README.md
+++ b/README.md
@@ -70,6 +70,30 @@ group. A `START_UNIX_MS` of 0 or one the transport cannot honor is corrected
 forward to the earliest feasible instant (250 ms minimum lead, 200 ms on RAOP)
 and the `[STATUS] started` ack always reports the true scheduled instant.
 
+**Late joins: wait for the receiver's clock instead of guessing a headroom.**
+A receiver that has just connected cannot seat an anchor yet — it begins
+probing our PTP clock about a second after connect, on its own schedule, and
+its servo needs roughly 2.3 s more. That is a property of the device, so any
+fixed join headroom is either too short or needlessly slow. The binary reports
+what it measures, from connect:
+
+```
+[STATUS] clock_ready mode=<ptp|ntp> state=<cold|probing|ready> streak_ms=<u64> exchanges=<u32> ready_in_ms=<u64> ready_at_unix_ms=<u64>
+```
+
+The first line arrives right after `[STATUS] connected`, whatever the state, so
+a caller never blocks on a line that will not come; further lines follow only
+when the state or the projected instant changes, ending at the first
+`state=ready`. Plan a join anchor at or after `ready_at_unix_ms` (valid only
+when `state` is `probing` or `ready`). `mode=ntp` means readiness is not
+measurable for this session — legacy RAOP, or a PTP session that fell back to
+the NTP responder — so do not wait for it. `state=cold` can also persist
+indefinitely for a receiver past the timing engine's 8-peer limit, so keep a
+timeout. `FLUSH` and `START` re-arm the reporting for the next cycle.
+
+Starting before readiness is still supported and still corrected — see
+`START_JOIN=1` below.
+
 Delivery is not gated on the start time: frames are released up to the
 receiver's buffer window ahead of each frame's deadline (the device-reported
 `latencyMax`, or 1.75 s when the receiver does not report one), so receiver

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -95,7 +95,6 @@ extern log_level *loglevel;
 #define AP2_CLOCK_LOCK_MS            2300
 #define AP2_CLOCK_SETTLE_MS          250
 #define AP2_CLOCK_SEAT_EXCHANGES     3
-#define AP2_CLOCK_VERIFY_POLL_MS     250
 /* Verification needs room to act before the initial fill starts releasing
  * real frames at anchor - pacing depth: anchors closer than the depth plus
  * one poll round plus slack can never be corrected, so they are not armed. */
@@ -277,6 +276,10 @@ struct ap2cl_s {
     pthread_t clock_verify_thread;
     bool clock_verify_thread_started;
     atomic_bool clock_verify_thread_stop;
+    atomic_bool clock_poll_wanted;  /* readiness reporting (ap2cl_clock_readiness)
+                                       also reads the snapshot, so in shared mode
+                                       the poller runs from connect and outlives
+                                       every verification that uses it */
     /* Retransmit history and the control-port reader that serves it. The ring
      * is written by the audio thread and read by the reader thread. */
     struct ap2_rtx_slot *rtx_ring;
@@ -346,6 +349,7 @@ static bool ap2_set_nonblocking(int fd, const char *name);
 static void ap2_raop_session_cleanup(struct ap2cl_s *p);
 static void ap2_clock_verify_disarm(struct ap2cl_s *p);
 static void ap2_clock_verify_reap_poller(struct ap2cl_s *p);
+static void ap2_clock_poller_ensure(struct ap2cl_s *p);
 
 static void ap2_remote_command_received(
     ap2_remote_command_t command, void *userdata)
@@ -1990,6 +1994,13 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     if (atomic_load(&p->rtsp_dead)) return false;
     p->rtsp_established = true;
     p->state = AP2_CONNECTED;
+    /* Readiness is measurable from here: a cold receiver starts probing our
+     * clock about a second after connect, on its own schedule and with no
+     * anchor announced (measured on a Samsung Music Frame, 187 probes over
+     * 24 s with no START ever sent). Keep the shared-daemon snapshot fresh
+     * from now on so ap2cl_clock_readiness can report it without blocking. */
+    atomic_store(&p->clock_poll_wanted, true);
+    ap2_clock_poller_ensure(p);
     if (!ap2_feedback_start(p)) {
         atomic_store(&p->rtsp_dead, true);
         return false;
@@ -2429,6 +2440,7 @@ struct ap2cl_s *ap2cl_create(
     pthread_mutex_init(&p->rtx_lock, NULL);
     pthread_mutex_init(&p->clock_verify_lock, NULL);
     atomic_init(&p->clock_verify_thread_stop, true);
+    atomic_init(&p->clock_poll_wanted, false);
     atomic_init(&p->rtx_stop, true);
     atomic_init(&p->rtx_requested, 0);
     atomic_init(&p->rtx_answered, 0);
@@ -2678,10 +2690,11 @@ static bool ap2_clock_query(struct ap2cl_s *p, struct ap2_ptp_exchange *ex)
 }
 
 /* Raise a commit's feasibility floor to the receiver's clock readiness. With
- * no live streak the clock is cold: the floor is left alone (the receiver
- * only begins probing after the anchor line is announced, so there is
- * nothing to measure yet) and *clock_cold tells the commit to arm the
- * post-commit verification instead. */
+ * no live streak the clock is cold: the floor is left alone (a receiver that
+ * has just connected takes about a second to start probing, so an early
+ * commit has nothing to measure yet) and *clock_cold tells the commit to arm
+ * the post-commit verification instead. Callers that can wait should instead
+ * follow ap2cl_clock_readiness from connect and commit once it reports ready. */
 static uint64_t ap2_clock_floor(struct ap2cl_s *p, uint64_t floor_ntp,
                                 bool *clock_cold)
 {
@@ -2703,7 +2716,8 @@ static uint64_t ap2_clock_floor(struct ap2cl_s *p, uint64_t floor_ntp,
 }
 
 /* Stop the verification without an event (new commit, flush, teardown). The
- * poller is signalled here and joined by the next arm or the destroy. */
+ * poller is signalled here and joined by the next arm or the destroy, unless
+ * readiness reporting still wants its snapshot. */
 static void ap2_clock_verify_disarm(struct ap2cl_s *p)
 {
     pthread_mutex_lock(&p->clock_verify_lock);
@@ -2713,7 +2727,8 @@ static void ap2_clock_verify_disarm(struct ap2cl_s *p)
      * the instant that stands. */
     p->start_ack_deferred = false;
     pthread_mutex_unlock(&p->clock_verify_lock);
-    atomic_store(&p->clock_verify_thread_stop, true);
+    if (!atomic_load(&p->clock_poll_wanted))
+        atomic_store(&p->clock_verify_thread_stop, true);
 }
 
 static void ap2_clock_verify_reap_poller(struct ap2cl_s *p)
@@ -2737,7 +2752,7 @@ static void *ap2_clock_verify_poller(void *arg)
         p->clock_verify_have_exchange = have;
         if (have) p->clock_verify_exchange = ex;
         pthread_mutex_unlock(&p->clock_verify_lock);
-        if (!armed) break;
+        if (!armed && !atomic_load(&p->clock_poll_wanted)) break;
         for (int i = 0; i < AP2_CLOCK_VERIFY_POLL_MS / 50 &&
                         !atomic_load(&p->clock_verify_thread_stop); i++)
             usleep(50000);
@@ -2745,9 +2760,29 @@ static void *ap2_clock_verify_poller(void *arg)
     return NULL;
 }
 
+/* Run the snapshot poller in shared-daemon mode, where the streak query is a
+ * blocking UDP round-trip no caller on the audio loop may make. Idempotent, and
+ * serialized by the send lock: connect starts it before the command thread
+ * exists, and every later call comes from a commit, which the session engine
+ * brackets with that lock. */
+static void ap2_clock_poller_ensure(struct ap2cl_s *p)
+{
+    if (!ap2_ptp_shared_active(p->ptp)) return;
+    if (p->clock_verify_thread_started &&
+        !atomic_load(&p->clock_verify_thread_stop))
+        return;
+    ap2_clock_verify_reap_poller(p);
+    atomic_store(&p->clock_verify_thread_stop, false);
+    if (pthread_create(&p->clock_verify_thread, NULL,
+                       ap2_clock_verify_poller, p) == 0)
+        p->clock_verify_thread_started = true;
+    else
+        atomic_store(&p->clock_verify_thread_stop, true);
+}
+
 /* Arm the post-commit verification for a cold-clock commit: the receiver's
- * probe streak is expected to begin only after the anchor announce, and the
- * committed instant must then be checked against the observed readiness.
+ * probe streak had not begun when the instant was committed, so the committed
+ * instant must be checked against readiness once it does.
  * Only a join-marked start (landing on an already-live group timeline) is
  * ENFORCED with a forward correction; an origin start is observed and
  * reported only — its receivers self-seat a fresh session cleanly, and
@@ -2772,15 +2807,7 @@ static void ap2_clock_verify_arm(struct ap2cl_s *p, uint64_t requested_unix_ms,
     LOG_INFO("[AP2] clock verification armed (%s): cold receiver clock, "
              "anchor in %" PRIu64 " ms", enforce ? "join, enforcing" : "observe",
              at_unix_ms - now_ms);
-    if (ap2_ptp_shared_active(p->ptp)) {
-        ap2_clock_verify_reap_poller(p);
-        atomic_store(&p->clock_verify_thread_stop, false);
-        if (pthread_create(&p->clock_verify_thread, NULL,
-                           ap2_clock_verify_poller, p) == 0)
-            p->clock_verify_thread_started = true;
-        else
-            atomic_store(&p->clock_verify_thread_stop, true);
-    }
+    ap2_clock_poller_ensure(p);
 }
 
 /* Resolve a commanded start: a request at or beyond `floor_ntp` is honored
@@ -3479,9 +3506,47 @@ ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
         p->start_ack_deferred = false;
     }
     pthread_mutex_unlock(&p->clock_verify_lock);
-    if (result != AP2_CLOCK_VERIFY_IDLE)
+    if (result != AP2_CLOCK_VERIFY_IDLE &&
+        !atomic_load(&p->clock_poll_wanted))
         atomic_store(&p->clock_verify_thread_stop, true);
     return result;
+}
+
+bool ap2cl_uses_ptp(struct ap2cl_s *p)
+{
+    return p && p->flow == FLOW_NATIVE_AP2 && p->use_ptp;
+}
+
+void ap2cl_clock_readiness(struct ap2cl_s *p, ap2_clock_readiness_t *out)
+{
+    if (!out) return;
+    memset(out, 0, sizeof(*out));
+    /* Without the PTP engine there is no probe streak to measure: NTP-timed
+     * sessions (and the RAOP-compat flow) report cold and stay there. */
+    if (!ap2cl_uses_ptp(p)) return;
+
+    struct ap2_ptp_exchange ex;
+    bool have = false;
+    pthread_mutex_lock(&p->clock_verify_lock);
+    if (p->clock_verify_have_exchange) {
+        have = true;
+        ex = p->clock_verify_exchange;
+    }
+    pthread_mutex_unlock(&p->clock_verify_lock);
+    /* The in-process engine answers from its own lock, so the audio loop may
+     * ask it directly; shared-daemon mode must take the poller's snapshot,
+     * whose staleness only ever pushes readiness later — the safe direction. */
+    if (!have && !ap2_ptp_shared_active(p->ptp))
+        have = ap2_clock_query(p, &ex);
+    if (!have) return;
+
+    uint64_t now_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
+    uint64_t ready_ms = ap2_clock_ready_from(p, &ex, now_ms);
+    out->streak_ms = ex.first_ms;
+    out->exchanges = ex.count;
+    out->ready_at_unix_ms = ready_ms;
+    out->ready_in_ms = ready_ms > now_ms ? ready_ms - now_ms : 0;
+    out->state = ready_ms > now_ms ? AP2_CLOCK_PROBING : AP2_CLOCK_READY;
 }
 
 bool ap2cl_clock_verify_armed(struct ap2cl_s *p)

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -262,6 +262,41 @@ typedef struct {
 ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
                                                   ap2_clock_verify_event_t *ev);
 
+/* One sample of the receiver's probe streak: the rate at which the client
+ * refreshes it, and at which a caller reporting readiness should sample. */
+#define AP2_CLOCK_VERIFY_POLL_MS     250
+
+/* How far the receiver's clock has come since the session connected. */
+typedef enum {
+    AP2_CLOCK_COLD = 0,   /* no timing probe recorded yet */
+    AP2_CLOCK_PROBING,    /* probing; readiness is projected, not reached */
+    AP2_CLOCK_READY,      /* the projected readiness instant has passed */
+} ap2_clock_state_t;
+
+typedef struct {
+    ap2_clock_state_t state;
+    uint64_t streak_ms;        /* age of the streak's first probe */
+    uint32_t exchanges;        /* probes in the current uninterrupted streak */
+    uint64_t ready_in_ms;      /* 0 once ready; meaningless while cold */
+    uint64_t ready_at_unix_ms; /* projected readiness instant; 0 while cold */
+} ap2_clock_readiness_t;
+
+/* True when the session's EFFECTIVE timing is PTP. False for NTP-timed
+ * sessions — including a PTP session that fell back because 319/320 could not
+ * be bound — where clock readiness is not measurable. */
+bool ap2cl_uses_ptp(struct ap2cl_s *p);
+
+/*
+ * Sample the receiver's clock readiness, so a caller can pick a join anchor it
+ * can actually meet instead of guessing a headroom. A receiver begins probing
+ * our clock about a second after it connects, on its own schedule and without
+ * an anchor having been announced; readiness follows from the probe streak
+ * (see ap2_clock_ready_from). Safe to call from the audio loop: it never
+ * blocks on the network. Recompute per use — ready_at_unix_ms is a projection
+ * against the wall clock and must not be cached.
+ */
+void ap2cl_clock_readiness(struct ap2cl_s *p, ap2_clock_readiness_t *out);
+
 /* True while a cold-clock verification can still produce a result. It goes
  * false on the resolving poll and on every disarm (commit, flush, park,
  * teardown), which is how a caller holding a withheld ack knows the

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -206,6 +206,56 @@ static void status_error(const char *msg)
     status_print("[ERROR] %s", msg);
 }
 
+/* Receiver-clock readiness, pushed from connect so the caller never has to
+ * guess a join headroom: a receiver begins probing our clock about a second
+ * after it connects, on its own schedule and with no anchor announced, and is
+ * seated roughly AP2_CLOCK_LOCK_MS after that — a property of the device, not
+ * of any fixed lead. The first line goes out unconditionally right after
+ * [STATUS] connected, whatever the state, so a caller can always tell the
+ * difference between "not ready yet" and "this binary will never tell me".
+ * After that only a MATERIAL change is reported — the state, or the projected
+ * instant the caller would plan against; the exchange count rides along as
+ * telemetry but never triggers a line on its own — rate-limited to one sample
+ * per AP2_CLOCK_VERIFY_POLL_MS, ending at the first state=ready. FLUSH and
+ * START re-arm it for the next cycle. */
+static bool g_clock_ready_reported = false;   /* emitted at least once this cycle */
+static bool g_clock_ready_done = false;       /* terminal state=ready reported */
+static uint64_t g_clock_ready_next_ntp = 0;
+static ap2_clock_state_t g_clock_ready_state = AP2_CLOCK_COLD;
+static uint64_t g_clock_ready_at_ms = 0;
+
+static void clock_ready_rearm(void)
+{
+    g_clock_ready_reported = false;
+    g_clock_ready_done = false;
+    g_clock_ready_next_ntp = 0;
+}
+
+static void clock_ready_tick(void)
+{
+    if (g_clock_ready_done) return;
+    uint64_t now = raopcl_get_ntp(NULL);
+    if (g_clock_ready_reported && now < g_clock_ready_next_ntp) return;
+    g_clock_ready_next_ntp = now + MS2NTP(AP2_CLOCK_VERIFY_POLL_MS);
+
+    ap2_clock_readiness_t r;
+    ap2cl_clock_readiness(g_ap2cl, &r);
+    if (g_clock_ready_reported && r.state == g_clock_ready_state &&
+        r.ready_at_unix_ms == g_clock_ready_at_ms)
+        return;
+    g_clock_ready_reported = true;
+    g_clock_ready_state = r.state;
+    g_clock_ready_at_ms = r.ready_at_unix_ms;
+    g_clock_ready_done = r.state == AP2_CLOCK_READY;
+    status_print("[STATUS] clock_ready mode=%s state=%s streak_ms=%" PRIu64
+                 " exchanges=%u ready_in_ms=%" PRIu64
+                 " ready_at_unix_ms=%" PRIu64,
+                 ap2cl_uses_ptp(g_ap2cl) ? "ptp" : "ntp",
+                 r.state == AP2_CLOCK_READY ? "ready"
+                     : r.state == AP2_CLOCK_PROBING ? "probing" : "cold",
+                 r.streak_ms, r.exchanges, r.ready_in_ms, r.ready_at_unix_ms);
+}
+
 /* The join's [STATUS] started, withheld at commit so the receiver-clock
  * verification can answer it with the instant the receiver can actually seat
  * (see ap2cl_start_ack_deferred). Exactly one ack leaves per START: the commit
@@ -640,6 +690,9 @@ static ap2_commit_result_t session_commit(void *transport,
      * described. */
     start_ack_flush();
     g_start_ack_withheld = false;
+    /* Report readiness afresh for the next cycle: this start consumed the
+     * reading the caller planned it against. */
+    clock_ready_rearm();
     /* The first START begins the session; a START after a FLUSH re-anchors the
      * flushed stream (no second receiver flush, no crypto/sequence reset). An
      * infeasible instant is corrected forward by the transport, which reports
@@ -691,6 +744,8 @@ static bool session_flush_op(void *transport)
     /* A failed RTSP round-trip can leave the receiver partially flushed.
      * Keep sends paused while the caller falls back to a cold restart. */
     if (g_status == STATUS_PLAYING) g_status = STATUS_PAUSED;
+    /* The next track's start plans against a fresh readiness reading. */
+    clock_ready_rearm();
     return flushed;
 }
 
@@ -950,6 +1005,11 @@ static int run_raop(cli_config_t *cfg)
         return 1;
     status_connected_legacy(inet_ntoa(player_addr), cfg->port,
                             (int)TS2MS(latency, raopcl_sample_rate(g_raopcl)));
+    /* Legacy RAOP has no PTP clock to measure, but the line still goes out so
+     * a caller that gates a join on it is answered rather than left waiting. */
+    pthread_mutex_lock(&g_audio_send_lock);
+    clock_ready_tick();
+    pthread_mutex_unlock(&g_audio_send_lock);
 
     /* Commanded PCM format:
      * For 16-bit: s16le (2 bytes per sample, 4 bytes per frame stereo)
@@ -1230,6 +1290,13 @@ static int run_airplay2(cli_config_t *cfg)
             cfg, ap2_input_bpf, AP2_FRAMES_PER_CHUNK))
         return 1;
     status_connected();
+    /* The caller gates its join on this line, so it goes out with the ack that
+     * the session is up — before any START, whatever the clock state. Under
+     * the send lock like every other reader of the latch: the command thread
+     * is live from here and re-arms it on FLUSH and START. */
+    pthread_mutex_lock(&g_audio_send_lock);
+    clock_ready_tick();
+    pthread_mutex_unlock(&g_audio_send_lock);
 
     uint64_t last = 0, frames = 0;
     uint64_t current_epoch = ap2_session_epoch(g_session);
@@ -1277,6 +1344,7 @@ static int run_airplay2(cli_config_t *cfg)
         pthread_mutex_lock(&g_audio_send_lock);
         clock_verify_tick();
         if (!ap2cl_clock_verify_armed(g_ap2cl)) start_ack_flush();
+        clock_ready_tick();
         pthread_mutex_unlock(&g_audio_send_lock);
 
         /* Periodic status reporting (only while playing, so a pause does not keep

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -1213,11 +1213,14 @@ static void test_clock_readiness_report(void)
     uint64_t before = test_now_unix_ms();
     ap2cl_test_inject_clock_exchange(client, 2, 100, 0);
     ap2cl_clock_readiness(client, &r);
+    uint64_t after = test_now_unix_ms();
     assert(r.state == AP2_CLOCK_PROBING);
     assert(r.streak_ms == 100 && r.exchanges == 2);
     assert(r.ready_in_ms > 2100 && r.ready_in_ms <= 2200);
+    /* The projection reads the clock once inside the call, so bracketing it by
+     * the call's own span pins it exactly however long the call takes. */
     assert(r.ready_at_unix_ms >= before + 2200);
-    assert(r.ready_at_unix_ms < before + 2300);
+    assert(r.ready_at_unix_ms <= after + 2200);
 
     /* A streak whose projection has passed reports ready, with no wait left. */
     ap2cl_test_inject_clock_exchange(client, 12, 3000, 0);

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -1166,6 +1166,88 @@ static void test_clock_verified_anchor(void)
     puts("ap2_client clock verified anchor tests passed");
 }
 
+/* Readiness reported from connect, so a caller can plan a join anchor the
+ * receiver can actually meet instead of guessing a headroom. */
+static void test_clock_readiness_report(void)
+{
+    ap2_device_info_t device = {
+        .name = "readiness test",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "model=Era 100",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_set_splice(client, true);
+    ap2_clock_readiness_t r;
+
+    /* NTP timing — including a PTP session that fell back on a 319/320 bind
+     * failure: readiness is not measurable, and the caller is told so rather
+     * than left waiting for a reading that will never come. */
+    ap2cl_test_set_use_ptp(client, false);
+    assert(!ap2cl_uses_ptp(client));
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_COLD);
+    assert(r.streak_ms == 0 && r.exchanges == 0);
+    assert(r.ready_in_ms == 0 && r.ready_at_unix_ms == 0);
+
+    /* PTP with no probe recorded: a receiver that just connected, or one the
+     * engine has no peer slot left to serve. Cold, with nothing to plan
+     * against — the caller times out instead of waiting forever. */
+    ap2cl_test_set_use_ptp(client, true);
+    assert(ap2cl_uses_ptp(client));
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_COLD);
+    assert(r.streak_ms == 0 && r.exchanges == 0);
+    assert(r.ready_in_ms == 0 && r.ready_at_unix_ms == 0);
+
+    /* A live streak projects readiness one lock window from its start, and
+     * carries the same two numbers the commit-time floor logs. */
+    uint64_t before = test_now_unix_ms();
+    ap2cl_test_inject_clock_exchange(client, 2, 100, 0);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_PROBING);
+    assert(r.streak_ms == 100 && r.exchanges == 2);
+    assert(r.ready_in_ms > 2100 && r.ready_in_ms <= 2200);
+    assert(r.ready_at_unix_ms >= before + 2200);
+    assert(r.ready_at_unix_ms < before + 2300);
+
+    /* A streak whose projection has passed reports ready, with no wait left. */
+    ap2cl_test_inject_clock_exchange(client, 12, 3000, 0);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_READY);
+    assert(r.ready_in_ms == 0);
+    assert(r.ready_at_unix_ms != 0);
+    assert(r.streak_ms == 3000 && r.exchanges == 12);
+
+    /* The Apple fast bound moves readiness in: the streak still probing on a
+     * generic receiver is already ready on an Apple one. */
+    ap2cl_test_inject_clock_exchange(client, 3, 400, 300);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_PROBING);
+    ap2cl_test_set_apple_model(client, true);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_READY);
+    ap2cl_test_set_apple_model(client, false);
+
+    /* The projection is recomputed per call, never cached. */
+    uint64_t first_at = r.ready_at_unix_ms;
+    usleep(30000);
+    ap2cl_test_inject_clock_exchange(client, 4, 400, 300);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.ready_at_unix_ms > first_at);
+
+    ap2cl_destroy(client);
+    puts("ap2_client clock readiness report tests passed");
+}
+
 int main(void)
 {
     test_retransmit_responder();
@@ -1182,6 +1264,7 @@ int main(void)
     test_apple_model_resolution();
     test_pacing_window_rate_scaling();
     test_clock_verified_anchor();
+    test_clock_readiness_report();
 
     ap2_device_info_t device = {
         .name = "test",


### PR DESCRIPTION
Follow-up to #38.

A speaker starts talking to our clock about a second after the session is set
up — not when we announce where playback should begin, which is what the code
assumed. Measured on a Samsung Music Frame: the first timing probe arrived
1.078 s after the session was established, and it kept probing steadily for 24
seconds with no start instant ever announced. The field log from the original
sync report agrees, so announcing a start does not hurry it along.

That means we can simply tell the caller when the speaker's clock will be
usable, and it can place a join there, instead of guessing a headroom and
correcting afterwards.

- Report `[STATUS] clock_ready` from the moment the connection is up, with the
  projected instant the receiver's clock becomes usable
- Report the timing mode actually in use, so a fallback to the NTP responder is
  visible to the caller rather than silently looking like a stalled clock
- Keep the shared clock snapshot fresh from connect, so the answer is ready
  without a blocking query from the audio path
- Correct the source and design notes that claimed probing only begins after a
  start is announced
