### PR TITLE
Add error codes for a rejected START or FLUSH

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -166,9 +166,9 @@ status line, all headers and a bounded hex dump of the body
 (`ap2_io_format_response_dump()`), which is what tells whether a receiver's
 `401` carries a `WWW-Authenticate` challenge and what its TLV/plist body says.
 
-**Error contract.** Before the human-readable `[ERROR]` line, a fatal
-connect/auth failure emits exactly one machine-readable line on stderr that
-Music Assistant parses:
+**Error contract.** Before the human-readable `[ERROR]` line, a connect/auth
+failure or a rejected transport command emits exactly one machine-readable line
+on stderr that Music Assistant parses:
 
 ```
 [STATUS] error code=<slug> http=<int> detail="<single line>"
@@ -179,6 +179,14 @@ Music Assistant parses:
 | `auth_required` | a password is needed and none was supplied: reported before connecting when the TXT says so (and no credentials are stored), and on a `401`/`403` from a device we presented no password to |
 | `auth_failed` | the password we did present was rejected, on any exchange |
 | `connect_failed` | every other connect-path failure |
+| `start_failed` | `ACTION=START` scheduled no instant, so no `[STATUS] started` follows and no content may be mapped onto one |
+| `flush_failed` | `ACTION=FLUSH` was rejected, so no `[STATUS] flushed` follows |
+
+The connect/auth slugs are terminal — the process exits. `start_failed` and
+`flush_failed` are not: the connection survives and the caller decides whether
+to retry or fall back. Both exist so a caller can abort the pending ack wait
+immediately instead of waiting out a timeout that also means "a binary too old
+to ack at all"; a withheld join ack makes that wait seconds long.
 
 `http` is the most informative HTTP status seen, `0` when none applies (a
 TLV-level rejection is an HTTP 200). The detail is squeezed onto one line and

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -379,9 +379,11 @@ static void clock_verify_tick(void)
 #define ERROR_CODE_AUTH_REQUIRED  "auth_required"
 #define ERROR_CODE_AUTH_FAILED    "auth_failed"
 #define ERROR_CODE_CONNECT_FAILED "connect_failed"
+#define ERROR_CODE_START_FAILED   "start_failed"
+#define ERROR_CODE_FLUSH_FAILED   "flush_failed"
 
 /*
- * Report a fatal failure as one machine-readable line followed by the
+ * Report a failure as one machine-readable line followed by the
  * human-readable one:
  *   [STATUS] error code=<slug> http=<int> detail="<text>"
  *   [ERROR] <msg>
@@ -613,13 +615,23 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
             if (!g_start_ack_withheld)
                 status_started(g_pend_start_unix_ms, at_ms);
         } else {
-            status_error("START failed");
+            /* No instant was scheduled, so the caller must not map content
+             * onto one. Coded so it can abort its pending ack wait at once
+             * instead of waiting out the timeout that also means "old
+             * binary" — with the ack withheld, the wait is seconds long. */
+            status_error_ex(ERROR_CODE_START_FAILED, 0,
+                            g_session ? "session did not schedule the start"
+                                      : "no live session to start",
+                            "START failed");
         }
         g_pend_start_unix_ms = 0;
         g_pend_start_join = false;
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "FLUSH") == 0) {
         if (!g_session || !ap2_session_flush(g_session))
-            status_error("FLUSH failed");
+            status_error_ex(ERROR_CODE_FLUSH_FAILED, 0,
+                            g_session ? "session rejected the flush"
+                                      : "no live session to flush",
+                            "FLUSH failed");
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "STANDBY") == 0) {
         if (g_session) ap2_session_standby(g_session);
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "DISCONNECT") == 0) {

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -407,6 +407,17 @@ static void status_error_ex(const char *code, int http, const char *detail,
     status_error(msg);
 }
 
+/* Whether a transport command still has a session that could act on it. The
+ * pointer outlives the session it points at: DISCONNECT and the idle timeout
+ * mark it ENDED and only the teardown frees it, and every command entry point
+ * refuses an ended session. So the pointer alone would report a command the
+ * session refused where in truth there was no longer a session to refuse it.
+ * ap2_session_state() answers ENDED for NULL too. */
+static bool session_is_live(void)
+{
+    return ap2_session_state(g_session) != AP2_SESSION_ENDED;
+}
+
 static void remote_command_event(
     ap2_remote_command_t command, void *userdata)
 {
@@ -620,8 +631,8 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
              * instead of waiting out the timeout that also means "old
              * binary" — with the ack withheld, the wait is seconds long. */
             status_error_ex(ERROR_CODE_START_FAILED, 0,
-                            g_session ? "session did not schedule the start"
-                                      : "no live session to start",
+                            session_is_live() ? "session did not schedule the start"
+                                              : "no live session to start",
                             "START failed");
         }
         g_pend_start_unix_ms = 0;
@@ -629,8 +640,8 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "FLUSH") == 0) {
         if (!g_session || !ap2_session_flush(g_session))
             status_error_ex(ERROR_CODE_FLUSH_FAILED, 0,
-                            g_session ? "session rejected the flush"
-                                      : "no live session to flush",
+                            session_is_live() ? "session rejected the flush"
+                                              : "no live session to flush",
                             "FLUSH failed");
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "STANDBY") == 0) {
         if (g_session) ap2_session_standby(g_session);


### PR DESCRIPTION
A rejected `START` or `FLUSH` only printed `[ERROR] START failed`, with no code. A caller could not tell that apart from an older binary that never acknowledges, so it had to wait out its full ack timeout first — and then map audio onto an instant that was never scheduled.

Both now carry a code on the structured error line: `code=start_failed` / `code=flush_failed`. Unlike the connect/auth codes these are not terminal — the connection survives and the caller decides what to do.

Music Assistant side: music-assistant/server#5240.
