### PR TITLE
Remove dead code around the clock poller

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ stdin, the single persistent audio input for the whole process lifetime.
   `ARTWORK=<local file path or http:// imageproxy URL>`, followed by
   `ACTION=SENDMETA` to push the set.
 
+`[STATUS] stopped` acknowledges `ACTION=STOP` once playback has been torn down.
+The process stays up, so a later `ACTION=START` can open a new session.
+
 `[STATUS] eof` means the stdin input ended — the whole feed is done, not just
 one track.
 

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -288,14 +288,13 @@ struct ap2cl_s {
                                            poller; takes over from the connect
                                            instant once it is set */
     /* Shared-daemon mode queries the streak over UDP (blocking); this poller
-     * keeps the snapshot fresh so the audio loop never blocks on it. */
+     * keeps the snapshot fresh so the audio loop never blocks on it. Readiness
+     * reporting (ap2cl_clock_readiness) reads the same snapshot, so the poller
+     * runs from connect and outlives every verification that uses it: only a
+     * reap (re-ensure or destroy) stops it. */
     pthread_t clock_verify_thread;
     bool clock_verify_thread_started;
     atomic_bool clock_verify_thread_stop;
-    atomic_bool clock_poll_wanted;  /* readiness reporting (ap2cl_clock_readiness)
-                                       also reads the snapshot, so in shared mode
-                                       the poller runs from connect and outlives
-                                       every verification that uses it */
     /* Retransmit history and the control-port reader that serves it. The ring
      * is written by the audio thread and read by the reader thread. */
     struct ap2_rtx_slot *rtx_ring;
@@ -2019,7 +2018,6 @@ static bool ap2_native_connect(struct ap2cl_s *p)
      * and stamp the instant its stall window runs from. The streak mark starts
      * clear: one left by an earlier session on this client describes a receiver
      * that is no longer the one being measured. */
-    atomic_store(&p->clock_poll_wanted, true);
     pthread_mutex_lock(&p->clock_verify_lock);
     p->clock_connected_unix_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
     p->clock_last_streak_unix_ms = 0;
@@ -2464,7 +2462,6 @@ struct ap2cl_s *ap2cl_create(
     pthread_mutex_init(&p->rtx_lock, NULL);
     pthread_mutex_init(&p->clock_verify_lock, NULL);
     atomic_init(&p->clock_verify_thread_stop, true);
-    atomic_init(&p->clock_poll_wanted, false);
     atomic_init(&p->rtx_stop, true);
     atomic_init(&p->rtx_requested, 0);
     atomic_init(&p->rtx_answered, 0);
@@ -2740,8 +2737,8 @@ static uint64_t ap2_clock_floor(struct ap2cl_s *p, uint64_t floor_ntp,
 }
 
 /* Stop the verification without an event (new commit, flush, teardown). The
- * poller is signalled here and joined by the next arm or the destroy, unless
- * readiness reporting still wants its snapshot. */
+ * poller is left running: readiness reporting keeps reading its snapshot, so
+ * it is stopped only by a reap (the next re-ensure, or the destroy). */
 static void ap2_clock_verify_disarm(struct ap2cl_s *p)
 {
     pthread_mutex_lock(&p->clock_verify_lock);
@@ -2751,8 +2748,6 @@ static void ap2_clock_verify_disarm(struct ap2cl_s *p)
      * the instant that stands. */
     p->start_ack_deferred = false;
     pthread_mutex_unlock(&p->clock_verify_lock);
-    if (!atomic_load(&p->clock_poll_wanted))
-        atomic_store(&p->clock_verify_thread_stop, true);
 }
 
 static void ap2_clock_verify_reap_poller(struct ap2cl_s *p)
@@ -2773,7 +2768,6 @@ static void *ap2_clock_verify_poller(void *arg)
         bool have = ap2_clock_query(p, &ex);
         uint64_t now_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
         pthread_mutex_lock(&p->clock_verify_lock);
-        bool armed = p->clock_verify_armed;
         p->clock_verify_have_exchange = have;
         if (have) {
             p->clock_verify_exchange = ex;
@@ -2784,7 +2778,6 @@ static void *ap2_clock_verify_poller(void *arg)
             p->clock_last_streak_unix_ms = now_ms;
         }
         pthread_mutex_unlock(&p->clock_verify_lock);
-        if (!armed && !atomic_load(&p->clock_poll_wanted)) break;
         for (int i = 0; i < AP2_CLOCK_VERIFY_POLL_MS / 50 &&
                         !atomic_load(&p->clock_verify_thread_stop); i++)
             usleep(50000);
@@ -3538,9 +3531,6 @@ ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
         p->start_ack_deferred = false;
     }
     pthread_mutex_unlock(&p->clock_verify_lock);
-    if (result != AP2_CLOCK_VERIFY_IDLE &&
-        !atomic_load(&p->clock_poll_wanted))
-        atomic_store(&p->clock_verify_thread_stop, true);
     return result;
 }
 

--- a/src/ap2_ptp.c
+++ b/src/ap2_ptp.c
@@ -1152,11 +1152,6 @@ void ap2_ptp_set_clock_id(struct ap2_ptp_ctx *ctx, uint64_t clock_id)
     ctx->clock_id_set = true;
 }
 
-uint64_t ap2_ptp_clock_id(struct ap2_ptp_ctx *ctx)
-{
-    return ctx ? ctx->clock_id : 0;
-}
-
 uint64_t ap2_ptp_now_ns(struct ap2_ptp_ctx *ctx)
 {
     (void)ctx;
@@ -1178,11 +1173,6 @@ void ap2_ptp_set_peers(struct ap2_ptp_ctx *ctx, const char *const *ips, int coun
         LOG_DEBUG("[PTP] peer[%d] = %s", i, ctx->peers[i]);
     ctx->peer_kick = ctx->npeers > 0;
     pthread_mutex_unlock(&ctx->lock);
-}
-
-bool ap2_ptp_engine_active(struct ap2_ptp_ctx *ctx)
-{
-    return ctx && ctx->engine_active;
 }
 
 bool ap2_ptp_engine_start(struct ap2_ptp_ctx *ctx, struct in_addr bind_addr,

--- a/src/ap2_ptp.h
+++ b/src/ap2_ptp.h
@@ -59,9 +59,6 @@ uint64_t ap2_ptp_local_to_device(struct ap2_ptp_ctx *ctx, uint64_t local_ntp);
  */
 void ap2_ptp_set_clock_id(struct ap2_ptp_ctx *ctx, uint64_t clock_id);
 
-/* The 64-bit PTP clock identity used by the engine (grandmasterIdentity). */
-uint64_t ap2_ptp_clock_id(struct ap2_ptp_ctx *ctx);
-
 /*
  * Set the timing peer IP list (typically [receiver_ip, our_ip]) learned from
  * SETPEERS / timingPeerInfo. Used for logging and, when unicast mirroring is
@@ -81,9 +78,6 @@ void ap2_ptp_set_peers(struct ap2_ptp_ctx *ctx, const char *const *ips, int coun
  */
 bool ap2_ptp_engine_start(struct ap2_ptp_ctx *ctx, struct in_addr bind_addr,
                           const char *device_ip);
-
-/* True if the PTP grandmaster engine is running (vs the NTP responder). */
-bool ap2_ptp_engine_active(struct ap2_ptp_ctx *ctx);
 
 /*
  * Block for up to timeout_ms while the engine listens for peer Announce


### PR DESCRIPTION
`clock_poll_wanted` was set at connect and never cleared, so the three "stop the poller when nothing wants it" guards (in `ap2_clock_verify_disarm`, the poller loop, and the tail of `ap2cl_clock_verify_poll`) could not fire. The poller already runs from connect until a reap (re-ensure or destroy) — which is what the field's own comment described — so the guards and the field go, and the stale disarm comment now states the real lifetime.

Also drops `ap2_ptp_clock_id` and `ap2_ptp_engine_active`, two accessors with no callers.

The other uncalled entry points in `ap2_ptp.h` are deliberately left alone: `ap2_ptp_set_offset` is the only setter of the offset that `ap2_ptp_get_time` and `ap2_ptp_local_to_device` apply, and four live branches still read it, so those three are a dormant documented feature rather than stray symbols — worth a separate decision.

Also documents `[STATUS] stopped`, which was emitted but never written down. Kept rather than dropped since removing an emitted line is a wire-contract change.

No behaviour change. `make test STATIC=1` is green.