### PR TITLE
Remove the false alarm about dropped AirPlay streams

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -721,16 +721,17 @@ capture.
   each feedback POST. RAOP paths use libraop's keepalive (~20 s).
 - **Receiver stream list** — each `/feedback` response carries the receiver's
   own list of the streams it still holds for us,
-  `{"streams": [{"type": 96, "sr": 44100}]}`, logged at DEBUG every tick. An
-  empty list while the client is streaming means the receiver dropped the
-  stream under us and every packet is going nowhere; three consecutive empty
-  ticks (~6 s, past the transitions around SETUP/RECORD and a warm splice)
-  report it once per episode as `[STATUS] stream_dropped streams=0 ticks=<n>
-  interval_ms=<ms>`, and a stream coming back closes the episode. A receiver
-  that omits the key reports no stream status at all and is never faulted.
-  The list is what the receiver HOLDS, not what it renders: a Sonos Era 100
-  confirmed playing and a silent-class Samsung HW-LS60D answer with the same
-  single-entry body, so this detects a dropped stream, not a silent speaker.
+  `{"streams": [{"type": 96, "sr": 44100}]}`, logged at DEBUG every tick.
+  Diagnostic only — it carries no health verdict, because two independent
+  measurements (2026-08-02) show it cannot support one. Whether a receiver
+  fills the list in is vendor choice: a Sonos Era 100 and a Samsung HW-LS60D
+  report a single entry every tick, while an Apple TV 4K (tvOS 27) reports an
+  empty list throughout a perfectly healthy session (PTP clock ready over four
+  exchanges, no remote pause, audio flowing), so "empty" cannot mean "faulted".
+  And the list is what the receiver HOLDS, not what it renders: the
+  silent-class Samsung answers identically to the Sonos, so a live entry
+  cannot mean "audible" either. Channel health is judged by the keepalive
+  miss/`rtsp_dead`/`media_healthy` signals instead.
 - **RTSP serialization** — one mutex serializes the RTSP channel, so the
   keepalive thread and the streaming path can never interleave frames on the
   encrypted channel.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -719,9 +719,11 @@ capture.
   sessions without it), independent of command-pipe metadata, artwork loading,
   and progress updates. The worker services encrypted reverse events after
   each feedback POST. RAOP paths use libraop's keepalive (~20 s).
-- **Receiver stream list** — each `/feedback` response carries the receiver's
+- **Receiver stream list** — a `/feedback` response may carry the receiver's
   own list of the streams it still holds for us,
-  `{"streams": [{"type": 96, "sr": 44100}]}`, logged at DEBUG every tick.
+  `{"streams": [{"type": 96, "sr": 44100}]}`, logged at DEBUG on each tick that
+  reports one. A receiver is free to omit the key (or answer with no body at
+  all), and then nothing is logged.
   Diagnostic only — it carries no health verdict, because two independent
   measurements (2026-08-02) show it cannot support one. Whether a receiver
   fills the list in is vendor choice: a Sonos Era 100 and a Samsung HW-LS60D

--- a/README.md
+++ b/README.md
@@ -266,13 +266,6 @@ stdin, the single persistent audio input for the whole process lifetime.
 `[STATUS] eof` means the stdin input ended — the whole feed is done, not just
 one track.
 
-`[STATUS] stream_dropped streams=0 ticks=<n> interval_ms=<ms>` means the
-receiver has answered `<n>` consecutive keepalives reporting that it holds no
-stream for us while the session is streaming: it dropped the stream and the
-audio still being sent goes nowhere. It is reported once per episode (a
-returning stream closes it), and never for receivers that report no stream
-status at all.
-
 Some receivers (notably Sonos) do not emit audio until they have received
 metadata; the binary pushes an initial metadata set at the first commanded
 start, so audio starts regardless of whether the caller ever sends `SENDMETA`.

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3740,6 +3740,11 @@ void ap2cl_stop(struct ap2cl_s *p)
  * ready over four exchanges, no remote pause, audio flowing. A live entry
  * equally does not prove audio is audible: the Samsung answers like the
  * Sonos while its speaker stays silent.
+ *
+ * Three shapes therefore reach here and only the first logs a count: a body
+ * carrying the key (any length of list), a body without it, and no body at
+ * all. The last two are receivers that report no stream status, so silence
+ * in the log is expected of them rather than a missed tick.
  */
 static void ap2_feedback_log_streams(const uint8_t *resp, int resp_len)
 {

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -75,12 +75,6 @@ extern log_level *loglevel;
  * are tolerated up to this count (the final one kills), so a genuinely dead
  * channel is still detected within roughly misses x (interval + timeout). */
 #define AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES 3
-/* Consecutive feedback ticks the receiver may report an empty stream list
- * while we believe we are streaming before it counts as a fault. The list is
- * legitimately empty for a moment around SETUP/RECORD and while a receiver
- * re-seats a warm splice, so only a sustained streak means the stream really
- * is gone. */
-#define AP2_FEEDBACK_IDLE_STREAM_TICKS 3
 #define AP2_EVENT_POLL_INTERVAL_MS   100
 #define AP2_RTSP_RX_BUF_SIZE         16384
 #define AP2_UDP_SEND_TIMEOUT_MS      20
@@ -210,9 +204,6 @@ struct ap2cl_s {
     pthread_t feedback_thread;
     atomic_bool feedback_stop;
     bool feedback_thread_started;
-    /* Consecutive /feedback bodies that listed no active stream while the
-     * client believed it was streaming. Only the feedback worker touches it. */
-    unsigned feedback_idle_streams;
     struct ap2_hap_ctx *hap;      /* HAP encryption context */
     struct ap2_ptp_ctx *ptp;      /* Timing */
     /* MRP now-playing over POST /command (path A, see DESIGN.md §8):
@@ -3738,59 +3729,26 @@ void ap2cl_stop(struct ap2cl_s *p)
 }
 
 /*
- * Read the receiver's own view of the session out of a /feedback response:
- * {"streams": [...]} lists the streams it still holds for us. An empty list
- * while we believe we are streaming means the receiver dropped the stream
- * under us and every packet we send is going nowhere — the POST answers 200
- * either way, so nothing else on this channel reports it. Receivers that omit
- * the key report no stream status at all, which is never a fault: only a
- * present-but-empty list counts.
- *
- * The list is what the receiver HOLDS, not what it renders: measured
- * 2026-08-02, a Sonos Era 100 confirmed playing (its own UPnP transport
- * reported PLAYING) and a Samsung HW-LS60D both answered every tick with the
- * identical body {"streams": [{"type": 96, "sr": 44100}]}. So a live entry
- * does not prove audio is audible, and this is not a silence detector.
+ * Log the receiver's own view of the session from a /feedback response:
+ * {"streams": [...]} lists the streams it still holds for us. Diagnostic
+ * only — an empty list is not a fault signal, because whether a receiver
+ * fills the list in at all is its own choice. Measured 2026-08-02: a Sonos
+ * Era 100 confirmed playing (its own UPnP transport reported PLAYING) and a
+ * Samsung HW-LS60D both answer every tick with the identical body
+ * {"streams": [{"type": 96, "sr": 44100}]}, while an Apple TV 4K (tvOS 27)
+ * answers with an empty list for a perfectly healthy session — PTP clock
+ * ready over four exchanges, no remote pause, audio flowing. A live entry
+ * equally does not prove audio is audible: the Samsung answers like the
+ * Sonos while its speaker stays silent.
  */
-static void ap2_feedback_note_streams(struct ap2cl_s *p, const uint8_t *resp,
-                                      int resp_len)
+static void ap2_feedback_log_streams(const uint8_t *resp, int resp_len)
 {
     size_t streams = 0;
     if (!resp || resp_len <= 0 ||
         !ap2_bplist_find_array_count(resp, (size_t)resp_len, "streams",
-                                     &streams)) {
-        p->feedback_idle_streams = 0;
+                                     &streams))
         return;
-    }
-
     LOG_DEBUG("[AP2] /feedback streams=%zu", streams);
-    /* Only while audio should actually be rendering: the splice timeline keeps
-     * a paused or parked session AP2_STREAMING and feeds the wire silence, and
-     * a receiver is free to hold nothing through that. */
-    bool rendering = p->state == AP2_STREAMING && !p->content_paused &&
-                     !p->content_stopped;
-    if (streams > 0 || !rendering) {
-        /* Only a stream coming back closes a reported episode; leaving the
-         * streaming state just drops the streak, since an idle receiver
-         * holding nothing is the expected shape there. */
-        if (streams > 0 &&
-            p->feedback_idle_streams >= AP2_FEEDBACK_IDLE_STREAM_TICKS)
-            LOG_INFO("[AP2] receiver holds a stream again (streams=%zu)",
-                     streams);
-        p->feedback_idle_streams = 0;
-        return;
-    }
-    /* Report the fault once per episode; the recovery above closes it. */
-    if (++p->feedback_idle_streams != AP2_FEEDBACK_IDLE_STREAM_TICKS) return;
-    LOG_WARN("[AP2] Receiver holds no stream after %u feedback ticks while "
-             "streaming: it dropped the stream we are still sending to",
-             p->feedback_idle_streams);
-    /* Machine-readable counterpart on the same stderr channel as the binary's
-     * other [STATUS] lines, so Music Assistant can act on a dropped stream
-     * without scraping the human-readable log. */
-    fprintf(stderr, "[STATUS] stream_dropped streams=0 ticks=%u interval_ms=%d\n",
-            p->feedback_idle_streams, AP2_FEEDBACK_INTERVAL_MS);
-    fflush(stderr);
 }
 
 bool ap2cl_feedback(struct ap2cl_s *p)
@@ -3804,7 +3762,7 @@ bool ap2cl_feedback(struct ap2cl_s *p)
     int status = ap2_rtsp_send_tracked(
         p, "POST", "/feedback", NULL, 0, NULL,
         &resp, &resp_len, &request_started);
-    ap2_feedback_note_streams(p, resp, resp_len);
+    ap2_feedback_log_streams(resp, resp_len);
     free(resp);
     ap2_feedback_result_t result =
         ap2_io_feedback_result(status, request_started);
@@ -4517,11 +4475,6 @@ void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p)
 bool ap2cl_test_first_packet(struct ap2cl_s *p)
 {
     return p->first_packet;
-}
-
-unsigned ap2cl_test_feedback_idle_streams(struct ap2cl_s *p)
-{
-    return p->feedback_idle_streams;
 }
 
 void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet)

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -30,7 +30,6 @@ void ap2cl_test_unlock_mrp(struct ap2cl_s *p);
 void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd);
 void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p);
 bool ap2cl_test_first_packet(struct ap2cl_s *p);
-unsigned ap2cl_test_feedback_idle_streams(struct ap2cl_s *p);
 void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet);
 void ap2cl_test_set_splice(struct ap2cl_s *p, bool enable);
 bool ap2cl_test_splice_default(const char *txt, const char *am);
@@ -438,184 +437,6 @@ static void test_feedback_stream_counts(void)
                    FEEDBACK_ACTIVE, len, "streams", &streams) == 0);
     }
     puts("ap2_bplist /feedback stream-count tests passed");
-}
-
-typedef struct {
-    int fd;
-    int beats;                  /* keepalives to answer */
-    const uint8_t *body;        /* NULL for a receiver that reports nothing */
-    size_t body_len;
-    bool ok;
-} feedback_body_peer_t;
-
-static void *run_feedback_body_peer(void *arg)
-{
-    feedback_body_peer_t *peer = arg;
-    peer->ok = false;
-    for (int beat = 0; beat < peer->beats; beat++) {
-        int cseq = 0;
-        if (!read_rtsp_request_cseq(peer->fd, "POST /feedback ", &cseq))
-            return NULL;
-        char header[192];
-        int header_len = snprintf(
-            header, sizeof(header),
-            "RTSP/1.0 200 OK\r\nCSeq: %d\r\n"
-            "Content-Type: application/x-apple-binary-plist\r\n"
-            "Content-Length: %zu\r\n\r\n", cseq, peer->body_len);
-        if (write(peer->fd, header, (size_t)header_len) != header_len)
-            return NULL;
-        if (peer->body_len &&
-            write(peer->fd, peer->body, peer->body_len) !=
-                (ssize_t)peer->body_len)
-            return NULL;
-    }
-    peer->ok = true;
-    return NULL;
-}
-
-/* Answer `beats` keepalives with `body` and return what the session captured
- * on stderr while they ran (the test log level is silent, so only [STATUS]
- * lines land there). */
-static void run_feedback_beats(struct ap2cl_s *client, int peer_fd, int beats,
-                               const uint8_t *body, size_t body_len,
-                               char *status_out, size_t status_size)
-{
-    feedback_body_peer_t peer = {
-        .fd = peer_fd,
-        .beats = beats,
-        .body = body,
-        .body_len = body_len,
-    };
-    pthread_t peer_thread;
-    assert(pthread_create(&peer_thread, NULL,
-                          run_feedback_body_peer, &peer) == 0);
-
-    FILE *captured = tmpfile();
-    assert(captured);
-    int saved_stderr = dup(STDERR_FILENO);
-    assert(saved_stderr >= 0);
-    fflush(stderr);
-    assert(dup2(fileno(captured), STDERR_FILENO) >= 0);
-
-    /* Collect rather than assert: stderr belongs to the capture until it is
-     * restored, so an assertion failing here would swallow its own message. */
-    bool beats_ok = true;
-    for (int beat = 0; beat < beats; beat++)
-        if (!ap2cl_feedback(client)) beats_ok = false;
-
-    fflush(stderr);
-    assert(dup2(saved_stderr, STDERR_FILENO) >= 0);
-    assert(close(saved_stderr) == 0);
-    assert(beats_ok);
-
-    rewind(captured);
-    size_t read_len = fread(status_out, 1, status_size - 1, captured);
-    status_out[read_len] = '\0';
-    assert(fclose(captured) == 0);
-
-    assert(pthread_join(peer_thread, NULL) == 0);
-    assert(peer.ok);
-}
-
-/* A receiver that keeps answering 200 while reporting an empty stream list has
- * dropped the stream we keep sending to. That is only a fault once it persists:
- * the list is briefly empty around setup and warm splices, so the report
- * lands on the tick that completes the streak, and exactly once per episode.
- */
-static void test_feedback_idle_streams_reported(void)
-{
-    int sockets[2];
-    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
-
-    ap2_device_info_t device = {
-        .name = "feedback streams test",
-        .address = "127.0.0.1",
-        .port = 7000,
-        .txt_records = "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE",
-    };
-    ap2_audio_format_t format = {
-        .sample_rate = 44100,
-        .bit_depth = 16,
-        .channels = 2,
-    };
-    struct ap2cl_s *client = ap2cl_create(
-        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
-    assert(client);
-    ap2cl_force_native(client);
-    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
-    ap2cl_test_set_splice(client, true);
-    assert(ap2cl_start(client, 0, NULL) == AP2_COMMIT_OK);
-    assert(ap2cl_state(client) == AP2_STREAMING);
-
-    char status[1024];
-    /* A receiver that reports nothing at all (no body, no key) is never
-     * faulted — most non-Apple receivers answer this way. */
-    run_feedback_beats(client, sockets[1], 4, NULL, 0, status, sizeof(status));
-    assert(ap2cl_test_feedback_idle_streams(client) == 0);
-    assert(!strstr(status, "stream_dropped"));
-
-    /* A live stream keeps the streak at zero however long it runs. */
-    run_feedback_beats(client, sockets[1], 4, FEEDBACK_ACTIVE,
-                       sizeof(FEEDBACK_ACTIVE), status, sizeof(status));
-    assert(ap2cl_test_feedback_idle_streams(client) == 0);
-    assert(!strstr(status, "stream_dropped"));
-
-    /* Two empty ticks are still inside the tolerated transition window. */
-    run_feedback_beats(client, sockets[1], 2, FEEDBACK_IDLE,
-                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
-    assert(ap2cl_test_feedback_idle_streams(client) == 2);
-    assert(!strstr(status, "stream_dropped"));
-
-    /* The third completes the streak and reports; the fourth stays quiet. */
-    run_feedback_beats(client, sockets[1], 2, FEEDBACK_IDLE,
-                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
-    assert(ap2cl_test_feedback_idle_streams(client) == 4);
-    const char *report = strstr(status, "[STATUS] stream_dropped streams=0 "
-                                        "ticks=3 interval_ms=2000\n");
-    assert(report);
-    assert(!strstr(report + 1, "[STATUS] stream_dropped"));
-
-    /* A stream coming back closes the episode and says so. */
-    test_log_level = lINFO;
-    run_feedback_beats(client, sockets[1], 1, FEEDBACK_ACTIVE,
-                       sizeof(FEEDBACK_ACTIVE), status, sizeof(status));
-    assert(ap2cl_test_feedback_idle_streams(client) == 0);
-    assert(strstr(status, "holds a stream again (streams=1)"));
-
-    /* A paused splice session stays AP2_STREAMING and feeds the wire silence;
-     * a receiver holding nothing through that is not a dropped stream. */
-    ap2cl_pause(client);
-    assert(ap2cl_state(client) == AP2_STREAMING);
-    run_feedback_beats(client, sockets[1], 3, FEEDBACK_IDLE,
-                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
-    assert(ap2cl_test_feedback_idle_streams(client) == 0);
-    assert(!strstr(status, "stream_dropped"));
-    ap2cl_play(client);
-
-    /* The next episode re-arms on the same threshold. */
-    run_feedback_beats(client, sockets[1], 3, FEEDBACK_IDLE,
-                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
-    assert(ap2cl_test_feedback_idle_streams(client) == 3);
-    assert(strstr(status, "[STATUS] stream_dropped streams=0 ticks=3 "
-                          "interval_ms=2000\n"));
-
-    /* Leaving the streaming state is not a recovery: a receiver holding
-     * nothing is the expected shape there, so the streak drops silently
-     * rather than claiming a stream came back. */
-    ap2cl_stop(client);
-    assert(ap2cl_state(client) != AP2_STREAMING);
-    run_feedback_beats(client, sockets[1], 1, FEEDBACK_IDLE,
-                       sizeof(FEEDBACK_IDLE), status, sizeof(status));
-    assert(ap2cl_test_feedback_idle_streams(client) == 0);
-    assert(!strstr(status, "holds a stream again"));
-    assert(!strstr(status, "stream_dropped"));
-    test_log_level = lSILENCE;
-
-    ap2cl_test_detach_rtsp_socket(client);
-    assert(close(sockets[0]) == 0);
-    assert(close(sockets[1]) == 0);
-    assert(ap2cl_destroy(client));
-    puts("ap2_client feedback idle-stream report tests passed");
 }
 
 /* A password-protected receiver keeps its native AirPlay 2 route: the password
@@ -1620,7 +1441,6 @@ int main(void)
     test_splice_delivery_gap_recovery();
     test_splice_pause_keeps_line_hot();
     test_feedback_miss_tolerated_then_recovered();
-    test_feedback_idle_streams_reported();
     test_apple_model_resolution();
     test_pacing_window_rate_scaling();
     test_clock_verified_anchor();


### PR DESCRIPTION
Follows #40 and #42, and replaces #43 (closed).

The speaker's keepalive replies list the streams it holds for us, and #40 turned an empty list into a fault report. Hardware testing since then shows that list cannot carry a health verdict:

- Whether a speaker fills the list in at all is its own choice. An Apple TV 4K reports an empty list throughout a perfectly healthy session, so "empty" cannot mean "faulty" — every Apple TV session currently raises a false alarm.
- A filled-in list does not mean sound is coming out either: a speaker known to stay silent reports exactly the same thing as a Sonos that is audibly playing.

Both readings are unreliable, and the report never caught a real fault on any speaker we tested, so it goes. The stream count stays as a debug log line, which is what made the differences above visible in the first place. Connection health is already covered by the existing keepalive checks.

- Log the stream count each keepalive; drop the fault report and its `[STATUS] stream_dropped` line
- Removes the false alarm on Apple hardware that is live today
- Net 258 lines removed
