### PR TITLE
Fix documentation that had drifted from the code

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -204,8 +204,11 @@ authority. The engine (`ap2_ptp.c`) implements:
   accuracy 0x21 (100 ns), variance 0x436A, timeSource GPS (matching captured
   iOS senders). It must out-rank the receivers' own datasets (Sonos announces
   248/248/0xFE) or the session anchor is not honored.
-- **Two-step Sync/Follow_Up** every 125 ms and Announce every 1 s, multicast
-  (224.0.1.129) on UDP 319/320, plus **unicast** copies to each timing peer.
+- **Two-step Sync/Follow_Up** every 125 ms and Announce every 1 s, **unicast**
+  on UDP 319/320 to every timing peer — Apple receivers consume the session
+  clock as unicast PTP and never join an open multicast election. The multicast
+  group (224.0.1.129) is only the fallback while the peer list is still empty,
+  before SETPEERS fills it in.
 - **Unicast negotiation** — REQUEST_UNICAST_TRANSMISSION Signaling TLVs from
   receivers are answered with GRANT TLVs (Apple receivers request unicast
   Announce/Sync/Delay_Resp this way).
@@ -252,9 +255,13 @@ grandmaster — but MA spawns one cliairplay per device. The split
 exactly T on every streaming protocol.** Legacy RAOP, RAOP-compatible AirPlay 2,
 and native AirPlay 2 members are handed the same T, then align by construction.
 The first `ACTION=START` begins the session; a `START` after an `ACTION=FLUSH`
-re-anchors the same live stream (§10) by re-basing the frozen anchor line below,
-with no reconnect and no crypto/sequence reset. The first packet carries a fresh
-restart marker and sync announcement for the new timeline. The caller can gate
+re-anchors the same live stream (§10) with no reconnect and no crypto/sequence
+reset. On the splice timeline — the default for every native session — the
+frozen anchor line below is not re-based at all: it stays exactly where the
+first START put it, and the commanded instant is expressed as a pad of encoded
+silence up to it (§10). A lapsed line, a deny-listed receiver and the RAOP
+paths re-base instead, and their first packet carries a fresh restart marker
+and sync announcement for the new timeline. The caller can gate
 the command on the one-shot `[STATUS] audio buffered_ms=` line — emitted once a
 complete transport packet is buffered (or the final short packet reaches EOF),
 and re-armed by each FLUSH — so it commits a start only after the feed is ready.
@@ -447,11 +454,12 @@ identity — receivers slaved to that clock place the anchor precisely.
 **Pacing** (realtime): frames are released against the **anchor deadline**,
 capped to the receiver's buffer. Frame f is audible at its frame-clock
 position, so its deadline is f itself; a frame delivered more than the
-receiver's `latencyMax` early overflows the buffer and is dropped (Sonos:
-88200 frames = 2.0 s). Release therefore runs up to `window` ahead of the
-deadline — the device-reported window less a 250 ms margin when known, else
-1.75 s (inside every AirPlay receiver's standard 2 s) — which fills the
-receiver's buffer before a scheduled start no matter how far ahead T lies.
+receiver's `latencyMax` early overflows the buffer and is dropped. Release
+therefore runs up to `window` ahead of the deadline — the device-reported
+window less a 250 ms margin when known, else 1.75 s (inside every AirPlay
+receiver's standard 2 s, the same assumption our own stream SETUP proposes as
+`latencyMax` 88200 frames) — which fills the receiver's buffer before a
+scheduled start no matter how far ahead T lies.
 
 **Per-process timeline offsets**: streams in one group share T, and with
 identical RTP positions two sessions from one host are wire-identical twins
@@ -536,10 +544,12 @@ connect the sender emits the initial sequence from AirPlaySender's
 5. **`updateMRNowPlayingClient`** — the serialized `NowPlayingClient` external
    representation the receiver expects.
 
-Playback state is re-sent on every start/pause/resume/stop; now-playing on
-every metadata/progress/artwork change, plus a defensive re-push every ~15 s.
-Progress itself is never streamed — the receiver extrapolates position from
-`ElapsedTime` + `Timestamp` + `PlaybackRate`, so a steady state needs no push.
+Playback state is re-sent on every start/pause/resume/stop and now-playing on
+every metadata/progress/artwork change — all caller-driven; nothing on this
+path is pushed on a timer. Progress itself is never streamed — the receiver
+extrapolates position from `ElapsedTime` + `Timestamp` + `PlaybackRate`, so a
+steady state needs no push. The ~15 s defensive state re-push belongs to the
+type-130 channel below, which is off by default.
 
 **`updateMRNowPlayingInfo` envelope.** The `npi-text` / `mergePolicy` wrapper
 is mandatory; a bare or fabricated outer type string is rejected with HTTP 400:
@@ -682,9 +692,14 @@ enum** — the two enumerations disagree, so the wire values here
 **Type-130 remote-control channel — off by default.** A dedicated
 length-prefixed protobuf data channel (ChaCha20-Poly1305 with HKDF-SHA512
 DataStream keys derived from the pair-verify shared secret) exists for *inbound*
-remote control (Siri-remote play/pause). It carries no now-playing state — the
-real sender pushes now-playing only over `/command` — and is off by default;
-`CLIAIRPLAY_MRP_TYPE130=1` enables the channel. `src/ap2_mrp.c` hand-rolls the
+remote control (Siri-remote play/pause). It is off by default because the real
+sender pushes now-playing over `/command`; `CLIAIRPLAY_MRP_TYPE130=1` enables
+it. Its outbound `SET_STATE` does carry a full now-playing picture —
+title/artist/album, duration, elapsed time, playback state and the artwork
+bytes — and while the channel is up and playback is PLAYING the feedback worker
+re-pushes it every 15 s (`MRP_STATE_REPUSH_S`) as a defensive refresh. That
+push is skipped while the channel is down, which is why the default path has no
+periodic state refresh. `src/ap2_mrp.c` hand-rolls the
 proto2 emitters, the `/command` builders, the bplist `params.data` wrapper, the
 DataStream key derivation and channel framing, and answers inbound `sync`
 frames with `rply`.
@@ -809,7 +824,7 @@ capture.
   pause parks members through standby), and the post-EOF drain/idle window
   each keep the wire fed with encoded silence, and a delivery stall
   longer than the pacing depth splice-pads the timeline forward (reported as
-  REANCHOR) instead of bursting the queued content on past timestamps when
+  REANCHOR, §12) instead of bursting the queued content on past timestamps when
   sending resumes. The 2026-07-31 fleet A/B validated the same mechanism on
   the third-party park (Sonos Era 100 pair and solo, Sonos Bookshelf, WiiM
   Pro, Edifier MS50A, Samsung HW-LS60D:
@@ -821,11 +836,18 @@ capture.
   member of a sync group, so a group splices sample-aligned); the pacing
   depth is kept shallow (600 ms) because the receiver's queued audio plays
   out before a splice is audible. A commanded instant at or behind a
-  member's head splices at that member's own head instead — silently
-  breaking the shared instant — so the flush ack carries the frozen head's
-  audible instant (`[STATUS] flushed head_unix_ms=<ms>`), the depth rides
-  `warm_lead_ms` on the `[STATUS] latency` line, and the caller anchors
-  every warm START beyond all members' heads (plus their sync adjustments).
+  member's head is corrected forward to that member's head plus the 250 ms
+  minimum warm lead, which breaks the shared instant unless the caller
+  re-aligns — so the flush ack carries the frozen head's audible instant
+  (`[STATUS] flushed head_unix_ms=<ms>`), the depth rides `warm_lead_ms` on
+  the `[STATUS] latency` line, and the caller anchors every warm START beyond
+  all members' heads (plus their sync adjustments). The correction is logged
+  at WARN and the corrected instant is what `[STATUS] started at_unix_ms=`
+  reports, so a caller detects it by comparing that against what it asked
+  for. It lands one lead beyond the head rather than at it because the
+  keepalive advances the head 1:1 with the wall clock: an ack naming the bare
+  head sends the corrective retry chasing a moving target (+212/+418/+15 ms
+  rounds, no convergence).
   A lapsed line (resume over a long-idle pipeline) re-anchors fresh — the
   clean session-start shape — and deny-listed receivers keep the classic
   warm path throughout.
@@ -835,8 +857,9 @@ capture.
   a nonzero process exit rather than a false EOF.
 - **EOF drain** — `[STATUS] eof` means the single stdin input ended (the whole
   feed, not one track). The receiver then drains at most `latency + 2 s`, and
-  the connection idles awaiting the next `START` or the orphan idle timeout /
-  `DISCONNECT`.
+  the connection idles awaiting the next `START` or `DISCONNECT`. The session
+  stays in its playing state across EOF, so the orphan timeout (§12) does not
+  cover this window — an abandoned post-EOF session is the caller's to end.
 - **Initial metadata** — pushed at the first START with a placeholder title if the
   caller has not set any (Sonos withholds audio until it has metadata; the
   native flow also requires `RTP-Info` on the metadata request — Sonos 400s
@@ -878,8 +901,9 @@ callers:
   must hold grandmaster for the session timeline (§4).
 - **Sonos household stream tracking cross-wires wire-identical sessions**
   from one host; per-process RTP timeline offsets are required (§6).
-- **Receiver buffer windows are ~2 s** (Sonos reports 88200 frames); the
-  SETUP echo of the window is optional, so pacing falls back to 1.75 s.
+- **Receiver buffer windows are ~2 s** — the AirPlay standard our own stream
+  SETUP proposes as `latencyMax` 88200 frames. The receiver's echo of the
+  window is optional (Sonos omits it), so pacing falls back to 1.75 s.
 - **Pairing posture differs by vendor**: Sonos/JBL/WiiM accept transient
   pairing (no PIN); Apple TV/HomePod require stored credentials from a PIN
   pair-setup (transient returns 200 + an in-band TLV error and silence).
@@ -891,3 +915,93 @@ callers:
   order but renders silence; moving RECORD immediately before the stream
   SETUP — the order Apple senders and owntone already use — fixes it, with
   no regression seen on Apple TV 4K or Sonos Era 100 (§3).
+
+## 12. Caller-facing output contract
+
+Everything the caller parses is one `[STATUS]` or `[EVENT]` line. **The
+contract spans both standard streams, and the split does not follow a semantic
+boundary — a parser has to read both.** stderr carries the runtime and
+lifecycle lines; stdout carries the one-shot setup lines and the remote-control
+events. The `[STATUS] mrp` family is itself split: `artwork=` on stderr,
+`path=` on stdout. stderr is unbuffered and every machine-readable stdout line
+is flushed as it is written, but the two are separate buffers, so their
+relative order is not guaranteed even when merged with `2>&1` — correlate by
+content, never by arrival order. Human-readable `LOG_*` output shares stderr,
+prefixed `[HH:MM:SS.mmm] <function>:<line>`; `--debug` changes only its
+verbosity, never its stream.
+
+| Line | Stream | Emitted |
+|---|---|---|
+| `[STATUS] route` | stdout | once, before any connect attempt |
+| `[STATUS] capabilities` | stdout | once after connect, AirPlay 2 route only |
+| `[STATUS] latency` | stdout | once after connect, AirPlay 2 route only |
+| `[STATUS] mrp path=channel` | stdout | once after connect, only when type-130 is enabled (§8) |
+| `[STATUS] mrp path=command` | stdout | on each change of the `/command` HTTP status |
+| `[EVENT] remote command=` | stdout | device-originated remote-control press |
+| `[STATUS] connected` | stderr | once, when the session is up |
+| `[STATUS] clock_ready` | stderr | after `connected`, then on material change until `state=ready` (§6) |
+| `[STATUS] audio buffered_ms=` | stderr | once per start cycle, re-armed by FLUSH (§10) |
+| `[STATUS] started` | stderr | exactly one per `ACTION=START` (§6) |
+| `[STATUS] clock_verified` / `anchor_corrected` / `content_cut` | stderr | outcomes of a cold-commit clock verification (§6) |
+| `[STATUS] flushed` (optional `head_unix_ms=`) | stderr | one per accepted `ACTION=FLUSH` (§10) |
+| `[STATUS] REANCHOR` | stderr | the timeline was shifted to recover a gap |
+| `[STATUS] playing` / `paused` | stderr | `ACTION=PLAY` / `ACTION=PAUSE`, carrying `elapsed_ms=` |
+| `[STATUS] stopped` | stderr | `ACTION=STOP`; the process then exits 0 |
+| `[STATUS] mrp artwork=` | stderr | every artwork attempt (§8) |
+| `[STATUS] eof` | stderr | the stdin input ended |
+| `[STATUS] idle_timeout` | stderr | the orphan timer fired; the process then exits 0 |
+| `[STATUS] error code=` | stderr | immediately before the `[ERROR]` line (§3a) |
+
+The utility modes print `CREDENTIALS: <192 hex>` (`--pair-setup`) and
+`cliairplay <version> check` (`--check`) on stdout; the pair-setup PIN prompt
+goes to stderr precisely so the credentials line stays clean.
+
+**Route and capabilities.**
+
+```
+[STATUS] route protocol=<raop|airplay2> flow=<legacy|native|raop-compat> timing=<ptp|ntp> buffered=0
+[STATUS] capabilities requested=0x<hex> realtime_formats=0x<hex> realtime_known=<0|1> buffered_formats=0x<hex> buffered_known=<0|1>
+```
+
+`route` reports the resolved route (§2) before the first connect attempt, so it
+describes a session that then fails to connect just as well as one that
+succeeds, and its `timing=` is route intent rather than effective timing — a
+PTP session that falls back to the NTP responder still reports `timing=ptp`
+while `[STATUS] clock_ready` reports `mode=ntp`. `buffered=0` is a constant,
+kept so the line's shape does not change (§9). `capabilities` carries the
+selected `audioFormat` and the device's advertised format tables (§7); a
+`*_known=0` means the device published no such table, and `requested=0x0` on
+the RAOP-compat flow, which never reads `/info`. Both tables are evidence, not
+proof — hardware understates and overstates them (§11).
+
+**MediaRemote paths.** `[STATUS] mrp path=command status=<http>` is the
+`POST /command` status, edge-triggered: it prints only when the status changes
+to a new positive value, so a healthy session emits one `status=200` and
+nothing further. `[STATUS] mrp path=channel status=<0|1>` reports whether the
+type-130 channel came up and appears only when that channel is enabled at all
+(§8), so a stock session never sees it.
+
+**REANCHOR.**
+
+```
+[STATUS] REANCHOR shifted_frames=<u64> total_shifted_frames=<u64> sample_rate=<hz>
+```
+
+The timeline was padded forward to recover a gap: PCM starvation (the feed
+produced nothing within the read window) or a delivery stall (the head lapsed
+at or behind the wall clock through a process freeze or a network dropout).
+Both counts are in PCM frames — divide by `sample_rate` for seconds — where
+`shifted_frames` is this event alone and `total_shifted_frames` is **cumulative
+since the last START, not since process start**, because a commanded start
+zeroes the drift baseline on both sides. Native AirPlay 2 only, and only while
+streaming. Repeated recovery while a pad is still draining folds into the pad
+already queued, so one stall produces one line rather than a stream of them.
+
+**Orphan idle timeout.** A 120 s safety net ends a session nobody is driving.
+It arms when the session is created (so, at connect), on `ACTION=STANDBY`, and
+on each successful `ACTION=FLUSH` — a FLUSH whose transport leg fails does not
+re-arm it. Only a successful `START` disarms it. On expiry the binary emits
+`[STATUS] idle_timeout` and the process exits 0, with no `[ERROR]` and no
+`[STATUS] stopped`; a session that connects and never receives a `START` ends
+exactly this way. `ACTION=PAUSE` and EOF both leave the session in its playing
+state, so neither arms the timer.

--- a/README.md
+++ b/README.md
@@ -239,9 +239,9 @@ stdin, the single persistent audio input for the whole process lifetime.
   it reports an instant the receiver can actually seat. Wait for the ack rather
   than assuming it is immediate; exactly one arrives per START.
 - `ACTION=FLUSH` — in-place warm flush for seek/next: it discards the internal
-  ring and drains stdin to empty, acks with
-  `[STATUS] flushed head_unix_ms=<ms>`, and keeps buffering the next track
-  until the next `START`. The one-shot `[STATUS] audio buffered_ms=<ms>` line
+  ring and drains stdin to empty, acks with `[STATUS] flushed`, and keeps
+  buffering the next track until the next `START`. The one-shot
+  `[STATUS] audio buffered_ms=<ms>` line
   fires again when the next track's feed has a complete packet buffered, or its
   final short packet reaches EOF.
   Every native AirPlay 2 session runs a splice timeline: nothing is sent to the
@@ -251,13 +251,15 @@ stdin, the single persistent audio input for the whole process lifetime.
   the bitstream stays contiguous on one immutable anchor line. Apple receivers
   require it (any discard, re-anchor or stamp jump makes them emit a short
   noise burst) and it measured clean on every other receiver class, so it is
-  the default for all of them. `head_unix_ms=<ms>` is the audible instant of
-  the frozen delivery head: a commanded start at or behind a member's head is
+  the default for all of them. On a live splice timeline the ack carries
+  `head_unix_ms=<ms>`, the audible instant of the frozen delivery head: a
+  commanded start at or behind a member's head is
   corrected forward to that head plus 250 ms, so anchor every warm START beyond
   all members' heads and check `[STATUS] started at_unix_ms=` against what you
   asked for.
   The RAOP paths flush the receiver for real (RTSP FLUSH), go quiet until the
-  next `START`, and ack with a bare `[STATUS] flushed`.
+  next `START`, and ack without the field — as does a flush that arrives before
+  the first `START`, when there is no head yet.
 - Session lifecycle: `ACTION=STANDBY` (silence the receiver, keep the connection
   warm), `ACTION=DISCONNECT` (end the session).
 - Transport: `ACTION=PLAY|PAUSE|STOP`.

--- a/README.md
+++ b/README.md
@@ -238,22 +238,26 @@ stdin, the single persistent audio input for the whole process lifetime.
   is withheld until that clock is measured (up to the anchor, never longer) so
   it reports an instant the receiver can actually seat. Wait for the ack rather
   than assuming it is immediate; exactly one arrives per START.
-- `ACTION=FLUSH` — in-place warm flush for seek/next: flush the receiver (RTSP
-  FLUSH), discard the internal ring, and drain stdin to empty; after the receiver
-  accepts the flush, acks with `[STATUS] flushed` and keeps buffering the next
-  track while sending nothing until the next `START` (idle-primed; the Apple
-  splice timeline sends keepalive silence instead). The one-shot
-  `[STATUS] audio buffered_ms=<ms>` line fires again when the next track's feed
-  has a complete packet buffered, or its final short packet reaches EOF.
-  On Apple receivers the native flow instead runs a splice timeline (no receiver
-  flush, one immutable anchor line; any discard, re-anchor or stamp jump makes
-  them emit a short noise burst): the queued audio — kept shallow, reported as
-  `warm_lead_ms` on the `[STATUS] latency` line — plays out and the next `START`
-  splices the new track at the commanded instant, filling the gap with encoded
-  silence so the bitstream stays contiguous.
-  The ack then reads `[STATUS] flushed head_unix_ms=<ms>` (the audible instant
-  of the frozen delivery head); the commanded start must land beyond every
-  member's head or that member splices at its own head instead.
+- `ACTION=FLUSH` — in-place warm flush for seek/next: it discards the internal
+  ring and drains stdin to empty, acks with
+  `[STATUS] flushed head_unix_ms=<ms>`, and keeps buffering the next track
+  until the next `START`. The one-shot `[STATUS] audio buffered_ms=<ms>` line
+  fires again when the next track's feed has a complete packet buffered, or its
+  final short packet reaches EOF.
+  Every native AirPlay 2 session runs a splice timeline: nothing is sent to the
+  receiver, its queued audio — kept shallow, reported as `warm_lead_ms` on the
+  `[STATUS] latency` line — simply plays out, and the next `START` splices the
+  new track at the commanded instant, filling the gap with encoded silence so
+  the bitstream stays contiguous on one immutable anchor line. Apple receivers
+  require it (any discard, re-anchor or stamp jump makes them emit a short
+  noise burst) and it measured clean on every other receiver class, so it is
+  the default for all of them. `head_unix_ms=<ms>` is the audible instant of
+  the frozen delivery head: a commanded start at or behind a member's head is
+  corrected forward to that head plus 250 ms, so anchor every warm START beyond
+  all members' heads and check `[STATUS] started at_unix_ms=` against what you
+  asked for.
+  The RAOP paths flush the receiver for real (RTSP FLUSH), go quiet until the
+  next `START`, and ack with a bare `[STATUS] flushed`.
 - Session lifecycle: `ACTION=STANDBY` (silence the receiver, keep the connection
   warm), `ACTION=DISCONNECT` (end the session).
 - Transport: `ACTION=PLAY|PAUSE|STOP`.
@@ -264,10 +268,18 @@ stdin, the single persistent audio input for the whole process lifetime.
   `ACTION=SENDMETA` to push the set.
 
 `[STATUS] stopped` acknowledges `ACTION=STOP` once playback has been torn down.
-The process stays up, so a later `ACTION=START` can open a new session.
+`STOP` is terminal: the audio loop exits, the connection is torn down and the
+process exits 0, the same shape as `ACTION=DISCONNECT`. To keep a session
+reusable, use `ACTION=FLUSH` (warm seek/next) or `ACTION=STANDBY` (warm park) —
+both leave the process and the connection up for a later `ACTION=START`.
 
 `[STATUS] eof` means the stdin input ended — the whole feed is done, not just
 one track.
+
+Status lines are split across both streams: the lifecycle lines on stderr, and
+the one-shot setup lines (`route`, `capabilities`, `latency`) plus
+remote-control events on stdout — so a parser has to read both. `DESIGN.md` §12
+lists every line, the stream it uses, and when it fires.
 
 Some receivers (notably Sonos) do not emit audio until they have received
 metadata; the binary pushes an initial metadata set at the first commanded

--- a/TODO.md
+++ b/TODO.md
@@ -12,4 +12,6 @@ Genuinely open work only. Completed work lives in git history.
       caller can pick the best format per device before the first stream —
       the CLI half of fully automatic 24-bit selection (no user toggle; the
       format tables are evidence, the Apple-model check covers understating
-      receivers).
+      receivers). The fetch and the format-table parse already run as part of
+      the normal connect; what is missing is the flag that stops there and
+      exits.

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3103,8 +3103,9 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
          * group splices sample-aligned by construction. The feasibility
          * floor is the head itself: anything earlier would require
          * discarding queued audio (the noise trigger), so such a request is
-         * corrected FORWARD to the head and the ack carries the truth. A
-         * start of 0 splices at the head — the earliest possible point. */
+         * corrected FORWARD to head + AP2_MIN_WARM_LEAD_MS and the ack
+         * carries the truth. A start of 0 splices at the head — the earliest
+         * possible point. */
         uint64_t head_ntp = TS2NTP(p->head_ts, p->format.sample_rate);
         uint64_t requested =
             start_unix_ms ? ap2_unix_ms_to_ntp(start_unix_ms) : 0;
@@ -3244,9 +3245,10 @@ bool ap2cl_accept_frames(struct ap2cl_s *p)
          * Contract: frame f is AUDIBLE at its frame-clock position (the anchor
          * line starts one lead early), so f's deadline IS f. A frame delivered
          * more than the receiver's latencyMax before its deadline overflows
-         * its buffer and is dropped (Sonos: 88200 = 2.0s) — release at most
-         * `window` ahead: the reported window when known, else 1.75s (inside
-         * every AirPlay receiver's standard 2s). Delivery therefore
+         * its buffer and is dropped — release at most `window` ahead: the
+         * reported window when known, else 1.75s (inside every AirPlay
+         * receiver's standard 2s, the same assumption our own stream SETUP
+         * proposes as latencyMax=88200). Delivery therefore
          * runs up to ~window AHEAD of playback from the very first sample —
          * the receiver's buffer is filled before the scheduled start and the
          * start cannot underrun — while scheduled group starts stay safe no
@@ -4386,10 +4388,11 @@ int ap2cl_warm_lead_ms(struct ap2cl_s *p)
 /* Wall-clock instant (unix ms) at which the current delivery head becomes
  * audible on the splice timeline. The flush ack carries it so the caller can
  * anchor the warm START beyond EVERY member's queued audio: a commanded
- * instant at or behind a member's head splices at that member's own head
- * instead, silently breaking the shared instant (and the session's recorded
- * start time, which late joiners anchor against). 0 when the stream is not on
- * the splice timeline (no constraint). */
+ * instant at or behind a member's head is corrected forward to that head plus
+ * AP2_MIN_WARM_LEAD_MS, which breaks the shared instant (and the session's
+ * recorded start time, which late joiners anchor against) unless the caller
+ * re-aligns the group on the instant the started ack reports. 0 when the
+ * stream is not on the splice timeline (no constraint). */
 uint64_t ap2cl_splice_head_unix_ms(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || !p->splice_timeline || !p->head_ts)

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -139,7 +139,8 @@ enum mrp_ext_field {
  * MRP timestamps are doubles on this timebase. */
 #define MRP_APPLE_EPOCH_OFFSET 978307200.0
 
-/* Cadence of the defensive state re-push from ap2_mrp_tick (seconds). */
+/* Cadence of the defensive state re-push that ap2_mrp_prepare_state_push()
+ * arms for the /feedback keepalive worker (seconds, type-130 channel only). */
 #define MRP_STATE_REPUSH_S 15
 #define MRP_WRITE_TIMEOUT_MS 1000
 #define MRP_EVENT_LOG_TEXT_MAX 96

--- a/src/ap2_ptp.c
+++ b/src/ap2_ptp.c
@@ -163,9 +163,10 @@ struct ap2_ptp_ctx {
     uint16_t signaling_seq;
     char *peers[PTP_MAX_PEERS];
     int npeers;
-    /* When true, timing messages are ALSO sent unicast to each peer. Multicast
-     * is the standard/default transport (this stays false); the peer list and
-     * this switch keep unicast one flip away for on-device experimentation. */
+    /* Timing messages go unicast to every timing peer; multicast is only the
+     * fallback while the peer list is still empty. Set true at create and never
+     * cleared — Apple receivers consume the session clock as unicast PTP and
+     * never join an open multicast election. */
     bool unicast_mirror;
 
     /* ---- BMCA / slave state (guarded by lock) ---- */

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -21,10 +21,13 @@
  *
  *   START(start time)  -> first call: full session start; a call after a FLUSH
  *                         re-bases the frozen anchor and resumes from the ring
- *   FLUSH              -> stop sending, RTSP-FLUSH the receiver, discard the
+ *   FLUSH              -> stop sending, take the transport's warm-boundary
+ *                         action (splice timeline: leave the receiver's queued
+ *                         audio playing and swap the content behind it; RAOP
+ *                         lanes: RTSP/libraop FLUSH it away), discard the
  *                         ring, drain the input to EAGAIN; stream goes
- *                         idle-primed (keeps buffering, sends nothing) until the
- *                         next START. Emits `[STATUS] flushed`.
+ *                         idle-primed (keeps buffering, sends nothing) until
+ *                         the next START. Emits `[STATUS] flushed`.
  *   STANDBY            -> stop playback, keep the connection warm
  *   END                -> real teardown (DISCONNECT / idle timeout)
  *
@@ -125,16 +128,18 @@ typedef enum {
  * verify the contract, re-align a group with a corrective START, and log the
  * mismatch. A `start_unix_ms` of 0 asks the transport to pick (earliest).
  * AP2_COMMIT_FAILED is terminal (the caller then ends the session so MA can
- * fall back cold). `flush` discards the receiver's buffered audio in place
- * (RTSP FLUSH / libraop flush), keeping the session and timeline continuity;
- * it returns false when the receiver did not accept the flush.
+ * fall back cold). `flush` performs the transport's warm-boundary action,
+ * keeping the session and timeline continuity: on the splice timeline nothing
+ * is sent — the receiver's queued audio plays out and the content is swapped
+ * behind it — while the RAOP lanes discard the buffered audio in place (RTSP
+ * FLUSH / libraop flush). It returns false when that action failed.
  * `warm_head_unix_ms` (optional) reports the audible instant of the delivery
  * head frozen by the flush (unix ms; 0 = no constraint); it rides the
  * `[STATUS] flushed` ack as the caller's anchor hint.
  */
 typedef struct {
     void (*quiesce)(void *transport);    /* pause audio sends across a command */
-    bool (*flush)(void *transport);      /* RTSP-flush receiver, keep session */
+    bool (*flush)(void *transport);      /* warm-boundary action, keep session */
     ap2_commit_result_t (*commit)(void *transport, uint64_t start_unix_ms,
                                   uint64_t *at_unix_ms);
     void (*resume)(void *transport);     /* resume sends after the command */

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -20,7 +20,9 @@
  * possible": the transport picks and the ack reports the pick.
  *
  *   START(start time)  -> first call: full session start; a call after a FLUSH
- *                         re-bases the frozen anchor and resumes from the ring
+ *                         resumes from the ring at the commanded instant (the
+ *                         splice timeline pads silence up to it on its
+ *                         immutable anchor line; the other lanes re-base)
  *   FLUSH              -> stop sending, take the transport's warm-boundary
  *                         action (splice timeline: leave the receiver's queued
  *                         audio playing and swap the content behind it; RAOP
@@ -34,7 +36,8 @@
  * The input is never re-opened across a FLUSH: the caller (MA) restarts only
  * the per-seek transcoder feeding the same persistent fd, so sequence numbers
  * and audio nonces are never reset within the connection and crypto state stays
- * valid across the boundary. The media timeline re-bases per START.
+ * valid across the boundary. Each START places the media timeline at the
+ * commanded instant.
  *
  * Command pipe verbs (newline-terminated KEY=VALUE, existing verbs unchanged):
  *   START_UNIX_MS=<ms|0>      audible start instant; 0 = ASAP at the minimum
@@ -119,7 +122,7 @@ typedef enum {
  * Callbacks the session engine invokes from its own threads. All are required
  * except `warm_head_unix_ms`. `commit` performs the START transport work on a
  * LIVE connection: on the first start it begins the session; after a FLUSH it
- * re-bases the timeline. The commanded instant is honored exactly when
+ * resumes the timeline. The commanded instant is honored exactly when
  * feasible (padding silence or re-anchoring as the transport's lane
  * requires); an instant the transport cannot honor — behind its feasibility
  * floor — is CORRECTED FORWARD to the earliest feasible instant instead of

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -492,7 +492,7 @@ static void status_elapsed_legacy(uint64_t elapsed_ms, uint64_t frames, struct r
 /*
  * Truncate s32le samples to s24le (packed 3 bytes) for ALAC encoder.
  * Input: 4 bytes per sample (s32le), Output: 3 bytes per sample (s24le)
- * Takes the lower 3 bytes of each 32-bit LE sample (bytes 0,1,2 = bits 0-23).
+ * Takes the upper 3 bytes of each 32-bit LE sample (bytes 1,2,3 = bits 8-31).
  * Returns number of output bytes.
  */
 static int truncate_32to24(const uint8_t *in, int in_bytes, uint8_t *out)
@@ -1766,7 +1766,8 @@ static void print_usage(const char *name)
     printf("                             clamped into the device-reported window)\n");
     printf("  --dacp <id>                DACP ID\n");
     printf("  --activeremote <id>        Active Remote ID\n");
-    printf("  --cmdpipe <path>           Required named pipe for commands/audio staging\n");
+    printf("  --cmdpipe <path>           Required named pipe for commands and metadata\n");
+    printf("                             (audio is the process stdin, not this pipe)\n");
     printf("  --udn <name>               UDN name for mDNS\n");
     printf("  --samplerate <rate>        Sample rate (default: 44100)\n");
     printf("  --bitdepth <bits>          Bit depth: 16 or 24 (default: 16). 24-bit\n");


### PR DESCRIPTION
Several statements in `DESIGN.md`, `README.md` and a handful of source comments described behaviour the code no longer has, and in places contradicted each other. Every item below was checked against the source.

- Warm flush: the splice timeline is the default for **every** native AirPlay 2 session and sends nothing to the receiver — the docs presented it as an Apple-only path taken instead of an RTSP flush, and described a receiver acceptance that never happens
- A warm start behind a member's playback head is corrected forward to that head plus 250 ms and reported in the start ack, not silently placed at the head
- PTP timing goes unicast to each timing peer; multicast is only the fallback before the peer list is known
- `latencyMax` 88200 is the value cliairplay proposes in its own stream SETUP, not something Sonos reports back — Sonos omits the echo, which is why pacing falls back to 1.75 s
- The ~15 s now-playing re-push exists only on the type-130 channel, which is off by default; that channel does carry now-playing state
- `ACTION=STOP` ends the process — `FLUSH` and `STANDBY` are the warm paths that keep a session reusable
- New `DESIGN.md` §12 documents the status-line contract: which lines go to stdout and which to stderr, plus `route`, `capabilities`, `mrp path=`, `REANCHOR` and the 120 s orphan timeout
- `--help` no longer claims the command pipe carries audio, and now says where audio actually arrives
- `TODO.md`: both entries are still open; the probe entry now notes the `/info` fetch and parse already exist

No behaviour changes — comments, docs and one usage string only. `make STATIC=1 test` passes.