### PR TITLE
Make CLIAIRPLAY_MRP_TYPE130=0 actually turn the channel off

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -694,7 +694,8 @@ length-prefixed protobuf data channel (ChaCha20-Poly1305 with HKDF-SHA512
 DataStream keys derived from the pair-verify shared secret) exists for *inbound*
 remote control (Siri-remote play/pause). It is off by default because the real
 sender pushes now-playing over `/command`; `CLIAIRPLAY_MRP_TYPE130=1` enables
-it. Its outbound `SET_STATE` does carry a full now-playing picture —
+it. Its value is parsed the same way as `CLIAIRPLAY_MRP`, so `0`/`false`/`off`
+keep it off. Its outbound `SET_STATE` does carry a full now-playing picture —
 title/artist/album, duration, elapsed time, playback state and the artwork
 bytes — and while the channel is up and playback is PLAYING the feedback worker
 re-pushes it every 15 s (`MRP_STATE_REPUSH_S`) as a defensive refresh. That

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -375,6 +375,29 @@ static void ap2_remote_command_received(
         p->remote_command_cb(command, p->remote_command_userdata);
 }
 
+/* ---- Environment toggles ---- */
+
+/* Read a diagnostic on/off toggle: `0`, `false` and `off` disable it, any
+ * other value enables it, and an unset variable leaves the compiled-in
+ * default in place. */
+static bool ap2_env_enabled(const char *name, bool unset_default)
+{
+    const char *setting = getenv(name);
+    if (!setting) return unset_default;
+    if (!strcmp(setting, "0") || !strcmp(setting, "false") ||
+        !strcmp(setting, "off"))
+        return false;
+    return true;
+}
+
+/* Single answer for the opt-in type-130 channel: the setup site and the
+ * [STATUS] reporter must agree, or the status line reports on a channel that
+ * was never set up. */
+static bool ap2_mrp_type130_enabled(void)
+{
+    return ap2_env_enabled("CLIAIRPLAY_MRP_TYPE130", false);
+}
+
 /* ---- Native AP2 failure reporting ---- */
 
 /* True for the statuses a receiver uses to refuse an unauthenticated or
@@ -1997,7 +2020,7 @@ static bool ap2_native_connect(struct ap2cl_s *p)
      * default; now-playing rides /command (ap2cl_mrp_register + ap2cl_mrp_push).
      * Set CLIAIRPLAY_MRP_TYPE130=1 to re-enable the channel (future remote-
      * control RX). Best-effort; audio is up regardless. */
-    if (getenv("CLIAIRPLAY_MRP_TYPE130"))
+    if (ap2_mrp_type130_enabled())
         ap2_native_setup_mrp(p);
 
     /* Create ALAC encoder */
@@ -3940,10 +3963,7 @@ static void ap2_mrp_ready(struct ap2cl_s *p)
     if (p->mrp || p->flow != FLOW_NATIVE_AP2 || !p->auth_credentials ||
         p->sock_fd < 0 || p->events_sock < 0 || !p->session_uuid[0])
         return;
-    const char *setting = getenv("CLIAIRPLAY_MRP");
-    if (setting && (!strcmp(setting, "0") || !strcmp(setting, "false") ||
-                    !strcmp(setting, "off")))
-        return;
+    if (!ap2_env_enabled("CLIAIRPLAY_MRP", true)) return;
     p->mrp = ap2_mrp_create(p->device.address, p->device.port, p->auth_credentials,
                             p->dacp_id, p->device.name,
                             p->session_uuid, p->group_uuid,
@@ -4167,10 +4187,10 @@ int ap2cl_mrp_push_progress(struct ap2cl_s *p)
 int ap2cl_mrp_channel_status(struct ap2cl_s *p)
 {
     if (!p || p->flow != FLOW_NATIVE_AP2 || !p->auth_credentials) return -1;
-    /* The type-130 channel is opt-in (see ap2_native_connect §6d); when it is
+    /* The type-130 channel is opt-in (see ap2_native_connect §6b); when it is
      * not attempted, report "not applicable" so the [STATUS] path=channel line
      * is suppressed and only path=command (the active now-playing path) shows. */
-    if (!getenv("CLIAIRPLAY_MRP_TYPE130")) return -1;
+    if (!ap2_mrp_type130_enabled()) return -1;
     pthread_mutex_lock(&p->mrp_lock);
     int status = (p->mrp && ap2_mrp_is_connected(p->mrp)) ? 1 : 0;
     pthread_mutex_unlock(&p->mrp_lock);
@@ -4588,6 +4608,16 @@ void ap2cl_test_set_apple_model(struct ap2cl_s *p, bool apple)
 bool ap2cl_test_apple_model_default(const char *txt, const char *am)
 {
     return ap2_apple_model(txt, am);
+}
+
+bool ap2cl_test_env_enabled(const char *name, bool unset_default)
+{
+    return ap2_env_enabled(name, unset_default);
+}
+
+bool ap2cl_test_mrp_type130_enabled(void)
+{
+    return ap2_mrp_type130_enabled();
 }
 
 /* Plant a probe-streak snapshot where the shared-daemon poller would put

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -48,6 +48,8 @@ unsigned long long ap2cl_test_rtx_expired(struct ap2cl_s *p);
 void ap2cl_test_set_use_ptp(struct ap2cl_s *p, bool enable);
 void ap2cl_test_set_apple_model(struct ap2cl_s *p, bool apple);
 bool ap2cl_test_apple_model_default(const char *txt, const char *am);
+bool ap2cl_test_env_enabled(const char *name, bool unset_default);
+bool ap2cl_test_mrp_type130_enabled(void);
 void ap2cl_test_inject_clock_exchange(struct ap2cl_s *p, uint32_t count,
                                       uint64_t first_ms, uint64_t third_ms);
 void ap2cl_test_clear_clock_exchange(struct ap2cl_s *p);
@@ -480,6 +482,39 @@ static void test_route_with_password(void)
         false, false);
     assert(legacy.use_raop);
     puts("ap2_client route password selection tests passed");
+}
+
+/* Both MediaRemote toggles parse their value, so the spellings a user reaches
+ * for to switch something off do that from either default — the /command path
+ * that ships on, and the type-130 channel that ships off. */
+static void test_env_toggle_parsing(void)
+{
+    static const char *const off[] = { "0", "false", "off" };
+    static const char *const on[] = { "1", "yes", "" };
+
+    /* Unset keeps each toggle's own default: /command on, type-130 off. */
+    assert(unsetenv("CLIAIRPLAY_MRP") == 0);
+    assert(unsetenv("CLIAIRPLAY_MRP_TYPE130") == 0);
+    assert(ap2cl_test_env_enabled("CLIAIRPLAY_MRP", true));
+    assert(!ap2cl_test_mrp_type130_enabled());
+
+    for (size_t i = 0; i < sizeof(off) / sizeof(off[0]); i++) {
+        assert(setenv("CLIAIRPLAY_MRP", off[i], 1) == 0);
+        assert(setenv("CLIAIRPLAY_MRP_TYPE130", off[i], 1) == 0);
+        assert(!ap2cl_test_env_enabled("CLIAIRPLAY_MRP", true));
+        assert(!ap2cl_test_mrp_type130_enabled());
+    }
+    /* The documented CLIAIRPLAY_MRP_TYPE130=1 spelling enables (DESIGN.md §8),
+     * and no other value is read as off. */
+    for (size_t i = 0; i < sizeof(on) / sizeof(on[0]); i++) {
+        assert(setenv("CLIAIRPLAY_MRP", on[i], 1) == 0);
+        assert(setenv("CLIAIRPLAY_MRP_TYPE130", on[i], 1) == 0);
+        assert(ap2cl_test_env_enabled("CLIAIRPLAY_MRP", true));
+        assert(ap2cl_test_mrp_type130_enabled());
+    }
+    assert(unsetenv("CLIAIRPLAY_MRP") == 0);
+    assert(unsetenv("CLIAIRPLAY_MRP_TYPE130") == 0);
+    puts("ap2_client env toggle parsing tests passed");
 }
 
 /* The splice timeline is the default for every native session; the deny-list
@@ -1442,6 +1477,7 @@ int main(void)
     test_feedback_stream_counts();
     test_native_flush_resume_reuses_rtsp_session();
     test_native_flush_rejects_receiver_error();
+    test_env_toggle_parsing();
     test_splice_default_resolution();
     test_splice_timeline_warm_path();
     test_splice_delivery_gap_recovery();


### PR DESCRIPTION
The `CLIAIRPLAY_MRP_TYPE130` escape hatch only checked whether the variable was
set, not what it was set to, so `CLIAIRPLAY_MRP_TYPE130=0` switched the
type-130 MediaRemote channel **on** — the opposite of what setting it to 0
means. It now reads its value the same way the neighbouring `CLIAIRPLAY_MRP`
toggle always has.

- Both toggles share one value parser: `0`, `false` and `off` disable, anything
  else enables, and leaving the variable unset keeps each toggle's own default
  (`/command` on, type-130 off).
- The two type-130 call sites — channel setup and the `[STATUS]` line — now ask
  the same function, so the status line can no longer report on a channel that
  was never set up.
- `CLIAIRPLAY_MRP_TYPE130=1` keeps working exactly as documented.