### PR TITLE
Fix the audible pop when stopping playback

### DIFF
--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -407,12 +407,16 @@ static bool ap2_status_is_auth(int status)
     return status == 401 || status == 403;
 }
 
-/* An auth-shaped rejection means "supply a password" when we presented none,
- * and "this password is wrong" when we did. */
+/* An auth-shaped rejection means "supply a secret" only when we presented none
+ * at all; whatever we did present was rejected. Stored HAP credentials count as
+ * a presented secret: a receiver that has rotated them (tvOS re-pairing) answers
+ * pair-verify with 401/403, and the remedy is to pair again — reporting
+ * AUTH_REQUIRED there would point the user at a password the device never had. */
 static ap2_connect_error_t ap2_auth_error_kind(struct ap2cl_s *p)
 {
-    return (p->password && *p->password) ? AP2_CONNECT_ERROR_AUTH_FAILED
-                                         : AP2_CONNECT_ERROR_AUTH_REQUIRED;
+    bool presented_secret = (p->password && *p->password) || p->auth_credentials;
+    return presented_secret ? AP2_CONNECT_ERROR_AUTH_FAILED
+                            : AP2_CONNECT_ERROR_AUTH_REQUIRED;
 }
 
 static void ap2_set_connect_error(struct ap2cl_s *p, ap2_connect_error_t kind,
@@ -3323,10 +3327,9 @@ static bool ap2_splice_pad_to_lead(struct ap2cl_s *p, uint64_t now_ts,
     LOG_WARN("[AP2] Splice-padded after %s: shifted_frames="
              "%" PRIu64 " lead_frames=%" PRIu64 " count=%" PRIu64,
              cause, pad, recovery_lead, p->timeline_reanchors);
-    fprintf(stderr, "[STATUS] REANCHOR shifted_frames=%" PRIu64
-            " total_shifted_frames=%" PRIu64 " sample_rate=%d\n",
-            pad, p->reanchor_shifted_frames, p->format.sample_rate);
-    fflush(stderr);
+    ap2_io_status_line("[STATUS] REANCHOR shifted_frames=%" PRIu64
+                       " total_shifted_frames=%" PRIu64 " sample_rate=%d",
+                       pad, p->reanchor_shifted_frames, p->format.sample_rate);
     return true;
 }
 
@@ -3378,11 +3381,10 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p)
     /* Machine-readable counterpart of the LOG_WARN above, on the same stderr
      * channel as the binary's other [STATUS] lines, so Music Assistant can
      * track re-anchor drift without scraping the human-readable log. */
-    fprintf(stderr, "[STATUS] REANCHOR shifted_frames=%" PRIu64
-            " total_shifted_frames=%" PRIu64 " sample_rate=%d\n",
-            recovery.shifted_frames, p->reanchor_shifted_frames,
-            p->format.sample_rate);
-    fflush(stderr);
+    ap2_io_status_line("[STATUS] REANCHOR shifted_frames=%" PRIu64
+                       " total_shifted_frames=%" PRIu64 " sample_rate=%d",
+                       recovery.shifted_frames, p->reanchor_shifted_frames,
+                       p->format.sample_rate);
     return true;
 }
 
@@ -4676,5 +4678,10 @@ void ap2cl_test_set_dev_latency_max(struct ap2cl_s *p, uint32_t frames)
 uint64_t ap2cl_test_pacing_window_frames(struct ap2cl_s *p)
 {
     return ap2_pacing_window_frames(p);
+}
+
+ap2_connect_error_t ap2cl_test_auth_error_kind(struct ap2cl_s *p)
+{
+    return ap2_auth_error_kind(p);
 }
 #endif

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -459,9 +459,9 @@ void ap2cl_set_remote_command_callback(
  */
 void ap2cl_latency_info(struct ap2cl_s *p, int *lead_ms, uint32_t *dev_min, uint32_t *dev_max);
 
-/* Device-reported arrival->render latency in ms (0 when unreported). Members
- * reporting it are scheduled earlier by this amount so their acoustic output
- * aligns with the group. */
+/* Device-reported arrival->render latency in ms (0 when unreported). Reported
+ * for diagnostics on the [STATUS] latency line and never applied to a schedule:
+ * receivers already self-compensate their own render latency. */
 int ap2cl_render_latency_ms(struct ap2cl_s *p);
 
 /* Frames between the delivery head and the audible position (elapsed

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -15,6 +15,25 @@
 #include <strings.h>
 #include <time.h>
 
+void ap2_io_status_vline(const char *fmt, va_list args)
+{
+    char line[512];
+    int written = vsnprintf(line, sizeof(line) - 1, fmt, args);
+    size_t len = written < 0 ? 0 : (size_t)written;
+    if (len > sizeof(line) - 2) len = sizeof(line) - 2;
+    line[len++] = '\n';
+    fwrite(line, 1, len, stderr);
+    fflush(stderr);
+}
+
+void ap2_io_status_line(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    ap2_io_status_vline(fmt, args);
+    va_end(args);
+}
+
 uint64_t ap2_io_monotonic_ms(void)
 {
     struct timespec ts;

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -15,6 +15,12 @@
 #include <strings.h>
 #include <time.h>
 
+/* One buffer, one stdio call. POSIX requires stdio functions to lock the
+ * FILE for the whole call, so this fwrite cannot interleave with another
+ * thread's fprintf to the same stream - that lock, not the write itself, is
+ * the serialization every emitter in this process shares (nothing writes the
+ * fd raw). Staying under 512 bytes additionally keeps the line inside
+ * PIPE_BUF, the backstop if such a writer ever appears. */
 void ap2_io_status_vline(const char *fmt, va_list args)
 {
     char line[512];

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -6,6 +6,7 @@
 #ifndef __AP2_IO_H_
 #define __AP2_IO_H_
 
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -32,6 +33,33 @@ typedef struct {
     size_t body_len;
     size_t message_len;
 } ap2_rtsp_response_t;
+
+/*
+ * Emit one [STATUS] line on stderr: one line, one write.
+ *
+ * Three threads emit these (the audio loop, the command pipe, the session
+ * reader) and the human-readable LOG_* output shares the stream, so formatting
+ * the body and the newline as two writes lets another thread land between them
+ * and corrupt a line the caller then drops. The relied-on guarantee is POSIX
+ * pipe atomicity: concurrent writes of at most PIPE_BUF bytes are not
+ * interleaved, and PIPE_BUF is at least 512 everywhere (exactly 512 on macOS),
+ * so the buffer is sized to emit at most 511 bytes. That is well past the
+ * longest line we produce (a `mrp artwork=` report, ~200 chars); a line that
+ * would still overflow is clamped rather than split. The flush is a no-op while
+ * stderr stays unbuffered (set at startup) and is kept so a future buffering
+ * change cannot silently delay status lines.
+ *
+ * This lives here rather than in cliairplay.c so the AP2 client's own status
+ * emissions share the one implementation of the single-write guarantee.
+ *
+ * :param fmt: printf-style format for the line body, without the newline.
+ */
+void ap2_io_status_line(const char *fmt, ...)
+    __attribute__((format(printf, 1, 2)));
+
+/* va_list form of ap2_io_status_line, for a caller wrapping it in its own
+ * variadic helper. */
+void ap2_io_status_vline(const char *fmt, va_list args);
 
 uint64_t ap2_io_monotonic_ms(void);
 /* Returns 1 when acquired, 0 on deadline expiry, and -1 on mutex error. */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -36,6 +36,7 @@
 #include "cross_log.h"
 #include "ap2_client.h"
 #include "ap2_session.h"
+#include "ap2_io.h"
 #include "ap2_ptp.h"
 #include "ap2_hap.h"
 #include "raop_session.h"
@@ -149,29 +150,15 @@ static struct debug_s {
 
 /* ---- Normalized status output ---- */
 
-/* One line, one write. Three threads emit these (the audio loop, the command
- * pipe, the session reader) and the human-readable LOG_* output shares the
- * stream, so formatting the body and the newline as two writes lets another
- * thread land between them and corrupt a line the caller then drops. The
- * relied-on guarantee is POSIX pipe atomicity: concurrent writes of at most
- * PIPE_BUF bytes are not interleaved, and PIPE_BUF is at least 512 everywhere
- * (exactly 512 on macOS), so the buffer is sized to emit at most 511 bytes.
- * That is well past the longest line we produce (a `mrp artwork=` report, ~200
- * chars); a line that would still overflow is clamped rather than split. The
- * flush is a no-op while stderr stays unbuffered (set at startup) and is kept
- * so a future buffering change cannot silently delay status lines. */
+/* One line, one write — see ap2_io_status_line() for the atomicity the emitters
+ * here rely on. The implementation lives in ap2_io.c so the AP2 client's own
+ * status lines go out through the same single write. */
 static void status_print(const char *fmt, ...)
 {
-    char line[512];
     va_list args;
     va_start(args, fmt);
-    int written = vsnprintf(line, sizeof(line) - 1, fmt, args);
+    ap2_io_status_vline(fmt, args);
     va_end(args);
-    size_t len = written < 0 ? 0 : (size_t)written;
-    if (len > sizeof(line) - 2) len = sizeof(line) - 2;
-    line[len++] = '\n';
-    fwrite(line, 1, len, stderr);
-    fflush(stderr);
 }
 
 /* Status messages parsed by Music Assistant's _stderr_reader() */
@@ -901,7 +888,16 @@ static void *cmdpipe_reader_thread(void *arg)
 
     while (g_running) {
         struct pollfd pfds = {.fd = g_cmdpipe_fd, .events = POLLIN};
-        int n = poll(&pfds, 1, 1000);
+        /* The timeout bounds teardown, not command latency: an arriving command
+         * wakes the poll at once, but STOP, DISCONNECT and the idle timeout all
+         * tear down through join_command_thread(), which cannot return before
+         * this wait expires. By then the client is AP2_DOWN, so the audio loop's
+         * silence keepalive has already stopped and nothing feeds the wire until
+         * TEARDOWN goes out — a receiver whose queue underruns while its session
+         * is still armed pops audibly. 100 ms keeps that gap far inside the
+         * 600 ms queue depth. The wait's only other job is pacing libraop's 20 s
+         * RAOP keepalive below, which ten wakeups a second serve as well as one. */
+        int n = poll(&pfds, 1, 100);
         if (!g_running) break;
 
         uint64_t now = raopcl_get_ntp(NULL);

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -59,6 +59,7 @@ void ap2cl_test_set_clock_marks(struct ap2cl_s *p, uint64_t connected_ms,
 void ap2cl_test_bump_audio_sent(struct ap2cl_s *p);
 void ap2cl_test_set_dev_latency_max(struct ap2cl_s *p, uint32_t frames);
 uint64_t ap2cl_test_pacing_window_frames(struct ap2cl_s *p);
+ap2_connect_error_t ap2cl_test_auth_error_kind(struct ap2cl_s *p);
 
 typedef struct {
     int fd;
@@ -482,6 +483,67 @@ static void test_route_with_password(void)
         false, false);
     assert(legacy.use_raop);
     puts("ap2_client route password selection tests passed");
+}
+
+/* A 401/403 is classified from what we actually presented, because the two
+ * verdicts send the caller to different remedies: AUTH_REQUIRED becomes MA's
+ * "password required" prompt, AUTH_FAILED tells the user to fix the secret.
+ * Stored HAP credentials count as a presented secret — a receiver that rotated
+ * them (tvOS re-pairing) rejects pair-verify, and prompting for a password the
+ * device never had leaves the user with nothing to enter. */
+static void test_auth_error_kind(void)
+{
+    ap2_device_info_t device = {
+        .name = "auth kind test",
+        .address = "127.0.0.1",
+        .port = 7000,
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    /* Only credentials of the exact HAP length are stored by ap2cl_create. */
+    char creds[193];
+    memset(creds, 'a', sizeof(creds) - 1);
+    creds[sizeof(creds) - 1] = '\0';
+
+    struct ap2cl_s *bare = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(bare);
+    assert(ap2cl_test_auth_error_kind(bare) == AP2_CONNECT_ERROR_AUTH_REQUIRED);
+    assert(ap2cl_destroy(bare));
+
+    /* An empty password is no password: it is stored but can never be
+     * presented, so the "supply one" verdict still stands. */
+    struct ap2cl_s *empty = ap2cl_create(
+        &device, &format, NULL, "", NULL, NULL, 2000, 100);
+    assert(empty);
+    assert(ap2cl_test_auth_error_kind(empty) == AP2_CONNECT_ERROR_AUTH_REQUIRED);
+    assert(ap2cl_destroy(empty));
+
+    struct ap2cl_s *with_password = ap2cl_create(
+        &device, &format, NULL, "device-password", NULL, NULL, 2000, 100);
+    assert(with_password);
+    assert(ap2cl_test_auth_error_kind(with_password) ==
+           AP2_CONNECT_ERROR_AUTH_FAILED);
+    assert(ap2cl_destroy(with_password));
+
+    /* Credentials present, no password: revoked pairing, not a missing one. */
+    struct ap2cl_s *with_creds = ap2cl_create(
+        &device, &format, creds, NULL, NULL, NULL, 2000, 100);
+    assert(with_creds);
+    assert(ap2cl_test_auth_error_kind(with_creds) ==
+           AP2_CONNECT_ERROR_AUTH_FAILED);
+    assert(ap2cl_destroy(with_creds));
+
+    struct ap2cl_s *both = ap2cl_create(
+        &device, &format, creds, "device-password", NULL, NULL, 2000, 100);
+    assert(both);
+    assert(ap2cl_test_auth_error_kind(both) == AP2_CONNECT_ERROR_AUTH_FAILED);
+    assert(ap2cl_destroy(both));
+
+    puts("ap2_client auth error classification tests passed");
 }
 
 /* Both MediaRemote toggles parse their value, so the spellings a user reaches
@@ -1477,6 +1539,7 @@ int main(void)
     test_retransmit_responder();
     test_route_with_password();
     test_route_explicit_airplay2();
+    test_auth_error_kind();
     test_info_format_tables();
     test_feedback_stream_counts();
     test_native_flush_resume_reuses_rtsp_session();

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -504,7 +504,7 @@ static void test_auth_error_kind(void)
         .channels = 2,
     };
     /* Only credentials of the exact HAP length are stored by ap2cl_create. */
-    char creds[193];
+    char creds[192 + 1]; /* 192-hex HAP credential + NUL */
     memset(creds, 'a', sizeof(creds) - 1);
     creds[sizeof(creds) - 1] = '\0';
 


### PR DESCRIPTION
Pre-beta fixes from a full audit of the binary.

Stopping playback silenced the wire at once, but the teardown had to wait for
a one-second internal poll before it reached the speaker - which only holds
600 ms of audio. Every stop therefore ended in an audible underrun pop, on the
speaker classes users have been reporting pops on. The wait is now 100 ms, far
inside the buffer, and the same bound applies to disconnects and idle
timeouts.

- Bound the teardown wait well inside the speaker's audio buffer so stopping
  no longer pops
- Report rejected stored HomeKit credentials as a failed pairing rather than
  'password required' - the remedy is re-pairing, not a password the device
  never had
- Route the two re-anchor reports through the same atomic writer as every
  other status line, so they can no longer interleave with concurrent output
- Correct a header note that claimed the device's reported render latency is
  applied to scheduling; it is diagnostic only
