### PR TITLE
Make status lines land intact and rejections carry a code

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -178,15 +178,21 @@ on stderr that Music Assistant parses:
 |---|---|
 | `auth_required` | a password is needed and none was supplied: reported before connecting when the TXT says so (and no credentials are stored), and on a `401`/`403` from a device we presented no password to |
 | `auth_failed` | the password we did present was rejected, on any exchange |
-| `connect_failed` | every other connect-path failure |
+| `connect_failed` | every other connect-path failure, including the local session-engine and command-pipe setup that runs before `[STATUS] connected` |
 | `start_failed` | `ACTION=START` scheduled no instant, so no `[STATUS] started` follows and no content may be mapped onto one |
 | `flush_failed` | `ACTION=FLUSH` was rejected, so no `[STATUS] flushed` follows |
+| `standby_failed` | `ACTION=STANDBY` was rejected, or there was no live session to park |
+| `play_failed` | `ACTION=PLAY` was rejected by the transport, or the resolved protocol had no client to resume; the status stays where it was either way |
+| `pause_failed` | `ACTION=PAUSE` was rejected by the transport; `[STATUS] paused` still follows, because sends stop regardless |
+| `stop_failed` | `ACTION=STOP` found no client to stop; `[STATUS] stopped` still follows, because the caller treats STOP as terminal |
 
-The connect/auth slugs are terminal — the process exits. `start_failed` and
-`flush_failed` are not: the connection survives and the caller decides whether
-to retry or fall back. Both exist so a caller can abort the pending ack wait
-immediately instead of waiting out a timeout that also means "a binary too old
-to ack at all"; a withheld join ack makes that wait seconds long.
+The connect/auth slugs are terminal — the process exits. The command slugs are
+not: the connection survives and the caller decides whether to retry or fall
+back. `start_failed` and `flush_failed` exist so a caller can abort the pending
+ack wait immediately instead of waiting out a timeout that also means "a binary
+too old to ack at all"; a withheld join ack makes that wait seconds long. The
+rest answer commands that have no ack of their own to withhold, so without them
+a command that reached nothing is indistinguishable from one that worked.
 
 `http` is the most informative HTTP status seen, `0` when none applies (a
 TLV-level rejection is an HTTP 200). The detail is squeezed onto one line and
@@ -391,12 +397,16 @@ binary reports what it measures instead of leaving the caller to guess:
   one Delay_Req ever arriving. Measuring from the last streak rather than from
   connect alone is what keeps a single lost `Q` round-trip — which empties the
   snapshot exactly as a departed receiver does — from reading as a stall on a
-  healthy session, and gives a mid-session clock loss the same 5 s grace as a
-  cold start. That mark is stamped by the snapshot poller, on the same round it
-  refreshes the snapshot, precisely because the reporting below stops at the
-  first `state=ready`: for most of a session nothing else is watching, and a
-  mark left to age with the reporting would make the first reading after a
-  re-arm read stale. Only a PTP session can stall; `mode=ntp` stays cold.
+  healthy session. What it does not do is make a mid-session clock loss
+  reportable as it happens: nothing samples readiness between the first
+  `state=ready` and the next `FLUSH` or `START`, and that re-arm restarts the
+  window, so a receiver that went quiet mid-stream surfaces as stalled only once
+  the new cycle has run its own 5 s without a streak. That mark is stamped by
+  the snapshot poller, on the same round it refreshes the snapshot, precisely
+  because the reporting stops there: for most of a session nothing else is
+  watching, and a mark left to age with the reporting would make the first
+  reading after a re-arm read stale. Only a PTP session can stall; `mode=ntp`
+  stays cold.
   `ready_in_ms`/`ready_at_unix_ms` are 0 and mean nothing, as while cold.
 - `streak_ms`/`exchanges` are the streak's first-probe age and probe count,
   the same two numbers the commit-time floor logs, so field reports compare
@@ -406,12 +416,20 @@ The first line is emitted immediately after `[STATUS] connected`,
 unconditionally and whatever the state, so a caller can always distinguish
 "not ready yet" from "this binary will never tell me". After that only a
 material change is reported — the state, or the projected instant a caller
-would plan against; the exchange count rides along as telemetry but never
-triggers a line by itself — sampled at most every 250 ms, ending at the first
-`state=ready`. `state=stalled` does NOT end it (a receiver that begins probing
-late still reports `probing` and then `ready`) but does log the diagnosis once,
-on the way in. `FLUSH` and `START` re-arm it for the next cycle. The projection
-is recomputed per emission and never cached. In shared-daemon mode the snapshot
+would plan against moving more than 50 ms from the one last reported; the
+exchange count rides along as telemetry but never triggers a line by itself —
+sampled at most every 250 ms, ending at the first `state=ready`. The 50 ms is
+the projection's own jitter: it is arithmetic on two live readings, so it
+wobbles by a millisecond or two in-process (two clocks each truncated to
+milliseconds) and drifts with the snapshot's age under the shared daemon, and
+comparing exactly would report that wobble as news every sample. Measuring
+against the last line sent rather than the last sample keeps a slow drift from
+hiding under the tolerance forever. `state=stalled` does NOT end the reporting
+(a receiver that begins probing late still reports `probing` and then `ready`)
+but does log the diagnosis once, on the way in. `FLUSH` and `START` re-arm it
+for the next cycle, comparison baseline included, so the first line of a cycle
+is judged against nothing the previous one left behind. The projection is
+recomputed per emission and never cached. In shared-daemon mode the snapshot
 comes from the poller thread, started at connect, because the daemon's `Q`
 round-trip blocks and the audio loop must never make it inline; the in-process
 engine is queried directly under its own lock.
@@ -1007,7 +1025,9 @@ it for good, so a caller that keeps commanding is never cut off. On expiry the
 binary emits `[STATUS] idle_timeout` and the process exits 0, with no
 `[ERROR]` and no `[STATUS] stopped`; a session that connects and never
 receives a `START` ends exactly this way, and so does one played to EOF and
-then abandoned.
+then abandoned. In that second case the line reaches nobody but a human reading
+the raw log: Music Assistant's reader treats `[STATUS] eof` as terminal and has
+stopped parsing long before the timeout fires.
 
 The EOF arming is keyed on the input CLOSING, not on the drain finishing or
 the ring emptying. A closed stdin is the end of the whole feed — a warm

--- a/Makefile
+++ b/Makefile
@@ -228,12 +228,23 @@ test: directory $(EXECUTABLE) $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(CLIENT
 		/tmp/cliairplay-test-unused 127.0.0.1 - 2>&1 || true)"; \
 		printf '%s\n' "$$argv_audio" | \
 		grep -q "Streaming audio must be provided on stdin, not argv"
+# Both greps are chained with && on purpose: a recipe line reports only its
+# last command's status, so separating them with ; would leave the coded-line
+# assertion unenforced.
 	@auth_required="$$($(EXECUTABLE) --protocol raop --pw true \
 		127.0.0.1 2>&1 || true)"; \
 		printf '%s\n' "$$auth_required" | \
-		grep -q '^\[STATUS\] error code=auth_required http=0 detail="[^"]*"$$'; \
+		grep -q '^\[STATUS\] error code=auth_required http=0 detail="[^"]*"$$' && \
 		printf '%s\n' "$$auth_required" | \
 		grep -q "Password required but not supplied"
+# A connect-path setup failure must carry its code too: without one the caller
+# has nothing to fail fast on and waits out its connect timeout instead.
+	@setup_failed="$$($(EXECUTABLE) --protocol raop --cmdpipe \
+		/nonexistent-cliairplay-test-dir/pipe 127.0.0.1 2>&1 || true)"; \
+		printf '%s\n' "$$setup_failed" | \
+		grep -q '^\[STATUS\] error code=connect_failed http=0 detail="[^"]*"$$' && \
+		printf '%s\n' "$$setup_failed" | \
+		grep -q "Failed to create command pipe"
 
 $(RAOP_SESSION_TEST): tests/test_raop_session.c src/raop_session.c \
 		src/raop_session.h Makefile

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -149,14 +149,27 @@ static struct debug_s {
 
 /* ---- Normalized status output ---- */
 
+/* One line, one write. Three threads emit these (the audio loop, the command
+ * pipe, the session reader) and the human-readable LOG_* output shares the
+ * stream, so formatting the body and the newline as two writes lets another
+ * thread land between them and corrupt a line the caller then drops. The
+ * relied-on guarantee is POSIX pipe atomicity: concurrent writes of at most
+ * PIPE_BUF bytes are not interleaved, and PIPE_BUF is at least 512 everywhere
+ * (exactly 512 on macOS), so the buffer is sized to emit at most 511 bytes.
+ * That is well past the longest line we produce (a `mrp artwork=` report, ~200
+ * chars); a line that would still overflow is clamped rather than split. */
 static void status_print(const char *fmt, ...)
 {
+    char line[512];
     va_list args;
     va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
-    fprintf(stderr, "\n");
-    fflush(stderr);
+    int written = vsnprintf(line, sizeof(line) - 1, fmt, args);
     va_end(args);
+    size_t len = written < 0 ? 0 : (size_t)written;
+    if (len > sizeof(line) - 2) len = sizeof(line) - 2;
+    line[len++] = '\n';
+    fwrite(line, 1, len, stderr);
+    fflush(stderr);
 }
 
 /* Status messages parsed by Music Assistant's _stderr_reader() */
@@ -206,6 +219,14 @@ static void status_error(const char *msg)
     status_print("[ERROR] %s", msg);
 }
 
+/* How far the projected readiness instant must move to count as material. The
+ * projection is arithmetic on two live readings, so it jitters even while the
+ * receiver behaves: the shared-daemon snapshot freezes between poller rounds
+ * while now advances, and the in-process engine mixes two clocks each truncated
+ * to milliseconds. Comparing exactly reports that jitter as news every sample;
+ * nothing a caller plans against moves by this little. */
+#define CLOCK_READY_JITTER_MS 50
+
 /* Receiver-clock readiness, pushed from connect so the caller never has to
  * guess a join headroom: a receiver begins probing our clock about a second
  * after it connects, on its own schedule and with no anchor announced, and is
@@ -214,11 +235,13 @@ static void status_error(const char *msg)
  * [STATUS] connected, whatever the state, so a caller can always tell the
  * difference between "not ready yet" and "this binary will never tell me".
  * After that only a MATERIAL change is reported — the state, or the projected
- * instant the caller would plan against; the exchange count rides along as
- * telemetry but never triggers a line on its own — rate-limited to one sample
- * per AP2_CLOCK_VERIFY_POLL_MS, ending at the first state=ready. FLUSH and
- * START re-arm it for the next cycle. state=stalled does NOT end it: a
- * receiver that begins probing late still reports probing and then ready. */
+ * instant the caller would plan against moving further than
+ * CLOCK_READY_JITTER_MS from the one last reported; the exchange count rides
+ * along as telemetry but never triggers a line on its own — rate-limited to one
+ * sample per AP2_CLOCK_VERIFY_POLL_MS, ending at the first state=ready. FLUSH
+ * and START re-arm it for the next cycle, comparison baseline included.
+ * state=stalled does NOT end it: a receiver that begins probing late still
+ * reports probing and then ready. */
 static bool g_clock_ready_reported = false;   /* emitted at least once this cycle */
 static bool g_clock_ready_done = false;       /* terminal state=ready reported */
 static uint64_t g_clock_ready_next_ntp = 0;
@@ -230,6 +253,12 @@ static void clock_ready_rearm(void)
     g_clock_ready_reported = false;
     g_clock_ready_done = false;
     g_clock_ready_next_ntp = 0;
+    /* The comparison baseline goes with them. A cycle judged against the
+     * previous one's reading gets its own first transition wrong: a session
+     * already stalled when it is re-armed reads stalled->stalled, so it repeats
+     * the state without the diagnosis that explains what a stall means. */
+    g_clock_ready_state = AP2_CLOCK_COLD;
+    g_clock_ready_at_ms = 0;
     /* Reporting went terminal at the last ready and stopped asking, so under
      * the in-process engine — which has no poller to follow the receiver
      * meanwhile — the stall mark is as old as that quiet stretch. Restart the
@@ -257,8 +286,18 @@ static void clock_ready_tick(void)
 
     ap2_clock_readiness_t r;
     ap2cl_clock_readiness(g_ap2cl, &r);
+    /* Material change only: the state, or a projected instant that moved
+     * further than the reading's own jitter. Measured against what was last
+     * reported rather than against the last sample, so a slow drift still
+     * surfaces once it has grown past the tolerance. The terminal state=ready
+     * is out of the tolerance's reach either way — it is a state change, and
+     * once reported the latch below ends the reporting above — and the line is
+     * always formatted from this reading, never from the latched values. */
+    uint64_t moved = r.ready_at_unix_ms > g_clock_ready_at_ms
+        ? r.ready_at_unix_ms - g_clock_ready_at_ms
+        : g_clock_ready_at_ms - r.ready_at_unix_ms;
     if (g_clock_ready_reported && r.state == g_clock_ready_state &&
-        r.ready_at_unix_ms == g_clock_ready_at_ms)
+        moved <= CLOCK_READY_JITTER_MS)
         return;
     /* Read before the latch moves, so the diagnosis below is logged on the
      * transition into the stall and not on every sample that stays in it. */
@@ -381,6 +420,10 @@ static void clock_verify_tick(void)
 #define ERROR_CODE_CONNECT_FAILED "connect_failed"
 #define ERROR_CODE_START_FAILED   "start_failed"
 #define ERROR_CODE_FLUSH_FAILED   "flush_failed"
+#define ERROR_CODE_STANDBY_FAILED "standby_failed"
+#define ERROR_CODE_PLAY_FAILED    "play_failed"
+#define ERROR_CODE_PAUSE_FAILED   "pause_failed"
+#define ERROR_CODE_STOP_FAILED    "stop_failed"
 
 /*
  * Report a failure as one machine-readable line followed by the
@@ -644,7 +687,11 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
                                               : "no live session to flush",
                             "FLUSH failed");
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "STANDBY") == 0) {
-        if (g_session) ap2_session_standby(g_session);
+        if (!g_session || !ap2_session_standby(g_session))
+            status_error_ex(ERROR_CODE_STANDBY_FAILED, 0,
+                            session_is_live() ? "session rejected the standby"
+                                              : "no live session to stand by",
+                            "STANDBY failed");
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "DISCONNECT") == 0) {
         if (g_session) ap2_session_end(g_session);
         g_status = STATUS_STOPPED;
@@ -654,7 +701,9 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
             if (g_status == STATUS_PLAYING) {
                 if (cfg->protocol == PROTO_RAOP && g_raopcl) {
                     if (!raop_session_pause(g_raopcl))
-                        status_error("RAOP pause failed");
+                        status_error_ex(ERROR_CODE_PAUSE_FAILED, 0,
+                                        "the RAOP transport rejected the pause",
+                                        "RAOP pause failed");
                 } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
                     ap2cl_pause(g_ap2cl);
                 }
@@ -668,12 +717,20 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         bool play_ok = true;
         if (cfg->protocol == PROTO_RAOP && g_raopcl) {
             if (!raop_session_resume(g_raopcl)) {
-                status_error("RAOP play failed");
+                status_error_ex(ERROR_CODE_PLAY_FAILED, 0,
+                                "the RAOP transport rejected the resume",
+                                "RAOP play failed");
                 play_ok = false;
             }
         } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
             ap2cl_play(g_ap2cl);
         } else {
+            /* No client for the resolved protocol: the command reached nothing,
+             * and the status stays where it was. Coded so the caller does not
+             * read the silence as a resume it can start counting from. */
+            status_error_ex(ERROR_CODE_PLAY_FAILED, 0,
+                            "no transport client to resume",
+                            "PLAY failed");
             play_ok = false;
         }
         /* No status emission here: reporting elapsed_ms=0 would snap the
@@ -688,6 +745,14 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
             raopcl_stop(g_raopcl);
         } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
             ap2cl_stop(g_ap2cl);
+        } else {
+            /* Neither transport call reports a result, so the one failure that
+             * can be seen here is having no client to make the call on. The
+             * stopped line still goes out below: the caller treats STOP as
+             * terminal and tears the process down either way. */
+            status_error_ex(ERROR_CODE_STOP_FAILED, 0,
+                            "no transport client to stop",
+                            "STOP failed");
         }
         status_print("[STATUS] stopped");
         pthread_mutex_unlock(&g_audio_send_lock);
@@ -802,7 +867,9 @@ static void session_stop_op(void *transport)
     cli_config_t *cfg = transport;
     if (cfg->protocol == PROTO_RAOP) {
         if (g_raopcl && !raop_session_standby(g_raopcl))
-            status_error("RAOP standby failed");
+            status_error_ex(ERROR_CODE_STANDBY_FAILED, 0,
+                            "the RAOP transport rejected the standby",
+                            "RAOP standby failed");
     } else if (g_ap2cl) {
         ap2cl_standby(g_ap2cl);
     }
@@ -910,14 +977,18 @@ static bool start_command_thread(cli_config_t *cfg)
     if (g_cmdpipe_fd == -1) {
         LOG_ERROR("Failed to open command pipe: %s (errno=%d)",
                   cfg->cmdpipe, errno);
-        status_error("Failed to open command pipe");
+        status_error_ex(ERROR_CODE_CONNECT_FAILED, 0,
+                        "cannot open the command pipe",
+                        "Failed to open command pipe");
         return false;
     }
     int result = pthread_create(
         &g_cmdpipe_thread, NULL, cmdpipe_reader_thread, cfg);
     if (result != 0) {
         LOG_ERROR("Failed to start command pipe thread: %s", strerror(result));
-        status_error("Failed to start command pipe thread");
+        status_error_ex(ERROR_CODE_CONNECT_FAILED, 0,
+                        "cannot start the command pipe thread",
+                        "Failed to start command pipe thread");
         close(g_cmdpipe_fd);
         g_cmdpipe_fd = -1;
         return false;
@@ -944,7 +1015,9 @@ static bool start_stream_session(cli_config_t *cfg, int input_bpf,
         (unsigned)frames_per_chunk * (unsigned)input_bpf,
         SESSION_IDLE_TIMEOUT_MS, STDIN_FILENO);
     if (!g_session) {
-        status_error("Cannot create session engine");
+        status_error_ex(ERROR_CODE_CONNECT_FAILED, 0,
+                        "cannot create the session engine",
+                        "Cannot create session engine");
         return false;
     }
     g_status = STATUS_PAUSED;
@@ -2054,7 +2127,9 @@ int main(int argc, char *argv[])
     struct stat st;
     if (stat(cfg.cmdpipe, &st) != 0) {
         if (mkfifo(cfg.cmdpipe, 0666) != 0) {
-            status_error("Failed to create command pipe");
+            status_error_ex(ERROR_CODE_CONNECT_FAILED, 0,
+                            "cannot create the command pipe",
+                            "Failed to create command pipe");
             return 1;
         }
     }

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -157,7 +157,9 @@ static struct debug_s {
  * PIPE_BUF bytes are not interleaved, and PIPE_BUF is at least 512 everywhere
  * (exactly 512 on macOS), so the buffer is sized to emit at most 511 bytes.
  * That is well past the longest line we produce (a `mrp artwork=` report, ~200
- * chars); a line that would still overflow is clamped rather than split. */
+ * chars); a line that would still overflow is clamped rather than split. The
+ * flush is a no-op while stderr stays unbuffered (set at startup) and is kept
+ * so a future buffering change cannot silently delay status lines. */
 static void status_print(const char *fmt, ...)
 {
     char line[512];

--- a/tests/test_ap2_session.c
+++ b/tests/test_ap2_session.c
@@ -436,6 +436,29 @@ static void test_standby_then_resume(void)
     assert(close(write_fd) == 0);
 }
 
+/* The refusal behind [STATUS] error code=standby_failed. An ended session (and
+ * a session that is gone entirely) must answer false rather than report a park
+ * that never happened, and must not reach the transport on the way. */
+static void test_standby_is_refused_on_an_ended_session(void)
+{
+    test_state_t state;
+    int write_fd;
+    struct ap2_session_s *session = create_session(&state, 0, &write_fd);
+
+    assert(ap2_session_standby(session));
+    assert(atomic_load(&state.stops) == 1);
+
+    ap2_session_end(session);
+    assert(ap2_session_state(session) == AP2_SESSION_ENDED);
+    assert(!ap2_session_standby(session));
+    assert(atomic_load(&state.stops) == 1);
+    assert(!ap2_session_standby(NULL));
+
+    ap2_session_destroy(session);
+    status_state = NULL;
+    assert(close(write_fd) == 0);
+}
+
 static void test_idle_timeout_ends_session(void)
 {
     test_state_t state;
@@ -589,6 +612,7 @@ int main(void)
     test_flush_while_idle_before_start();
     test_failed_flush_preserves_pending_audio();
     test_standby_then_resume();
+    test_standby_is_refused_on_an_ended_session();
     test_idle_timeout_ends_session();
     test_idle_timeout_ends_an_abandoned_post_eof_session();
     test_start_after_eof_reopens_the_idle_window();


### PR DESCRIPTION
A batch of small robustness fixes to the status reporting, found in a code
audit after the recent timing work.

Status lines are the whole contract between the binary and the server, and a
line written as two separate writes from three concurrent threads could be
interleaved by another thread - the server then drops the corrupted line
silently. The clock readiness report also repeated every quarter second while
a speaker's clock warmed up, a re-armed reporting cycle skipped the one-time
stall explanation, and several rejected commands answered with nothing the
server could act on, so a failure cost a full timeout instead of failing fast.

- Emit every status line as one atomic write
- Report clock readiness on material change only, not on every sample
- Start a re-armed readiness cycle from a clean slate so a stall is explained
- Give standby, play, pause, stop and the remaining connect failures the same
  machine-readable rejection codes start and flush already had
- Fix the test target so all of its assertions actually gate it - one had
  never been enforced
- Correct the design notes on mid-session clock loss and the post-stop status
  line
