### PR TITLE
Report a receiver that never answers our clock

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -352,7 +352,7 @@ for callers that start before readiness anyway:
 binary reports what it measures instead of leaving the caller to guess:
 
 ```
-[STATUS] clock_ready mode=<ptp|ntp> state=<cold|probing|ready> streak_ms=<u64> exchanges=<u32> ready_in_ms=<u64> ready_at_unix_ms=<u64>
+[STATUS] clock_ready mode=<ptp|ntp> state=<cold|probing|ready|stalled> streak_ms=<u64> exchanges=<u32> ready_in_ms=<u64> ready_at_unix_ms=<u64>
 ```
 
 - `mode` is the **effective** timing, not the route intent: a PTP session that
@@ -366,6 +366,23 @@ binary reports what it measures instead of leaving the caller to guess:
 - `state=probing` — a live streak; `ready_at_unix_ms` is the projected
   readiness instant to plan the anchor against.
 - `state=ready` — the projection has passed.
+- `state=stalled` — 5 s with nothing to measure (`AP2_CLOCK_STALL_MS`, over four
+  times the 1.078 s first-probe latency measured above, so a merely slow
+  receiver cannot trip it), counted from the last streak actually seen and only
+  from connect while none ever has been. The receiver is not slaved to our
+  clock: it can seat no render position and renders **silence** however cleanly
+  the audio paces and however healthy the session looks — measured on a HomePod
+  pair that established, paced and answered every keepalive with a 200 without
+  one Delay_Req ever arriving. Measuring from the last streak rather than from
+  connect alone is what keeps a single lost `Q` round-trip — which empties the
+  snapshot exactly as a departed receiver does — from reading as a stall on a
+  healthy session, and gives a mid-session clock loss the same 5 s grace as a
+  cold start. That mark is stamped by the snapshot poller, on the same round it
+  refreshes the snapshot, precisely because the reporting below stops at the
+  first `state=ready`: for most of a session nothing else is watching, and a
+  mark left to age with the reporting would make the first reading after a
+  re-arm read stale. Only a PTP session can stall; `mode=ntp` stays cold.
+  `ready_in_ms`/`ready_at_unix_ms` are 0 and mean nothing, as while cold.
 - `streak_ms`/`exchanges` are the streak's first-probe age and probe count,
   the same two numbers the commit-time floor logs, so field reports compare
   directly.
@@ -376,7 +393,9 @@ unconditionally and whatever the state, so a caller can always distinguish
 material change is reported — the state, or the projected instant a caller
 would plan against; the exchange count rides along as telemetry but never
 triggers a line by itself — sampled at most every 250 ms, ending at the first
-`state=ready`. `FLUSH` and `START` re-arm it for the next cycle. The projection
+`state=ready`. `state=stalled` does NOT end it (a receiver that begins probing
+late still reports `probing` and then `ready`) but does log the diagnosis once,
+on the way in. `FLUSH` and `START` re-arm it for the next cycle. The projection
 is recomputed per emission and never cached. In shared-daemon mode the snapshot
 comes from the poller thread, started at connect, because the daemon's `Q`
 round-trip blocks and the audio loop must never make it inline; the in-process

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fixed join headroom is either too short or needlessly slow. The binary reports
 what it measures, from connect:
 
 ```
-[STATUS] clock_ready mode=<ptp|ntp> state=<cold|probing|ready> streak_ms=<u64> exchanges=<u32> ready_in_ms=<u64> ready_at_unix_ms=<u64>
+[STATUS] clock_ready mode=<ptp|ntp> state=<cold|probing|ready|stalled> streak_ms=<u64> exchanges=<u32> ready_in_ms=<u64> ready_at_unix_ms=<u64>
 ```
 
 The first line arrives right after `[STATUS] connected`, whatever the state, so
@@ -90,6 +90,15 @@ measurable for this session — legacy RAOP, or a PTP session that fell back to
 the NTP responder — so do not wait for it. `state=cold` can also persist
 indefinitely for a receiver past the timing engine's 8-peer limit, so keep a
 timeout. `FLUSH` and `START` re-arm the reporting for the next cycle.
+
+`state=stalled` means our clock has gone unanswered for 5 s — since the last
+probe if there ever was one, since connect if there was not. That is over four
+times the slowest first probe measured, so it is not a slow device and not a
+blip. The receiver is not slaved to us, so it can seat no render position and
+plays **silence** however healthy the session looks. Treat it as a failure to
+report rather than something to wait out; the usual cause is UDP 319/320 not
+reaching this host from the speaker. It is not final, though: a receiver that
+starts probing late, or picks up again, reports `probing` and then `ready`.
 
 Starting before readiness is still supported and still corrected — see
 `START_JOIN=1` below.

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -101,6 +101,15 @@ extern log_level *loglevel;
 #define AP2_CLOCK_LOCK_MS            2300
 #define AP2_CLOCK_SETTLE_MS          250
 #define AP2_CLOCK_SEAT_EXCHANGES     3
+/* Nothing to measure for this long, counted from the last streak seen or from
+ * connect while none ever has been, means the receiver is not answering our
+ * clock at all — over four times the 1.078 s first-probe latency measured on a
+ * Samsung Music Frame, and well past the full AP2_CLOCK_LOCK_MS servo window
+ * on top of it, so a merely slow receiver cannot trip it. That margin is the
+ * whole point: this is a diagnosis threshold, not a deadline anything plans
+ * against, so it answers "is this receiver definitively not answering" and is
+ * deliberately slower than any caller's own wait for a readiness projection. */
+#define AP2_CLOCK_STALL_MS           5000
 /* Verification needs room to act before the initial fill starts releasing
  * real frames at anchor - pacing depth: anchors closer than the depth plus
  * one poll round plus slack can never be corrected, so they are not armed. */
@@ -280,6 +289,13 @@ struct ap2cl_s {
     uint64_t clock_verify_next_poll_ntp;
     bool clock_verify_have_exchange;
     struct ap2_ptp_exchange clock_verify_exchange;
+    uint64_t clock_connected_unix_ms; /* session connect instant, which the
+                                         receiver's probe window is measured
+                                         from (0 until the session is up) */
+    uint64_t clock_last_streak_unix_ms; /* last instant a streak was actually
+                                           observed, kept current by the
+                                           poller; takes over from the connect
+                                           instant once it is set */
     /* Shared-daemon mode queries the streak over UDP (blocking); this poller
      * keeps the snapshot fresh so the audio loop never blocks on it. */
     pthread_t clock_verify_thread;
@@ -359,6 +375,7 @@ static void ap2_raop_session_cleanup(struct ap2cl_s *p);
 static void ap2_clock_verify_disarm(struct ap2cl_s *p);
 static void ap2_clock_verify_reap_poller(struct ap2cl_s *p);
 static void ap2_clock_poller_ensure(struct ap2cl_s *p);
+static uint64_t ap2_ntp_to_unix_ms(uint64_t ntp);
 
 static void ap2_remote_command_received(
     ap2_remote_command_t command, void *userdata)
@@ -2007,8 +2024,12 @@ static bool ap2_native_connect(struct ap2cl_s *p)
      * clock about a second after connect, on its own schedule and with no
      * anchor announced (measured on a Samsung Music Frame, 187 probes over
      * 24 s with no START ever sent). Keep the shared-daemon snapshot fresh
-     * from now on so ap2cl_clock_readiness can report it without blocking. */
+     * from now on so ap2cl_clock_readiness can report it without blocking,
+     * and stamp the instant its stall window runs from. */
     atomic_store(&p->clock_poll_wanted, true);
+    pthread_mutex_lock(&p->clock_verify_lock);
+    p->clock_connected_unix_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
+    pthread_mutex_unlock(&p->clock_verify_lock);
     ap2_clock_poller_ensure(p);
     if (!ap2_feedback_start(p)) {
         atomic_store(&p->rtsp_dead, true);
@@ -2756,10 +2777,18 @@ static void *ap2_clock_verify_poller(void *arg)
     while (!atomic_load(&p->clock_verify_thread_stop)) {
         struct ap2_ptp_exchange ex;
         bool have = ap2_clock_query(p, &ex);
+        uint64_t now_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
         pthread_mutex_lock(&p->clock_verify_lock);
         bool armed = p->clock_verify_armed;
         p->clock_verify_have_exchange = have;
-        if (have) p->clock_verify_exchange = ex;
+        if (have) {
+            p->clock_verify_exchange = ex;
+            /* The stall window is measured from here because this loop is the
+             * only thing that follows the receiver for a whole session:
+             * readiness reporting goes terminal at the first ready and stops
+             * asking until a flush or start re-arms it. */
+            p->clock_last_streak_unix_ms = now_ms;
+        }
         pthread_mutex_unlock(&p->clock_verify_lock);
         if (!armed && !atomic_load(&p->clock_poll_wanted)) break;
         for (int i = 0; i < AP2_CLOCK_VERIFY_POLL_MS / 50 &&
@@ -3541,15 +3570,39 @@ void ap2cl_clock_readiness(struct ap2cl_s *p, ap2_clock_readiness_t *out)
         have = true;
         ex = p->clock_verify_exchange;
     }
+    /* The stall window runs from the last streak actually seen, and only from
+     * connect while none ever has been: a snapshot goes empty on a single lost
+     * Q round-trip as readily as on a receiver that stopped answering, so
+     * measuring from connect alone would call a healthy session stalled on one
+     * dropped datagram. The poller refreshes the mark every round, so a blip
+     * can never reach the window while a real loss gets the same grace as a
+     * cold start. */
+    uint64_t stall_from_ms =
+        p->clock_last_streak_unix_ms > p->clock_connected_unix_ms
+            ? p->clock_last_streak_unix_ms : p->clock_connected_unix_ms;
     pthread_mutex_unlock(&p->clock_verify_lock);
     /* The in-process engine answers from its own lock, so the audio loop may
      * ask it directly; shared-daemon mode must take the poller's snapshot,
      * whose staleness only ever pushes readiness later — the safe direction. */
     if (!have && !ap2_ptp_shared_active(p->ptp))
         have = ap2_clock_query(p, &ex);
-    if (!have) return;
 
     uint64_t now_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
+    if (!have) {
+        /* Nothing to measure this long after the receiver was last heard from
+         * means it is not slaved to our clock: it can seat no render position
+         * and renders silence however cleanly the audio paces. Reported as its
+         * own state because a cold receiver looks the same on the way there. */
+        if (stall_from_ms && now_ms >= stall_from_ms + AP2_CLOCK_STALL_MS)
+            out->state = AP2_CLOCK_STALLED;
+        return;
+    }
+    /* Carry the mark for the in-process engine, which runs no poller to keep
+     * it current; in shared-daemon mode the poller has it already. */
+    pthread_mutex_lock(&p->clock_verify_lock);
+    p->clock_last_streak_unix_ms = now_ms;
+    pthread_mutex_unlock(&p->clock_verify_lock);
+
     uint64_t ready_ms = ap2_clock_ready_from(p, &ex, now_ms);
     out->streak_ms = ex.first_ms;
     out->exchanges = ex.count;
@@ -4572,6 +4625,27 @@ void ap2cl_test_inject_clock_exchange(struct ap2cl_s *p, uint32_t count,
     p->clock_verify_exchange.first_ms = first_ms;
     p->clock_verify_exchange.last_ms = 0;
     p->clock_verify_exchange.third_ms = third_ms;
+    pthread_mutex_unlock(&p->clock_verify_lock);
+}
+
+/* Retract the planted snapshot the way a poll that came back empty does, so a
+ * test can play a lost round-trip against a receiver that is still probing. */
+void ap2cl_test_clear_clock_exchange(struct ap2cl_s *p)
+{
+    pthread_mutex_lock(&p->clock_verify_lock);
+    p->clock_verify_have_exchange = false;
+    pthread_mutex_unlock(&p->clock_verify_lock);
+}
+
+/* Stamp the two instants the stall window is measured from — the connect a
+ * real session records in ap2_native_connect, and the last streak readiness
+ * itself observes — so a test can place that window wherever it needs it. */
+void ap2cl_test_set_clock_marks(struct ap2cl_s *p, uint64_t connected_ms,
+                                uint64_t last_streak_ms)
+{
+    pthread_mutex_lock(&p->clock_verify_lock);
+    p->clock_connected_unix_ms = connected_ms;
+    p->clock_last_streak_unix_ms = last_streak_ms;
     pthread_mutex_unlock(&p->clock_verify_lock);
 }
 

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3565,6 +3565,11 @@ void ap2cl_clock_readiness(struct ap2cl_s *p, ap2_clock_readiness_t *out)
     /* Without the PTP engine there is no probe streak to measure: NTP-timed
      * sessions (and the RAOP-compat flow) report cold and stay there. */
     if (!ap2cl_uses_ptp(p)) return;
+    /* Nothing measures a session that is down. Both the marks and the last
+     * snapshot outlive teardown, so a reading taken afterwards would otherwise
+     * answer for a receiver that is no longer connected — as a stall while the
+     * snapshot is empty, and as a live projection while it is not. */
+    if (p->state == AP2_DOWN) return;
 
     struct ap2_ptp_exchange ex;
     bool have = false;
@@ -3595,19 +3600,19 @@ void ap2cl_clock_readiness(struct ap2cl_s *p, ap2_clock_readiness_t *out)
         /* Nothing to measure this long after the receiver was last heard from
          * means it is not slaved to our clock: it can seat no render position
          * and renders silence however cleanly the audio paces. Reported as its
-         * own state because a cold receiver looks the same on the way there.
-         * Only a live session can be judged silent: the marks outlive teardown,
-         * so a reading taken once the session is down measures nothing. */
-        if (p->state != AP2_DOWN && stall_from_ms &&
-            now_ms >= stall_from_ms + AP2_CLOCK_STALL_MS)
+         * own state because a cold receiver looks the same on the way there. */
+        if (stall_from_ms && now_ms >= stall_from_ms + AP2_CLOCK_STALL_MS)
             out->state = AP2_CLOCK_STALLED;
         return;
     }
-    /* Carry the mark for the in-process engine, which runs no poller to keep
-     * it current; in shared-daemon mode the poller has it already. */
-    pthread_mutex_lock(&p->clock_verify_lock);
-    p->clock_last_streak_unix_ms = now_ms;
-    pthread_mutex_unlock(&p->clock_verify_lock);
+    /* Carry the mark for the in-process engine, which runs no poller to keep it
+     * current. Shared-daemon mode leaves it to the poller, so the mark has one
+     * owner per mode and can never be advanced off a snapshot already stale. */
+    if (!ap2_ptp_shared_active(p->ptp)) {
+        pthread_mutex_lock(&p->clock_verify_lock);
+        p->clock_last_streak_unix_ms = now_ms;
+        pthread_mutex_unlock(&p->clock_verify_lock);
+    }
 
     uint64_t ready_ms = ap2_clock_ready_from(p, &ex, now_ms);
     out->streak_ms = ex.first_ms;

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2025,10 +2025,13 @@ static bool ap2_native_connect(struct ap2cl_s *p)
      * anchor announced (measured on a Samsung Music Frame, 187 probes over
      * 24 s with no START ever sent). Keep the shared-daemon snapshot fresh
      * from now on so ap2cl_clock_readiness can report it without blocking,
-     * and stamp the instant its stall window runs from. */
+     * and stamp the instant its stall window runs from. The streak mark starts
+     * clear: one left by an earlier session on this client describes a receiver
+     * that is no longer the one being measured. */
     atomic_store(&p->clock_poll_wanted, true);
     pthread_mutex_lock(&p->clock_verify_lock);
     p->clock_connected_unix_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
+    p->clock_last_streak_unix_ms = 0;
     pthread_mutex_unlock(&p->clock_verify_lock);
     ap2_clock_poller_ensure(p);
     if (!ap2_feedback_start(p)) {
@@ -3592,8 +3595,11 @@ void ap2cl_clock_readiness(struct ap2cl_s *p, ap2_clock_readiness_t *out)
         /* Nothing to measure this long after the receiver was last heard from
          * means it is not slaved to our clock: it can seat no render position
          * and renders silence however cleanly the audio paces. Reported as its
-         * own state because a cold receiver looks the same on the way there. */
-        if (stall_from_ms && now_ms >= stall_from_ms + AP2_CLOCK_STALL_MS)
+         * own state because a cold receiver looks the same on the way there.
+         * Only a live session can be judged silent: the marks outlive teardown,
+         * so a reading taken once the session is down measures nothing. */
+        if (p->state != AP2_DOWN && stall_from_ms &&
+            now_ms >= stall_from_ms + AP2_CLOCK_STALL_MS)
             out->state = AP2_CLOCK_STALLED;
         return;
     }
@@ -4647,6 +4653,14 @@ void ap2cl_test_set_clock_marks(struct ap2cl_s *p, uint64_t connected_ms,
     p->clock_connected_unix_ms = connected_ms;
     p->clock_last_streak_unix_ms = last_streak_ms;
     pthread_mutex_unlock(&p->clock_verify_lock);
+}
+
+/* Place the session state a real connect and teardown move through, so a test
+ * can take a readiness reading against a live session and against a torn-down
+ * one — the marks outlive teardown, the verdict must not. */
+void ap2cl_test_set_session_state(struct ap2cl_s *p, ap2_state_t state)
+{
+    p->state = state;
 }
 
 void ap2cl_test_bump_audio_sent(struct ap2cl_s *p)

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -271,6 +271,7 @@ typedef enum {
     AP2_CLOCK_COLD = 0,   /* no timing probe recorded yet */
     AP2_CLOCK_PROBING,    /* probing; readiness is projected, not reached */
     AP2_CLOCK_READY,      /* the projected readiness instant has passed */
+    AP2_CLOCK_STALLED,    /* still no probe long past when one was due */
 } ap2_clock_state_t;
 
 typedef struct {
@@ -291,7 +292,16 @@ bool ap2cl_uses_ptp(struct ap2cl_s *p);
  * can actually meet instead of guessing a headroom. A receiver begins probing
  * our clock about a second after it connects, on its own schedule and without
  * an anchor having been announced; readiness follows from the probe streak
- * (see ap2_clock_ready_from). Safe to call from the audio loop: it never
+ * (see ap2_clock_ready_from). A PTP session with nothing to measure for
+ * AP2_CLOCK_STALL_MS — counted from the last streak this call saw, or from
+ * connect while it has seen none — reports AP2_CLOCK_STALLED: that receiver is
+ * not slaved to our clock, so it can seat no render position and stays silent
+ * however cleanly the audio paces. That window is measured from a mark the
+ * snapshot poller keeps current for the whole session, so the verdict holds
+ * however rarely a caller samples — a caller that stops asking once it has
+ * what it needs cannot make a later reading read stale.
+ * Stalled is not terminal — a receiver that begins probing late reports
+ * probing and then ready as usual. Safe to call from the audio loop: it never
  * blocks on the network. Recompute per use — ready_at_unix_ms is a projection
  * against the wall clock and must not be cached.
  */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -217,7 +217,8 @@ static void status_error(const char *msg)
  * instant the caller would plan against; the exchange count rides along as
  * telemetry but never triggers a line on its own — rate-limited to one sample
  * per AP2_CLOCK_VERIFY_POLL_MS, ending at the first state=ready. FLUSH and
- * START re-arm it for the next cycle. */
+ * START re-arm it for the next cycle. state=stalled does NOT end it: a
+ * receiver that begins probing late still reports probing and then ready. */
 static bool g_clock_ready_reported = false;   /* emitted at least once this cycle */
 static bool g_clock_ready_done = false;       /* terminal state=ready reported */
 static uint64_t g_clock_ready_next_ntp = 0;
@@ -229,6 +230,16 @@ static void clock_ready_rearm(void)
     g_clock_ready_reported = false;
     g_clock_ready_done = false;
     g_clock_ready_next_ntp = 0;
+}
+
+static const char *clock_state_name(ap2_clock_state_t state)
+{
+    switch (state) {
+    case AP2_CLOCK_PROBING: return "probing";
+    case AP2_CLOCK_READY:   return "ready";
+    case AP2_CLOCK_STALLED: return "stalled";
+    default:                return "cold";
+    }
 }
 
 static void clock_ready_tick(void)
@@ -243,6 +254,10 @@ static void clock_ready_tick(void)
     if (g_clock_ready_reported && r.state == g_clock_ready_state &&
         r.ready_at_unix_ms == g_clock_ready_at_ms)
         return;
+    /* Read before the latch moves, so the diagnosis below is logged on the
+     * transition into the stall and not on every sample that stays in it. */
+    bool stalling = r.state == AP2_CLOCK_STALLED &&
+                    g_clock_ready_state != AP2_CLOCK_STALLED;
     g_clock_ready_reported = true;
     g_clock_ready_state = r.state;
     g_clock_ready_at_ms = r.ready_at_unix_ms;
@@ -251,9 +266,13 @@ static void clock_ready_tick(void)
                  " exchanges=%u ready_in_ms=%" PRIu64
                  " ready_at_unix_ms=%" PRIu64,
                  ap2cl_uses_ptp(g_ap2cl) ? "ptp" : "ntp",
-                 r.state == AP2_CLOCK_READY ? "ready"
-                     : r.state == AP2_CLOCK_PROBING ? "probing" : "cold",
+                 clock_state_name(r.state),
                  r.streak_ms, r.exchanges, r.ready_in_ms, r.ready_at_unix_ms);
+    if (stalling)
+        LOG_WARN("[AP2] the receiver has not answered our PTP clock: it is "
+                 "not slaved to us, can seat no render position and will play "
+                 "silence however cleanly the audio paces — check that the "
+                 "speaker can reach UDP 319/320 on this host");
 }
 
 /* The join's [STATUS] started, withheld at commit so the receiver-clock

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -52,6 +52,7 @@ bool ap2cl_test_apple_model_default(const char *txt, const char *am);
 void ap2cl_test_inject_clock_exchange(struct ap2cl_s *p, uint32_t count,
                                       uint64_t first_ms, uint64_t third_ms);
 void ap2cl_test_clear_clock_exchange(struct ap2cl_s *p);
+void ap2cl_test_set_session_state(struct ap2cl_s *p, ap2_state_t state);
 void ap2cl_test_set_clock_marks(struct ap2cl_s *p, uint64_t connected_ms,
                                 uint64_t last_streak_ms);
 void ap2cl_test_bump_audio_sent(struct ap2cl_s *p);
@@ -1504,6 +1505,7 @@ static void test_clock_stall_detection(void)
     ap2cl_force_native(client);
     ap2cl_test_set_splice(client, true);
     ap2cl_test_set_use_ptp(client, true);
+    ap2cl_test_set_session_state(client, AP2_CONNECTED);
     ap2_clock_readiness_t r;
 
     /* No session yet: nothing has started the window the stall is measured
@@ -1575,6 +1577,12 @@ static void test_clock_stall_detection(void)
                                test_now_unix_ms() - 6000);
     ap2cl_clock_readiness(client, &r);
     assert(r.state == AP2_CLOCK_STALLED);
+
+    /* Once the session is down there is no receiver to be silent: the marks
+     * survive teardown, so a reading taken afterwards must not read as one. */
+    ap2cl_test_set_session_state(client, AP2_DOWN);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_COLD);
 
     ap2cl_destroy(client);
     puts("ap2_client clock stall detection tests passed");

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -1418,6 +1418,7 @@ static void test_clock_readiness_report(void)
     assert(client);
     ap2cl_force_native(client);
     ap2cl_test_set_splice(client, true);
+    ap2cl_test_set_session_state(client, AP2_CONNECTED);
     ap2_clock_readiness_t r;
 
     /* NTP timing — including a PTP session that fell back on a 319/320 bind
@@ -1578,11 +1579,18 @@ static void test_clock_stall_detection(void)
     ap2cl_clock_readiness(client, &r);
     assert(r.state == AP2_CLOCK_STALLED);
 
-    /* Once the session is down there is no receiver to be silent: the marks
-     * survive teardown, so a reading taken afterwards must not read as one. */
+    /* Once the session is down there is no receiver to answer for: the marks
+     * survive teardown, so a reading taken afterwards must not read as a stall. */
     ap2cl_test_set_session_state(client, AP2_DOWN);
     ap2cl_clock_readiness(client, &r);
     assert(r.state == AP2_CLOCK_COLD);
+
+    /* The snapshot survives teardown too, so the same has to hold with a streak
+     * still planted — a torn-down session must not answer with a live one. */
+    ap2cl_test_inject_clock_exchange(client, 40, 8000, 0);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_COLD);
+    assert(r.exchanges == 0 && r.ready_at_unix_ms == 0);
 
     ap2cl_destroy(client);
     puts("ap2_client clock stall detection tests passed");

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -51,6 +51,9 @@ void ap2cl_test_set_apple_model(struct ap2cl_s *p, bool apple);
 bool ap2cl_test_apple_model_default(const char *txt, const char *am);
 void ap2cl_test_inject_clock_exchange(struct ap2cl_s *p, uint32_t count,
                                       uint64_t first_ms, uint64_t third_ms);
+void ap2cl_test_clear_clock_exchange(struct ap2cl_s *p);
+void ap2cl_test_set_clock_marks(struct ap2cl_s *p, uint64_t connected_ms,
+                                uint64_t last_streak_ms);
 void ap2cl_test_bump_audio_sent(struct ap2cl_s *p);
 void ap2cl_test_set_dev_latency_max(struct ap2cl_s *p, uint32_t frames);
 uint64_t ap2cl_test_pacing_window_frames(struct ap2cl_s *p);
@@ -1479,6 +1482,104 @@ static void test_clock_readiness_report(void)
     puts("ap2_client clock readiness report tests passed");
 }
 
+/* A receiver that never probes is reported as such: a permanently dead
+ * receiver clock is otherwise indistinguishable from the cold state every
+ * healthy receiver passes through on its way to probing. */
+static void test_clock_stall_detection(void)
+{
+    ap2_device_info_t device = {
+        .name = "stall test",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "model=Era 100",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_set_splice(client, true);
+    ap2cl_test_set_use_ptp(client, true);
+    ap2_clock_readiness_t r;
+
+    /* No session yet: nothing has started the window the stall is measured
+     * against, so there is nothing to be late for. */
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_COLD);
+
+    /* Inside the window: the receiver measured slowest took 1.078 s to its
+     * first probe, so a second in this is still the normal cold state. */
+    ap2cl_test_set_clock_marks(client, test_now_unix_ms() - 1000, 0);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_COLD);
+    assert(r.streak_ms == 0 && r.exchanges == 0);
+    assert(r.ready_in_ms == 0 && r.ready_at_unix_ms == 0);
+
+    /* Past it with still no probe: the receiver never slaved to our clock. */
+    ap2cl_test_set_clock_marks(client, test_now_unix_ms() - 6000, 0);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_STALLED);
+    assert(r.streak_ms == 0 && r.exchanges == 0);
+    assert(r.ready_in_ms == 0 && r.ready_at_unix_ms == 0);
+
+    /* An NTP-timed session has no streak to be missing, however long it has
+     * been up, so it stays cold rather than raising a false alarm. */
+    ap2cl_test_set_use_ptp(client, false);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_COLD);
+    ap2cl_test_set_use_ptp(client, true);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_STALLED);
+
+    /* Stalled is not terminal: a receiver that starts probing late is picked
+     * up on the next sample and runs on to ready as usual. */
+    ap2cl_test_inject_clock_exchange(client, 2, 100, 0);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_PROBING);
+    assert(r.streak_ms == 100 && r.exchanges == 2);
+    assert(r.ready_in_ms > 2100 && r.ready_in_ms <= 2200);
+    ap2cl_test_inject_clock_exchange(client, 20, 3000, 0);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_READY);
+    assert(r.ready_in_ms == 0);
+
+    /* One empty snapshot is a lost round-trip, not a receiver that went away:
+     * the window runs from the streak seen a poll ago, so a session a minute
+     * past connect still reports nothing to measure rather than a stall. */
+    ap2cl_test_set_clock_marks(client, test_now_unix_ms() - 60000, 0);
+    ap2cl_test_inject_clock_exchange(client, 40, 8000, 0);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_READY);
+    ap2cl_test_clear_clock_exchange(client);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_COLD);
+
+    /* The mark is the poller's to keep, not the caller's: reporting goes
+     * terminal at the first ready, so a session can run for ten minutes with
+     * nothing sampling readiness at all. The reading that a flush re-arms then
+     * lands on a mark the poller refreshed a round ago, and a lost round-trip
+     * on that very cycle is still only a blip. */
+    ap2cl_test_set_clock_marks(client, test_now_unix_ms() - 600000,
+                               test_now_unix_ms() - 200);
+    ap2cl_test_clear_clock_exchange(client);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_COLD);
+
+    /* Only an absence lasting the whole window is the real thing, and it is
+     * measured from that last streak, not from the far older connect. */
+    ap2cl_test_set_clock_marks(client, test_now_unix_ms() - 600000,
+                               test_now_unix_ms() - 6000);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_STALLED);
+
+    ap2cl_destroy(client);
+    puts("ap2_client clock stall detection tests passed");
+}
+
 int main(void)
 {
     test_retransmit_responder();
@@ -1498,6 +1599,7 @@ int main(void)
     test_pacing_window_rate_scaling();
     test_clock_verified_anchor();
     test_clock_readiness_report();
+    test_clock_stall_detection();
 
     ap2_device_info_t device = {
         .name = "test",


### PR DESCRIPTION
A receiver that never starts probing our clock cannot work out when to play. It stays silent while the sender paces audio perfectly and every status line looks healthy, so nothing in a log explains it: readiness was reported as `cold` once at connect and then went quiet, which is exactly what a healthy receiver looks like on its way to `ready`.

- Add a `stalled` readiness state, reported when a receiver has not answered for 5 seconds
- Measure that window from the last probe streak actually seen, so one lost snapshot round cannot raise a false alarm, and a receiver that goes quiet mid-session is caught the same way
- Keep `stalled` non-terminal, so a receiver that starts late still goes on to report `probing` and `ready`
- Warn once on entry, and carry the new state in `[STATUS] clock_ready`