### PR TITLE
Stop reporting a healthy speaker as having lost our clock

### DIFF
--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3549,6 +3549,14 @@ bool ap2cl_uses_ptp(struct ap2cl_s *p)
     return p && p->flow == FLOW_NATIVE_AP2 && p->use_ptp;
 }
 
+void ap2cl_clock_watch_restart(struct ap2cl_s *p)
+{
+    if (!p) return;
+    pthread_mutex_lock(&p->clock_verify_lock);
+    p->clock_last_streak_unix_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
+    pthread_mutex_unlock(&p->clock_verify_lock);
+}
+
 void ap2cl_clock_readiness(struct ap2cl_s *p, ap2_clock_readiness_t *out)
 {
     if (!out) return;
@@ -3573,9 +3581,10 @@ void ap2cl_clock_readiness(struct ap2cl_s *p, ap2_clock_readiness_t *out)
      * connect while none ever has been: a snapshot goes empty on a single lost
      * Q round-trip as readily as on a receiver that stopped answering, so
      * measuring from connect alone would call a healthy session stalled on one
-     * dropped datagram. The poller refreshes the mark every round, so a blip
-     * can never reach the window while a real loss gets the same grace as a
-     * cold start. */
+     * dropped datagram. Under the shared daemon the poller refreshes the mark
+     * every round, so a blip can never reach the window while a real loss gets
+     * the same grace as a cold start; the in-process engine has no poller and
+     * relies on ap2cl_clock_watch_restart at each re-arm for the same grace. */
     uint64_t stall_from_ms =
         p->clock_last_streak_unix_ms > p->clock_connected_unix_ms
             ? p->clock_last_streak_unix_ms : p->clock_connected_unix_ms;

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -251,8 +251,9 @@ typedef struct {
 
 /*
  * Advance the clock verification of a start that was committed before the
- * receiver's first timing probe (a rejoining receiver resumes its clock
- * exchange only after the START is acked). Armed automatically by such
+ * receiver's first timing probe (a freshly connected receiver takes about a
+ * second to start probing, so a prompt start commits ahead of it). Armed
+ * automatically by such
  * commits; the audio loop calls this every iteration under its send lock and
  * reports VERIFIED/CORRECTED events on the status channel. On a join-marked
  * start (ap2cl_set_start_join) a correction moves the still-unsent anchor
@@ -296,16 +297,25 @@ bool ap2cl_uses_ptp(struct ap2cl_s *p);
  * AP2_CLOCK_STALL_MS — counted from the last streak this call saw, or from
  * connect while it has seen none — reports AP2_CLOCK_STALLED: that receiver is
  * not slaved to our clock, so it can seat no render position and stays silent
- * however cleanly the audio paces. That window is measured from a mark the
- * snapshot poller keeps current for the whole session, so the verdict holds
- * however rarely a caller samples — a caller that stops asking once it has
- * what it needs cannot make a later reading read stale.
+ * however cleanly the audio paces. Under the shared daemon the snapshot poller
+ * keeps that mark current for the whole session; the in-process engine has no
+ * poller, so the mark only moves while a caller is asking. A caller that stops
+ * asking must therefore call ap2cl_clock_watch_restart before it resumes, or
+ * the first reading afterwards measures a window nobody was watching.
  * Stalled is not terminal — a receiver that begins probing late reports
  * probing and then ready as usual. Safe to call from the audio loop: it never
  * blocks on the network. Recompute per use — ready_at_unix_ms is a projection
  * against the wall clock and must not be cached.
  */
 void ap2cl_clock_readiness(struct ap2cl_s *p, ap2_clock_readiness_t *out);
+/*
+ * Restart the stall window at now, so the receiver gets the full
+ * AP2_CLOCK_STALL_MS grace from the moment readiness reporting resumes.
+ * Call it wherever reporting re-arms after having gone terminal: the mark
+ * left behind is as old as the quiet stretch, and measuring a stall against
+ * it would condemn a healthy receiver on its first reading.
+ */
+void ap2cl_clock_watch_restart(struct ap2cl_s *p);
 
 /* True while a cold-clock verification can still produce a result. It goes
  * false on the resolving poll and on every disarm (commit, flush, park,

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -230,6 +230,12 @@ static void clock_ready_rearm(void)
     g_clock_ready_reported = false;
     g_clock_ready_done = false;
     g_clock_ready_next_ntp = 0;
+    /* Reporting went terminal at the last ready and stopped asking, so under
+     * the in-process engine — which has no poller to follow the receiver
+     * meanwhile — the stall mark is as old as that quiet stretch. Restart the
+     * window here so the first reading after the re-arm measures the receiver,
+     * not the silence of nobody having looked. */
+    ap2cl_clock_watch_restart(g_ap2cl);
 }
 
 static const char *clock_state_name(ap2_clock_state_t state)

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -1392,11 +1392,9 @@ static void test_clock_stall_detection(void)
     ap2cl_clock_readiness(client, &r);
     assert(r.state == AP2_CLOCK_COLD);
 
-    /* The mark is the poller's to keep, not the caller's: reporting goes
-     * terminal at the first ready, so a session can run for ten minutes with
-     * nothing sampling readiness at all. The reading that a flush re-arms then
-     * lands on a mark the poller refreshed a round ago, and a lost round-trip
-     * on that very cycle is still only a blip. */
+    /* A mark kept current — by the shared daemon's poller, or by the re-arm
+     * restarting the window — makes a lost round-trip on that very cycle only
+     * a blip. */
     ap2cl_test_set_clock_marks(client, test_now_unix_ms() - 600000,
                                test_now_unix_ms() - 200);
     ap2cl_test_clear_clock_exchange(client);
@@ -1409,6 +1407,14 @@ static void test_clock_stall_detection(void)
                                test_now_unix_ms() - 6000);
     ap2cl_clock_readiness(client, &r);
     assert(r.state == AP2_CLOCK_STALLED);
+
+    /* Restarting the watch is what earns a re-armed session the same grace as
+     * a cold one: without it the in-process engine, which has no poller, would
+     * measure the stall against a mark left behind while reporting was
+     * terminal and condemn a healthy receiver on the first reading. */
+    ap2cl_clock_watch_restart(client);
+    ap2cl_clock_readiness(client, &r);
+    assert(r.state == AP2_CLOCK_COLD);
 
     /* Once the session is down there is no receiver to answer for: the marks
      * survive teardown, so a reading taken afterwards must not read as a stall. */


### PR DESCRIPTION
A speaker could be reported as having stopped answering our clock while it was
playing perfectly well, with a misleading warning telling the user to check
their network.

Readiness reporting stops once a speaker's clock is usable, and on a single
speaker nothing else follows that clock afterwards. The window used to decide
"this speaker stopped answering" was therefore left as old as the quiet
stretch, so the first check after a track change or seek measured a period
nobody had been watching and could condemn a healthy speaker immediately.

- Restart the stall window whenever readiness reporting resumes, so a speaker
  gets the same grace it gets on a fresh connection
- Correct the comments claiming the background poller keeps that window current
  for every session; it only runs in shared-clock (multi-room) mode
- Correct a stale note claiming a receiver only starts its clock exchange after
  playback is anchored - it starts about a second after connecting
