### PR TITLE
Notice when an AirPlay speaker drops the stream

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -700,6 +700,18 @@ capture.
   sessions without it), independent of command-pipe metadata, artwork loading,
   and progress updates. The worker services encrypted reverse events after
   each feedback POST. RAOP paths use libraop's keepalive (~20 s).
+- **Receiver stream list** — each `/feedback` response carries the receiver's
+  own list of the streams it still holds for us,
+  `{"streams": [{"type": 96, "sr": 44100}]}`, logged at DEBUG every tick. An
+  empty list while the client is streaming means the receiver dropped the
+  stream under us and every packet is going nowhere; three consecutive empty
+  ticks (~6 s, past the transitions around SETUP/RECORD and a warm splice)
+  report it once per episode as `[STATUS] stream_dropped streams=0 ticks=<n>
+  interval_ms=<ms>`, and a stream coming back closes the episode. A receiver
+  that omits the key reports no stream status at all and is never faulted.
+  The list is what the receiver HOLDS, not what it renders: a Sonos Era 100
+  confirmed playing and a silent-class Samsung HW-LS60D answer with the same
+  single-entry body, so this detects a dropped stream, not a silent speaker.
 - **RTSP serialization** — one mutex serializes the RTSP channel, so the
   keepalive thread and the streaming path can never interleave frames on the
   encrypted channel.

--- a/README.md
+++ b/README.md
@@ -257,6 +257,13 @@ stdin, the single persistent audio input for the whole process lifetime.
 `[STATUS] eof` means the stdin input ended — the whole feed is done, not just
 one track.
 
+`[STATUS] stream_dropped streams=0 ticks=<n> interval_ms=<ms>` means the
+receiver has answered `<n>` consecutive keepalives reporting that it holds no
+stream for us while the session is streaming: it dropped the stream and the
+audio still being sent goes nowhere. It is reported once per episode (a
+returning stream closes it), and never for receivers that report no stream
+status at all.
+
 Some receivers (notably Sonos) do not emit audio until they have received
 metadata; the binary pushes an initial metadata set at the first commanded
 start, so audio starts regardless of whether the caller ever sends `SENDMETA`.

--- a/src/ap2_bplist.cpp
+++ b/src/ap2_bplist.cpp
@@ -407,4 +407,26 @@ int ap2_bplist_find_dict_uint_array_mask(const uint8_t *data, size_t len,
     return 1;
 }
 
+int ap2_bplist_find_array_count(const uint8_t *data, size_t len,
+                                const char *key, size_t *out)
+{
+    bp_raw_view view;
+    uint64_t array_ref;
+    if (!key || !out || !bp_view_init(data, len, &view) ||
+        !bp_find_value_ref(&view, key, &array_ref))
+        return 0;
+
+    size_t pos = bp_view_obj_ofs(&view, array_ref);
+    if (!pos || pos >= view.table_ofs ||
+        (view.data[pos] & 0xF0) != 0xA0)
+        return 0;
+
+    size_t count;
+    if (!bp_read_count(view.data, view.table_ofs, &pos, &count) ||
+        count > (view.table_ofs - pos) / view.ref_size)
+        return 0;
+    *out = count;
+    return 1;
+}
+
 } /* extern "C" */

--- a/src/ap2_bplist.h
+++ b/src/ap2_bplist.h
@@ -78,6 +78,15 @@ int ap2_bplist_find_dict_uint_array_mask(const uint8_t *data, size_t len,
                                          const char *dict_key, const char *key,
                                          uint64_t *out);
 
+/*
+ * Count the entries of an array value found by key anywhere in a raw binary
+ * plist, e.g. the /feedback body's "streams". An empty array reports 0 and
+ * still returns 1, so "the receiver listed no streams" stays distinguishable
+ * from "the receiver never reported the key".
+ */
+int ap2_bplist_find_array_count(const uint8_t *data, size_t len,
+                                const char *key, size_t *out);
+
 /* Find a string value by key in the root dictionary only. */
 int ap2_bplist_get_root_string(const uint8_t *data, size_t len, const char *key,
                                char *out, size_t out_size);

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -75,6 +75,12 @@ extern log_level *loglevel;
  * are tolerated up to this count (the final one kills), so a genuinely dead
  * channel is still detected within roughly misses x (interval + timeout). */
 #define AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES 3
+/* Consecutive feedback ticks the receiver may report an empty stream list
+ * while we believe we are streaming before it counts as a fault. The list is
+ * legitimately empty for a moment around SETUP/RECORD and while a receiver
+ * re-seats a warm splice, so only a sustained streak means the stream really
+ * is gone. */
+#define AP2_FEEDBACK_IDLE_STREAM_TICKS 3
 #define AP2_EVENT_POLL_INTERVAL_MS   100
 #define AP2_RTSP_RX_BUF_SIZE         16384
 #define AP2_UDP_SEND_TIMEOUT_MS      20
@@ -195,6 +201,9 @@ struct ap2cl_s {
     pthread_t feedback_thread;
     atomic_bool feedback_stop;
     bool feedback_thread_started;
+    /* Consecutive /feedback bodies that listed no active stream while the
+     * client believed it was streaming. Only the feedback worker touches it. */
+    unsigned feedback_idle_streams;
     struct ap2_hap_ctx *hap;      /* HAP encryption context */
     struct ap2_ptp_ctx *ptp;      /* Timing */
     /* MRP now-playing over POST /command (path A, see DESIGN.md §8):
@@ -3664,17 +3673,65 @@ void ap2cl_stop(struct ap2cl_s *p)
     p->state = AP2_DOWN;
 }
 
+/*
+ * Read the receiver's own view of the session out of a /feedback response:
+ * {"streams": [...]} lists the streams it still holds for us. An empty list
+ * while we believe we are streaming means the receiver dropped the stream
+ * under us and every packet we send is going nowhere — the POST answers 200
+ * either way, so nothing else on this channel reports it. Receivers that omit
+ * the key report no stream status at all, which is never a fault: only a
+ * present-but-empty list counts.
+ *
+ * The list is what the receiver HOLDS, not what it renders: measured
+ * 2026-08-02, a Sonos Era 100 confirmed playing (its own UPnP transport
+ * reported PLAYING) and a Samsung HW-LS60D both answered every tick with the
+ * identical body {"streams": [{"type": 96, "sr": 44100}]}. So a live entry
+ * does not prove audio is audible, and this is not a silence detector.
+ */
+static void ap2_feedback_note_streams(struct ap2cl_s *p, const uint8_t *resp,
+                                      int resp_len)
+{
+    size_t streams = 0;
+    if (!resp || resp_len <= 0 ||
+        !ap2_bplist_find_array_count(resp, (size_t)resp_len, "streams",
+                                     &streams)) {
+        p->feedback_idle_streams = 0;
+        return;
+    }
+
+    LOG_DEBUG("[AP2] /feedback streams=%zu", streams);
+    if (streams > 0 || p->state != AP2_STREAMING) {
+        if (p->feedback_idle_streams >= AP2_FEEDBACK_IDLE_STREAM_TICKS)
+            LOG_INFO("[AP2] receiver holds a stream again (streams=%zu)",
+                     streams);
+        p->feedback_idle_streams = 0;
+        return;
+    }
+    /* Report the fault once per episode; the recovery above closes it. */
+    if (++p->feedback_idle_streams != AP2_FEEDBACK_IDLE_STREAM_TICKS) return;
+    LOG_WARN("[AP2] Receiver holds no stream after %u feedback ticks while "
+             "streaming: it dropped the stream we are still sending to",
+             p->feedback_idle_streams);
+    /* Machine-readable counterpart on the same stderr channel as the binary's
+     * other [STATUS] lines, so Music Assistant can act on a dropped stream
+     * without scraping the human-readable log. */
+    fprintf(stderr, "[STATUS] stream_dropped streams=0 ticks=%u interval_ms=%d\n",
+            p->feedback_idle_streams, AP2_FEEDBACK_INTERVAL_MS);
+    fflush(stderr);
+}
+
 bool ap2cl_feedback(struct ap2cl_s *p)
 {
     /* Native flow only: the RAOP-compat flow rides libraop, whose keepalive
-     * is raopcl_keepalive(). The response body carries stream status we do
-     * not need; the POST itself is what resets the receiver's idle timer. */
+     * is raopcl_keepalive(). The POST itself is what resets the receiver's
+     * idle timer; its body carries the receiver's active-stream list. */
     if (!p || p->flow != FLOW_NATIVE_AP2 || p->sock_fd < 0) return false;
     uint8_t *resp = NULL; int resp_len = 0;
     bool request_started = false;
     int status = ap2_rtsp_send_tracked(
         p, "POST", "/feedback", NULL, 0, NULL,
         &resp, &resp_len, &request_started);
+    ap2_feedback_note_streams(p, resp, resp_len);
     free(resp);
     ap2_feedback_result_t result =
         ap2_io_feedback_result(status, request_started);
@@ -4387,6 +4444,11 @@ void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p)
 bool ap2cl_test_first_packet(struct ap2cl_s *p)
 {
     return p->first_packet;
+}
+
+unsigned ap2cl_test_feedback_idle_streams(struct ap2cl_s *p)
+{
+    return p->feedback_idle_streams;
 }
 
 void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet)

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3701,7 +3701,11 @@ static void ap2_feedback_note_streams(struct ap2cl_s *p, const uint8_t *resp,
 
     LOG_DEBUG("[AP2] /feedback streams=%zu", streams);
     if (streams > 0 || p->state != AP2_STREAMING) {
-        if (p->feedback_idle_streams >= AP2_FEEDBACK_IDLE_STREAM_TICKS)
+        /* Only a stream coming back closes a reported episode; leaving the
+         * streaming state just drops the streak, since an idle receiver
+         * holding nothing is the expected shape there. */
+        if (streams > 0 &&
+            p->feedback_idle_streams >= AP2_FEEDBACK_IDLE_STREAM_TICKS)
             LOG_INFO("[AP2] receiver holds a stream again (streams=%zu)",
                      streams);
         p->feedback_idle_streams = 0;

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -30,6 +30,7 @@ void ap2cl_test_unlock_mrp(struct ap2cl_s *p);
 void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd);
 void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p);
 bool ap2cl_test_first_packet(struct ap2cl_s *p);
+unsigned ap2cl_test_feedback_idle_streams(struct ap2cl_s *p);
 void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet);
 void ap2cl_test_set_splice(struct ap2cl_s *p, bool enable);
 bool ap2cl_test_splice_default(const char *txt, const char *am);
@@ -374,6 +375,207 @@ static void test_info_format_tables(void)
                    "supportedAudioFormatsExtended", "audioStream", &mask) == 0);
     }
     puts("ap2_bplist /info format-table tests passed");
+}
+
+/* Real /feedback response bodies, byte-for-byte as a receiver sends them:
+ * { "streams": [] } — the receiver considers no stream active, the signature
+ * of one that ACKs everything and renders nothing. */
+static const uint8_t FEEDBACK_IDLE[] = {
+    'b','p','l','i','s','t','0','0',
+    0xD1, 0x01, 0x02,                       /* root dict */
+    0x57, 's','t','r','e','a','m','s',      /* 7-char key */
+    0xA0,                                   /* empty array */
+    0x08, 0x0B, 0x13,                       /* offset table */
+    0, 0, 0, 0, 0, 0, 1, 1,                 /* trailer: ofs/ref sizes */
+    0, 0, 0, 0, 0, 0, 0, 3,                 /* num objects */
+    0, 0, 0, 0, 0, 0, 0, 0,                 /* top object */
+    0, 0, 0, 0, 0, 0, 0, 0x14,              /* offset-table offset */
+};
+
+/* { "streams": [ { "type": 96 } ] } — one stream is live. */
+static const uint8_t FEEDBACK_ACTIVE[] = {
+    'b','p','l','i','s','t','0','0',
+    0xD1, 0x01, 0x02,
+    0x57, 's','t','r','e','a','m','s',
+    0xA1, 0x03,                             /* array of one */
+    0xD1, 0x04, 0x05,                       /* stream dict */
+    0x54, 't','y','p','e',
+    0x10, 0x60,                             /* int 96 (realtime) */
+    0x08, 0x0B, 0x13, 0x15, 0x18, 0x1D,
+    0, 0, 0, 0, 0, 0, 1, 1,
+    0, 0, 0, 0, 0, 0, 0, 6,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0x1F,
+};
+
+static void test_feedback_stream_counts(void)
+{
+    size_t streams = 99;
+    assert(ap2_bplist_find_array_count(
+               FEEDBACK_IDLE, sizeof(FEEDBACK_IDLE), "streams", &streams) == 1);
+    assert(streams == 0);
+    assert(ap2_bplist_find_array_count(
+               FEEDBACK_ACTIVE, sizeof(FEEDBACK_ACTIVE), "streams",
+               &streams) == 1);
+    assert(streams == 1);
+
+    /* An absent key is "the receiver reports no stream status", which must
+     * stay distinct from an empty list; so must a non-array value. */
+    assert(ap2_bplist_find_array_count(
+               FEEDBACK_IDLE, sizeof(FEEDBACK_IDLE), "stream", &streams) == 0);
+    assert(ap2_bplist_find_array_count(
+               INFO_LEGACY, sizeof(INFO_LEGACY), "streams", &streams) == 0);
+    assert(ap2_bplist_find_array_count(
+               INFO_LEGACY, sizeof(INFO_LEGACY), "bufferStream", &streams) == 0);
+
+    /* Truncated input must fail cleanly at every length, never crash. */
+    for (size_t len = 0; len < sizeof(FEEDBACK_ACTIVE); len++) {
+        assert(ap2_bplist_find_array_count(
+                   FEEDBACK_ACTIVE, len, "streams", &streams) == 0);
+    }
+    puts("ap2_bplist /feedback stream-count tests passed");
+}
+
+typedef struct {
+    int fd;
+    int beats;                  /* keepalives to answer */
+    const uint8_t *body;        /* NULL for a receiver that reports nothing */
+    size_t body_len;
+    bool ok;
+} feedback_body_peer_t;
+
+static void *run_feedback_body_peer(void *arg)
+{
+    feedback_body_peer_t *peer = arg;
+    peer->ok = false;
+    for (int beat = 0; beat < peer->beats; beat++) {
+        int cseq = 0;
+        if (!read_rtsp_request_cseq(peer->fd, "POST /feedback ", &cseq))
+            return NULL;
+        char header[192];
+        int header_len = snprintf(
+            header, sizeof(header),
+            "RTSP/1.0 200 OK\r\nCSeq: %d\r\n"
+            "Content-Type: application/x-apple-binary-plist\r\n"
+            "Content-Length: %zu\r\n\r\n", cseq, peer->body_len);
+        if (write(peer->fd, header, (size_t)header_len) != header_len)
+            return NULL;
+        if (peer->body_len &&
+            write(peer->fd, peer->body, peer->body_len) !=
+                (ssize_t)peer->body_len)
+            return NULL;
+    }
+    peer->ok = true;
+    return NULL;
+}
+
+/* Answer `beats` keepalives with `body` and return what the session captured
+ * on stderr while they ran (the test log level is silent, so only [STATUS]
+ * lines land there). */
+static void run_feedback_beats(struct ap2cl_s *client, int peer_fd, int beats,
+                               const uint8_t *body, size_t body_len,
+                               char *status_out, size_t status_size)
+{
+    feedback_body_peer_t peer = {
+        .fd = peer_fd,
+        .beats = beats,
+        .body = body,
+        .body_len = body_len,
+    };
+    pthread_t peer_thread;
+    assert(pthread_create(&peer_thread, NULL,
+                          run_feedback_body_peer, &peer) == 0);
+
+    FILE *captured = tmpfile();
+    assert(captured);
+    int saved_stderr = dup(STDERR_FILENO);
+    assert(saved_stderr >= 0);
+    fflush(stderr);
+    assert(dup2(fileno(captured), STDERR_FILENO) >= 0);
+
+    for (int beat = 0; beat < beats; beat++) assert(ap2cl_feedback(client));
+
+    fflush(stderr);
+    assert(dup2(saved_stderr, STDERR_FILENO) >= 0);
+    assert(close(saved_stderr) == 0);
+
+    rewind(captured);
+    size_t read_len = fread(status_out, 1, status_size - 1, captured);
+    status_out[read_len] = '\0';
+    assert(fclose(captured) == 0);
+
+    assert(pthread_join(peer_thread, NULL) == 0);
+    assert(peer.ok);
+}
+
+/* A receiver that keeps answering 200 while reporting an empty stream list has
+ * dropped the stream we keep sending to. That is only a fault once it persists:
+ * the list is briefly empty around setup and warm splices, so the report
+ * lands on the tick that completes the streak, and exactly once per episode.
+ */
+static void test_feedback_idle_streams_reported(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+
+    ap2_device_info_t device = {
+        .name = "feedback streams test",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+    ap2cl_test_set_splice(client, true);
+    assert(ap2cl_start(client, 0, NULL) == AP2_COMMIT_OK);
+    assert(ap2cl_state(client) == AP2_STREAMING);
+
+    char status[1024];
+    /* A receiver that reports nothing at all (no body, no key) is never
+     * faulted — most non-Apple receivers answer this way. */
+    run_feedback_beats(client, sockets[1], 4, NULL, 0, status, sizeof(status));
+    assert(ap2cl_test_feedback_idle_streams(client) == 0);
+    assert(!strstr(status, "stream_dropped"));
+
+    /* A live stream keeps the streak at zero however long it runs. */
+    run_feedback_beats(client, sockets[1], 4, FEEDBACK_ACTIVE,
+                       sizeof(FEEDBACK_ACTIVE), status, sizeof(status));
+    assert(ap2cl_test_feedback_idle_streams(client) == 0);
+    assert(!strstr(status, "stream_dropped"));
+
+    /* Two empty ticks are still inside the tolerated transition window. */
+    run_feedback_beats(client, sockets[1], 2, FEEDBACK_IDLE,
+                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
+    assert(ap2cl_test_feedback_idle_streams(client) == 2);
+    assert(!strstr(status, "stream_dropped"));
+
+    /* The third completes the streak and reports; the fourth stays quiet. */
+    run_feedback_beats(client, sockets[1], 2, FEEDBACK_IDLE,
+                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
+    assert(ap2cl_test_feedback_idle_streams(client) == 4);
+    const char *report = strstr(status, "[STATUS] stream_dropped streams=0 "
+                                        "ticks=3 interval_ms=2000\n");
+    assert(report);
+    assert(!strstr(report + 1, "[STATUS] stream_dropped"));
+
+    /* The receiver rendering again closes the episode. */
+    run_feedback_beats(client, sockets[1], 1, FEEDBACK_ACTIVE,
+                       sizeof(FEEDBACK_ACTIVE), status, sizeof(status));
+    assert(ap2cl_test_feedback_idle_streams(client) == 0);
+
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+    puts("ap2_client feedback idle-stream report tests passed");
 }
 
 /* A password-protected receiver keeps its native AirPlay 2 route: the password
@@ -1257,6 +1459,7 @@ int main(void)
     test_route_with_password();
     test_route_explicit_airplay2();
     test_info_format_tables();
+    test_feedback_stream_counts();
     test_native_flush_resume_reuses_rtsp_session();
     test_native_flush_rejects_receiver_error();
     test_splice_default_resolution();
@@ -1264,6 +1467,7 @@ int main(void)
     test_splice_delivery_gap_recovery();
     test_splice_pause_keeps_line_hot();
     test_feedback_miss_tolerated_then_recovered();
+    test_feedback_idle_streams_reported();
     test_apple_model_resolution();
     test_pacing_window_rate_scaling();
     test_clock_verified_anchor();

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -493,11 +493,16 @@ static void run_feedback_beats(struct ap2cl_s *client, int peer_fd, int beats,
     fflush(stderr);
     assert(dup2(fileno(captured), STDERR_FILENO) >= 0);
 
-    for (int beat = 0; beat < beats; beat++) assert(ap2cl_feedback(client));
+    /* Collect rather than assert: stderr belongs to the capture until it is
+     * restored, so an assertion failing here would swallow its own message. */
+    bool beats_ok = true;
+    for (int beat = 0; beat < beats; beat++)
+        if (!ap2cl_feedback(client)) beats_ok = false;
 
     fflush(stderr);
     assert(dup2(saved_stderr, STDERR_FILENO) >= 0);
     assert(close(saved_stderr) == 0);
+    assert(beats_ok);
 
     rewind(captured);
     size_t read_len = fread(status_out, 1, status_size - 1, captured);
@@ -566,10 +571,31 @@ static void test_feedback_idle_streams_reported(void)
     assert(report);
     assert(!strstr(report + 1, "[STATUS] stream_dropped"));
 
-    /* The receiver rendering again closes the episode. */
+    /* A stream coming back closes the episode and says so. */
+    test_log_level = lINFO;
     run_feedback_beats(client, sockets[1], 1, FEEDBACK_ACTIVE,
                        sizeof(FEEDBACK_ACTIVE), status, sizeof(status));
     assert(ap2cl_test_feedback_idle_streams(client) == 0);
+    assert(strstr(status, "holds a stream again (streams=1)"));
+
+    /* The next episode re-arms on the same threshold. */
+    run_feedback_beats(client, sockets[1], 3, FEEDBACK_IDLE,
+                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
+    assert(ap2cl_test_feedback_idle_streams(client) == 3);
+    assert(strstr(status, "[STATUS] stream_dropped streams=0 ticks=3 "
+                          "interval_ms=2000\n"));
+
+    /* Leaving the streaming state is not a recovery: a receiver holding
+     * nothing is the expected shape there, so the streak drops silently
+     * rather than claiming a stream came back. */
+    ap2cl_stop(client);
+    assert(ap2cl_state(client) != AP2_STREAMING);
+    run_feedback_beats(client, sockets[1], 1, FEEDBACK_IDLE,
+                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
+    assert(ap2cl_test_feedback_idle_streams(client) == 0);
+    assert(!strstr(status, "holds a stream again"));
+    assert(!strstr(status, "stream_dropped"));
+    test_log_level = lSILENCE;
 
     ap2cl_test_detach_rtsp_socket(client);
     assert(close(sockets[0]) == 0);


### PR DESCRIPTION
When an AirPlay speaker drops the stream mid-playback, nothing tells us: it keeps answering our keepalives with "OK" while the audio we send goes nowhere, so playback looks healthy while the speaker has gone quiet.

Every keepalive response already carries the speaker's own list of the streams it still holds for us — we were throwing it away. We now read it.

- Read the stream list from each keepalive response and log it
- Report `[STATUS] stream_dropped` when a speaker reports no stream for ~6 seconds while we are playing, so Music Assistant can react
- Report it once per episode, never for speakers that report no stream status at all

The list says what the speaker holds, not what it plays: a speaker silent for other reasons still reports a live stream (measured on a Sonos Era 100 and a Samsung soundbar), so this catches a dropped stream, not a silent speaker.
