### PR TITLE
Fix a false alarm when pausing an Apple speaker

### DIFF
--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3700,7 +3700,12 @@ static void ap2_feedback_note_streams(struct ap2cl_s *p, const uint8_t *resp,
     }
 
     LOG_DEBUG("[AP2] /feedback streams=%zu", streams);
-    if (streams > 0 || p->state != AP2_STREAMING) {
+    /* Only while audio should actually be rendering: the splice timeline keeps
+     * a paused or parked session AP2_STREAMING and feeds the wire silence, and
+     * a receiver is free to hold nothing through that. */
+    bool rendering = p->state == AP2_STREAMING && !p->content_paused &&
+                     !p->content_stopped;
+    if (streams > 0 || !rendering) {
         /* Only a stream coming back closes a reported episode; leaving the
          * streaming state just drops the streak, since an idle receiver
          * holding nothing is the expected shape there. */

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -578,6 +578,16 @@ static void test_feedback_idle_streams_reported(void)
     assert(ap2cl_test_feedback_idle_streams(client) == 0);
     assert(strstr(status, "holds a stream again (streams=1)"));
 
+    /* A paused splice session stays AP2_STREAMING and feeds the wire silence;
+     * a receiver holding nothing through that is not a dropped stream. */
+    ap2cl_pause(client);
+    assert(ap2cl_state(client) == AP2_STREAMING);
+    run_feedback_beats(client, sockets[1], 3, FEEDBACK_IDLE,
+                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
+    assert(ap2cl_test_feedback_idle_streams(client) == 0);
+    assert(!strstr(status, "stream_dropped"));
+    ap2cl_play(client);
+
     /* The next episode re-arms on the same threshold. */
     run_feedback_beats(client, sockets[1], 3, FEEDBACK_IDLE,
                        sizeof(FEEDBACK_IDLE), status, sizeof(status));


### PR DESCRIPTION
Follow-up to #40. Pausing playback on an Apple speaker could report a dropped stream that was never dropped.

While paused, the connection is deliberately kept alive with silence and the session still counts as streaming, so a speaker that holds no stream during a pause looked identical to one that dropped it. Measured on an Apple TV 4K: it reports zero streams whenever it is not actually playing, so a pause on Apple hardware would raise a false alarm within about six seconds.

- Only report a dropped stream while audio should actually be playing, not while paused or parked
- Cover it with a test
