### PR TITLE
Fix two tests that could fail at random

### DIFF
--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -955,6 +955,10 @@ static void test_retransmit_responder(void)
         if (!memcmp(resp + 4, pkt_b, sizeof(pkt_b))) seen_b = true;
     }
     assert(seen_a && seen_b);
+    /* The responder counts a resend only once the datagram is away, so the
+     * second packet can reach us here before the counter catches up. */
+    for (int i = 0; i < 30 && ap2cl_test_rtx_answered(client) < 2; i++)
+        usleep(50000);
     assert(ap2cl_test_rtx_answered(client) == 2);
 
     /* A packet that has already aged out is counted, not answered. */
@@ -1519,7 +1523,10 @@ int main(void)
     ap2cl_test_lock_mrp(client);
     pthread_t thread;
     assert(pthread_create(&thread, NULL, run_health_check, &check) == 0);
-    usleep(50000);
+    /* Completing while the MRP lock is held is the property under test, so
+     * wait for the snapshot instead of assuming a fixed span was enough. */
+    for (int i = 0; i < 30 && !atomic_load(&check.done); i++)
+        usleep(50000);
     assert(atomic_load(&check.done));
     assert(check.healthy);
     ap2cl_test_unlock_mrp(client);


### PR DESCRIPTION
The test suite could fail for no real reason. `test_retransmit_responder` asked the retransmit responder how many packets it had resent the moment both packets arrived — but the responder puts a packet on the wire first and counts it a moment later, so the test could read one instead of two and abort. It was seen once during a full test run and passed 25 runs in a row afterwards, so it is rare but real.

A check further down had the same weakness: it slept a fixed 50 ms and then assumed a background thread had finished, which a busy machine can miss.

Both now wait for the state they are about to check, using the same bounded retry a neighbouring check in that test already used. Nothing in the shipped code changes.

- Wait for the resent-packet counter to catch up before checking it
- Wait for the health snapshot to finish instead of sleeping a fixed 50 ms