### PR TITLE
Fix a false alarm on every Apple TV

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -707,11 +707,20 @@ capture.
   stream under us and every packet is going nowhere; three consecutive empty
   ticks (~6 s, past the transitions around SETUP/RECORD and a warm splice)
   report it once per episode as `[STATUS] stream_dropped streams=0 ticks=<n>
-  interval_ms=<ms>`, and a stream coming back closes the episode. A receiver
-  that omits the key reports no stream status at all and is never faulted.
-  The list is what the receiver HOLDS, not what it renders: a Sonos Era 100
-  confirmed playing and a silent-class Samsung HW-LS60D answer with the same
-  single-entry body, so this detects a dropped stream, not a silent speaker.
+  interval_ms=<ms>`, and a stream coming back closes the episode. Reporting is
+  suppressed while playback is paused or parked (the splice timeline keeps
+  those sessions `AP2_STREAMING` on a silence-fed wire, and a receiver may hold
+  nothing through them).
+  Whether a receiver fills the list in at all is its own choice, so the check
+  calibrates itself: an empty list is only evidence once **that** receiver has
+  been seen holding a stream, which also covers a receiver omitting the key
+  entirely. Measured 2026-08-02: a Sonos Era 100 and a Samsung HW-LS60D report
+  a single entry every tick, while an Apple TV 4K (tvOS 27) reports an empty
+  list for a perfectly healthy session — PTP clock ready over four exchanges,
+  no remote pause, audio flowing — so Apple hardware never trips it.
+  The list is also what the receiver HOLDS, not what it renders: the
+  silent-class Samsung answers identically to the Sonos, so this detects a
+  dropped stream, not a silent speaker.
 - **RTSP serialization** — one mutex serializes the RTSP channel, so the
   keepalive thread and the streaming path can never interleave frames on the
   encrypted channel.

--- a/README.md
+++ b/README.md
@@ -261,8 +261,10 @@ one track.
 receiver has answered `<n>` consecutive keepalives reporting that it holds no
 stream for us while the session is streaming: it dropped the stream and the
 audio still being sent goes nowhere. It is reported once per episode (a
-returning stream closes it), and never for receivers that report no stream
-status at all.
+returning stream closes it), never while playback is paused, and never for
+receivers that do not report stream status — a receiver only becomes eligible
+once it has been seen holding a stream, so hardware that never fills the list
+in (Apple TV, HomePod) is silently exempt rather than falsely flagged.
 
 Some receivers (notably Sonos) do not emit audio until they have received
 metadata; the binary pushes an initial metadata set at the first commanded

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -202,8 +202,11 @@ struct ap2cl_s {
     atomic_bool feedback_stop;
     bool feedback_thread_started;
     /* Consecutive /feedback bodies that listed no active stream while the
-     * client believed it was streaming. Only the feedback worker touches it. */
+     * client believed it was streaming, and whether this receiver has ever
+     * filled the list in (below, only then does an empty one mean anything).
+     * Only the feedback worker touches them. */
     unsigned feedback_idle_streams;
+    bool feedback_streams_seen;
     struct ap2_hap_ctx *hap;      /* HAP encryption context */
     struct ap2_ptp_ctx *ptp;      /* Timing */
     /* MRP now-playing over POST /command (path A, see DESIGN.md §8):
@@ -3682,11 +3685,18 @@ void ap2cl_stop(struct ap2cl_s *p)
  * the key report no stream status at all, which is never a fault: only a
  * present-but-empty list counts.
  *
- * The list is what the receiver HOLDS, not what it renders: measured
- * 2026-08-02, a Sonos Era 100 confirmed playing (its own UPnP transport
- * reported PLAYING) and a Samsung HW-LS60D both answered every tick with the
- * identical body {"streams": [{"type": 96, "sr": 44100}]}. So a live entry
- * does not prove audio is audible, and this is not a silence detector.
+ * Whether a receiver fills the list in at all is its own choice, so the signal
+ * calibrates itself against the receiver in front of it: an empty list only
+ * means something once THIS receiver has been seen holding a stream. Measured
+ * 2026-08-02 — a Sonos Era 100 and a Samsung HW-LS60D report
+ * {"streams": [{"type": 96, "sr": 44100}]} every tick, while an Apple TV 4K
+ * (tvOS 27) reports an empty list for a perfectly healthy session (PTP clock
+ * ready over four exchanges, no remote pause, audio flowing), so on Apple
+ * hardware the list never carries stream status and never reports.
+ *
+ * The list is also what the receiver HOLDS, not what it renders: the Samsung
+ * answers identically to the Sonos, so a live entry does not prove audio is
+ * audible and this is not a silence detector.
  */
 static void ap2_feedback_note_streams(struct ap2cl_s *p, const uint8_t *resp,
                                       int resp_len)
@@ -3700,6 +3710,7 @@ static void ap2_feedback_note_streams(struct ap2cl_s *p, const uint8_t *resp,
     }
 
     LOG_DEBUG("[AP2] /feedback streams=%zu", streams);
+    if (streams > 0) p->feedback_streams_seen = true;
     /* Only while audio should actually be rendering: the splice timeline keeps
      * a paused or parked session AP2_STREAMING and feeds the wire silence, and
      * a receiver is free to hold nothing through that. */
@@ -3716,6 +3727,9 @@ static void ap2_feedback_note_streams(struct ap2cl_s *p, const uint8_t *resp,
         p->feedback_idle_streams = 0;
         return;
     }
+    /* A receiver that has never filled the list in is not reporting stream
+     * status at all, the same as one that omits the key. */
+    if (!p->feedback_streams_seen) return;
     /* Report the fault once per episode; the recovery above closes it. */
     if (++p->feedback_idle_streams != AP2_FEEDBACK_IDLE_STREAM_TICKS) return;
     LOG_WARN("[AP2] Receiver holds no stream after %u feedback ticks while "

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -513,6 +513,57 @@ static void run_feedback_beats(struct ap2cl_s *client, int peer_fd, int beats,
     assert(peer.ok);
 }
 
+/* Whether a receiver fills the stream list in at all is its own choice: an
+ * Apple TV 4K reports an empty list for a perfectly healthy session, so an
+ * empty list is only evidence once THIS receiver has been seen holding a
+ * stream. Without that, an Apple session would fault within three ticks. */
+static void test_feedback_idle_needs_a_seen_stream(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+
+    ap2_device_info_t device = {
+        .name = "never-reports test",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+    ap2cl_test_set_splice(client, true);
+    assert(ap2cl_start(client, 0, NULL) == AP2_COMMIT_OK);
+    assert(ap2cl_state(client) == AP2_STREAMING);
+
+    char status[1024];
+    run_feedback_beats(client, sockets[1], 6, FEEDBACK_IDLE,
+                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
+    assert(ap2cl_test_feedback_idle_streams(client) == 0);
+    assert(!strstr(status, "stream_dropped"));
+
+    /* Once it does hold one, a later drop is evidence again. */
+    run_feedback_beats(client, sockets[1], 1, FEEDBACK_ACTIVE,
+                       sizeof(FEEDBACK_ACTIVE), status, sizeof(status));
+    run_feedback_beats(client, sockets[1], 3, FEEDBACK_IDLE,
+                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
+    assert(ap2cl_test_feedback_idle_streams(client) == 3);
+    assert(strstr(status, "[STATUS] stream_dropped streams=0 ticks=3 "
+                          "interval_ms=2000\n"));
+
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+    puts("ap2_client feedback unreported-stream-list tests passed");
+}
+
 /* A receiver that keeps answering 200 while reporting an empty stream list has
  * dropped the stream we keep sending to. That is only a fault once it persists:
  * the list is briefly empty around setup and warm splices, so the report
@@ -1504,6 +1555,7 @@ int main(void)
     test_splice_pause_keeps_line_hot();
     test_feedback_miss_tolerated_then_recovered();
     test_feedback_idle_streams_reported();
+    test_feedback_idle_needs_a_seen_stream();
     test_apple_model_resolution();
     test_pacing_window_rate_scaling();
     test_clock_verified_anchor();


### PR DESCRIPTION
Follow-up to #40 and #42. Every Apple TV session currently reports a dropped stream that was never dropped.

Whether a speaker fills in the stream list at all turns out to be its own choice. Apple hardware always reports an empty list, even for a perfectly healthy session — measured on an Apple TV 4K (tvOS 27) with its clock locked, no pause, and audio flowing — so the check fires within about six seconds of normal playback. Sonos and Samsung speakers do report the list, and the check works correctly there.

Rather than keeping a list of which speakers to trust, the check now calibrates itself against the speaker in front of it: an empty list only counts once that speaker has been seen holding a stream.

- Only report a dropped stream on speakers that have shown they report one
- Speakers that never report the list are exempt, as those omitting it already were
- Cover it with a test
