### PR TITLE
End a forgotten AirPlay session after the music stops

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -858,9 +858,9 @@ capture.
   a nonzero process exit rather than a false EOF.
 - **EOF drain** — `[STATUS] eof` means the single stdin input ended (the whole
   feed, not one track). The receiver then drains at most `latency + 2 s`, and
-  the connection idles awaiting the next `START` or `DISCONNECT`. The session
-  stays in its playing state across EOF, so the orphan timeout (§12) does not
-  cover this window — an abandoned post-EOF session is the caller's to end.
+  the connection idles awaiting the next `START`, the orphan idle timeout, or
+  `DISCONNECT`. The session stays in its playing state across EOF, so the
+  timeout arms on the input closing rather than on that state (§12).
 - **Initial metadata** — pushed at the first START with a placeholder title if the
   caller has not set any (Sonos withholds audio until it has metadata; the
   native flow also requires `RTP-Info` on the metadata request — Sonos 400s
@@ -999,10 +999,22 @@ streaming. Repeated recovery while a pad is still draining folds into the pad
 already queued, so one stall produces one line rather than a stream of them.
 
 **Orphan idle timeout.** A 120 s safety net ends a session nobody is driving.
-It arms when the session is created (so, at connect), on `ACTION=STANDBY`, and
-on each successful `ACTION=FLUSH` — a FLUSH whose transport leg fails does not
-re-arm it. Only a successful `START` disarms it. On expiry the binary emits
-`[STATUS] idle_timeout` and the process exits 0, with no `[ERROR]` and no
-`[STATUS] stopped`; a session that connects and never receives a `START` ends
-exactly this way. `ACTION=PAUSE` and EOF both leave the session in its playing
-state, so neither arms the timer.
+It arms when the session is created (so, at connect), on `ACTION=STANDBY`, on
+each successful `ACTION=FLUSH` — a FLUSH whose transport leg fails does not
+re-arm it — and when the input closes. Only a successful `START` disarms it,
+and a `START` after the input closed re-opens the window rather than disarming
+it for good, so a caller that keeps commanding is never cut off. On expiry the
+binary emits `[STATUS] idle_timeout` and the process exits 0, with no
+`[ERROR]` and no `[STATUS] stopped`; a session that connects and never
+receives a `START` ends exactly this way, and so does one played to EOF and
+then abandoned.
+
+The EOF arming is keyed on the input CLOSING, not on the drain finishing or
+the ring emptying. A closed stdin is the end of the whole feed — a warm
+seek/next is a `FLUSH`, which keeps the writer open — so no later audio can
+reach the session and what remains is a bounded playout of the ring and the
+receiver's queue. Keying it on the close also covers a session that was paused
+when the input closed, where the audio loop never reads and so never observes
+the ring run dry. `ACTION=PAUSE` on its own does not arm the timer: a paused
+session is still being driven and routine pauses outlast 120 s, while a caller
+that dies while paused closes its end of stdin and arrives as the EOF case.

--- a/src/ap2_session.c
+++ b/src/ap2_session.c
@@ -200,6 +200,13 @@ static void *reader_thread(void *arg)
             int read_errno = errno;
             pthread_mutex_lock(&s->lock);
             s->ring.eof = true;
+            /* Open the orphan window here. A closed input is the end of the
+             * whole feed (a warm seek/next is a FLUSH, which keeps the writer
+             * open), so what remains is a bounded playout — the ring, then the
+             * receiver's queue — and no later audio can arrive to disarm it.
+             * A caller that never comes back gets the same [STATUS]
+             * idle_timeout as one that never started; a START re-opens it. */
+            s->idle_since_ms = ap2_io_monotonic_ms();
             if (n == 0 && !s->audio_seen && s->ring.fill > 0) {
                 /* A final short input can still form one silence-padded packet. */
                 s->audio_seen = true;
@@ -358,6 +365,10 @@ ap2_commit_result_t ap2_session_start(struct ap2_session_s *s,
     }
     s->epoch++;
     s->state = AP2_SESSION_PLAYING;
+    /* The caller is driving the session, so the orphan window re-opens from
+     * here. It only bites after the input closed, where PLAYING alone no
+     * longer holds the timeout off. */
+    s->idle_since_ms = ap2_io_monotonic_ms();
     pthread_cond_broadcast(&s->can_read);
     pthread_cond_broadcast(&s->can_write);
     pthread_mutex_unlock(&s->lock);
@@ -540,7 +551,14 @@ void ap2_session_poll(struct ap2_session_s *s)
 {
     if (!s || s->idle_timeout_ms <= 0) return;
     pthread_mutex_lock(&s->lock);
-    bool idle = s->state == AP2_SESSION_IDLE || s->state == AP2_SESSION_STANDBY;
+    /* Idle is "nothing the caller commanded is still running": the pre-start
+     * and post-flush waits, a standby park, and a stream whose input closed.
+     * That last one still reads as PLAYING while the ring and the receiver's
+     * queue drain (bounded, and far inside any sane timeout), which is why the
+     * state alone cannot answer this. */
+    bool idle = s->state == AP2_SESSION_IDLE ||
+                s->state == AP2_SESSION_STANDBY ||
+                (s->state == AP2_SESSION_PLAYING && s->ring.eof);
     if (idle && ap2_io_monotonic_ms() - s->idle_since_ms >=
                     (uint64_t)s->idle_timeout_ms) {
         s->state = AP2_SESSION_ENDED;

--- a/src/ap2_session.h
+++ b/src/ap2_session.h
@@ -158,8 +158,12 @@ typedef struct {
  * :param ops: transport quiesce/flush/commit/resume/stop + status callbacks.
  * :param byte_rate: PCM byte rate of the input format (ring sizing/timing).
  * :param ready_bytes: buffered PCM required before the one-shot audio status.
- * :param idle_timeout_ms: end the session after this long idle (no playing
- *                         stream), an orphan safety net; 0 disables it.
+ * :param idle_timeout_ms: end the session after this long without the caller
+ *                         driving it — the pre-start and post-flush idle
+ *                         waits, a standby park, and a stream whose input has
+ *                         closed (no further audio can reach it, so the
+ *                         post-EOF drain and wait are covered too). An orphan
+ *                         safety net; 0 disables it.
  * :param input_fd: PCM input descriptor (normally the process stdin). The
  *                  engine duplicates it, drives it non-blocking, and reads it
  *                  for the whole session; the caller keeps ownership of its own

--- a/tests/test_ap2_session.c
+++ b/tests/test_ap2_session.c
@@ -167,6 +167,18 @@ static bool wait_for_count(atomic_int *counter, int want, int timeout_ms)
     return atomic_load(counter) >= want;
 }
 
+/* Block until the reader thread has seen the input close: a read reporting the
+ * stream fully consumed is the observable proof, and the orphan window is
+ * stamped from that same moment. */
+static bool wait_for_input_eof(struct ap2_session_s *session)
+{
+    uint64_t deadline = ap2_io_monotonic_ms() + 2000;
+    uint8_t byte;
+    while (ap2_io_monotonic_ms() < deadline)
+        if (ap2_session_read(session, &byte, 1, 100) == -1) return true;
+    return false;
+}
+
 static void test_start_streams_the_input(void)
 {
     static const uint8_t audio[] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60};
@@ -443,6 +455,71 @@ static void test_idle_timeout_ends_session(void)
     assert(close(write_fd) == 0);
 }
 
+/* A session played to EOF and then abandoned is the orphan the net exists for:
+ * it stays PLAYING (nothing moves it out), so the timeout has to arm on the
+ * closed input instead. A stream still being fed must not be touched. */
+static void test_idle_timeout_ends_an_abandoned_post_eof_session(void)
+{
+    static const uint8_t audio[] = {0x50, 0x51, 0x52, 0x53};
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 20, &write_fd);
+
+    feed(write_fd, audio, sizeof(audio));
+    assert(ap2_session_start(session, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
+    read_exact(session, audio, sizeof(audio));
+
+    /* Playing with the writer still open: the caller is feeding us, so a quiet
+     * stretch (a pause, a slow producer) is not an orphan. */
+    usleep(60000);
+    ap2_session_poll(session);
+    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
+    assert(atomic_load(&state.idle_timeouts) == 0);
+
+    assert(close(write_fd) == 0);
+    assert(wait_for_input_eof(session));
+    usleep(60000);
+    ap2_session_poll(session);
+    assert(ap2_session_state(session) == AP2_SESSION_ENDED);
+    assert(atomic_load(&state.idle_timeouts) == 1);
+
+    ap2_session_destroy(session);
+    status_state = NULL;
+}
+
+/* A caller commanding a fresh START after the input closed is driving the
+ * session again, so the window re-opens from that START rather than expiring
+ * on the stamp the EOF left behind. */
+static void test_start_after_eof_reopens_the_idle_window(void)
+{
+    static const uint8_t audio[] = {0x60, 0x61};
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 20, &write_fd);
+
+    feed(write_fd, audio, sizeof(audio));
+    assert(ap2_session_start(session, 1700000000000ULL, NULL) == AP2_COMMIT_OK);
+    read_exact(session, audio, sizeof(audio));
+    assert(close(write_fd) == 0);
+    assert(wait_for_input_eof(session));
+
+    /* Well past the window the EOF opened, but the START pre-empts it. */
+    usleep(60000);
+    assert(ap2_session_start(session, 1700000005000ULL, NULL) == AP2_COMMIT_OK);
+    ap2_session_poll(session);
+    assert(ap2_session_state(session) == AP2_SESSION_PLAYING);
+    assert(atomic_load(&state.idle_timeouts) == 0);
+
+    /* Abandoned again: the re-opened window expires like any other. */
+    usleep(60000);
+    ap2_session_poll(session);
+    assert(ap2_session_state(session) == AP2_SESSION_ENDED);
+    assert(atomic_load(&state.idle_timeouts) == 1);
+
+    ap2_session_destroy(session);
+    status_state = NULL;
+}
+
 /* The input pipe's writer stays open (as MA holds the CLI stdin open), so the
  * reader never sees EOF; destroy must still tear it down promptly. */
 static void test_destroy_is_prompt_with_open_writer(void)
@@ -513,6 +590,8 @@ int main(void)
     test_failed_flush_preserves_pending_audio();
     test_standby_then_resume();
     test_idle_timeout_ends_session();
+    test_idle_timeout_ends_an_abandoned_post_eof_session();
+    test_start_after_eof_reopens_the_idle_window();
     test_destroy_is_prompt_with_open_writer();
     puts("AP2 session flush-and-refill tests passed");
     return 0;


### PR DESCRIPTION
A session that played its music to the end and was then forgotten by the caller stayed alive indefinitely, holding on to the speaker. The 120-second safety net that ends an abandoned session only ran while the session was idle or parked in standby, and nothing ever moved a finished stream into either state, so the process kept spinning until something else killed it.

The net now also covers a stream whose input has closed — the one case it was missing.

- Open the 120-second window when the input closes, so a session that plays to the end and is then abandoned ends by itself and exits cleanly
- Re-open the window on every `START`, so a caller that is still driving the session is never cut off, including one that starts again after the input ended
- Leave a paused session alone: pauses routinely outlast two minutes, and a caller that dies while paused closes its end of the input, which the new arming already covers
- Update the session robustness and output contract notes in DESIGN.md to match