### PR TITLE
Serve the receiver buffer depth as --latency and drop --no-ptp

### DIFF
--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -246,7 +246,7 @@ struct ap2cl_s {
                                      anchor line — the native default; false
                                      only for deny-listed receivers (see the
                                      splice comments at flush/resume/standby) */
-    int splice_depth_ms;          /* >0: --splice-depth-ms override of the
+    int splice_depth_ms;          /* >0: --buffer-depth-ms override of the
                                      AP2_SPLICE_PACING_MS queue depth */
     uint32_t splice_pad_frames;   /* silence frames still to send before the
                                      next real sample so it lands exactly on
@@ -2596,7 +2596,7 @@ void ap2cl_set_publish_ip(struct ap2cl_s *p, const char *ip)
 }
 
 /* Effective splice queue depth: the compiled default unless the caller
- * supplied --splice-depth-ms. Every consumer of the depth (pacing, warm
+ * supplied --buffer-depth-ms. Every consumer of the depth (pacing, warm
  * lead, clock-verification windows, connect log) reads it from here so an
  * override moves them all coherently. */
 static uint32_t ap2_splice_depth_ms(struct ap2cl_s *p)

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -110,7 +110,7 @@ extern log_level *loglevel;
 #define AP2_CLOCK_VERIFY_MIN_WINDOW_MS(p) (ap2_splice_depth_ms(p) + 500)
 /* Receiver queue depth on the splice timeline (§ splice below): the
  * depth IS the audible latency of a warm splice, so it stays shallow.
- * ap2_splice_depth_ms() applies the caller's --splice-depth-ms override:
+ * ap2_splice_depth_ms() applies the caller's --buffer-depth-ms override:
  * LinkPlay receivers acting as native multiroom master starve the AirPlay
  * renderer below ~1 s of queued audio, so their caller asks for more. */
 #define AP2_SPLICE_PACING_MS         600

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -163,7 +163,7 @@ struct ap2cl_s {
     ap2_device_info_t device;
     ap2_audio_format_t format;
     ap2_state_t state;
-    int latency_ms;
+    int lead_ms;
     uint32_t dev_latency_min;      /* receiver-reported buffering window (frames) */
     uint32_t dev_latency_max;
     int dev_render_ms;             /* receiver-reported arrival->render latency (ms) */
@@ -1960,18 +1960,18 @@ static bool ap2_native_connect(struct ap2cl_s *p)
         if (ap2_bplist_find_uint(resp, (size_t)resp_len, "latencyMax", &v) && v > 0)
             p->dev_latency_max = (uint32_t)v;
         if (p->dev_latency_min || p->dev_latency_max) {
-            int lat_frames = MS2TS(p->latency_ms, p->format.sample_rate);
+            int lat_frames = MS2TS(p->lead_ms, p->format.sample_rate);
             int min_f = p->dev_latency_min ? (int)p->dev_latency_min : 0;
             int max_f = p->dev_latency_max ? (int)p->dev_latency_max : lat_frames;
             int clamped = lat_frames < min_f ? min_f : (lat_frames > max_f ? max_f : lat_frames);
             int clamped_ms = clamped * 1000 / p->format.sample_rate;
-            if (clamped_ms != p->latency_ms) {
+            if (clamped_ms != p->lead_ms) {
                 LOG_INFO("[AP2] Device latency window %d..%d frames: adjusting lead "
-                         "%dms -> %dms", min_f, max_f, p->latency_ms, clamped_ms);
-                p->latency_ms = clamped_ms;
+                         "%dms -> %dms", min_f, max_f, p->lead_ms, clamped_ms);
+                p->lead_ms = clamped_ms;
             }
             LOG_INFO("[AP2] Device latency: min=%u max=%u frames, effective lead %dms",
-                     p->dev_latency_min, p->dev_latency_max, p->latency_ms);
+                     p->dev_latency_min, p->dev_latency_max, p->lead_ms);
         }
 
         if (remote_data > 0) {
@@ -2103,7 +2103,7 @@ static ap2_send_result_t ap2_send_sync_packet(struct ap2cl_s *p, bool first)
     pkt[2] = 0x00;
     pkt[3] = 0x07;
 
-    uint32_t latency_frames = MS2TS(p->latency_ms, p->format.sample_rate);
+    uint32_t latency_frames = MS2TS(p->lead_ms, p->format.sample_rate);
     uint32_t ts_latency = p->rtp_timestamp >= latency_frames
                           ? p->rtp_timestamp - latency_frames : 0;
     uint32_t ts_be = htonl(ts_latency);
@@ -2166,7 +2166,7 @@ static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
      * schedules playback as "frame_1 - 11035 plays at the packet timestamp"
      * and derives its buffer latency from frame_2 - frame_1 (Apple senders:
      * 77175). The mapping is FROZEN at stream start — playback of the first
-     * frame begins latency_ms after the anchor point — and every periodic
+     * frame begins lead_ms after the anchor point — and every periodic
      * packet extrapolates along that same line, so all time-announces agree. */
     uint64_t wall = ap2_ptp_master_now_ns(p->ptp);
     if (!p->rt_anchor_valid) {
@@ -2182,7 +2182,7 @@ static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
              * (libraop's NTP fixed-point is UNIX-epoch: seconds<<32 | frac). */
             uint64_t unix_ns = (p->start_ntp >> 32) * 1000000000ULL
                              + (((p->start_ntp & 0xFFFFFFFFULL) * 1000000000ULL) >> 32);
-            p->rt_anchor_wall0 = unix_ns - (uint64_t)p->latency_ms * 1000000ULL;
+            p->rt_anchor_wall0 = unix_ns - (uint64_t)p->lead_ms * 1000000ULL;
             p->rt_anchor_pos0 = (uint32_t)NTP2TS(p->start_ntp, p->format.sample_rate)
                               + atomic_load(&p->rtp_offset);
         } else {
@@ -2196,17 +2196,17 @@ static ap2_send_result_t ap2_send_sync_packet_ptp(struct ap2cl_s *p, bool first)
          * bring its output path up. */
         int64_t audible_in_ms =
             ((int64_t)(p->rt_anchor_wall0 - wall) / 1000000LL)
-            + (int64_t)p->latency_ms;
+            + (int64_t)p->lead_ms;
         LOG_INFO("[AP2] anchor frozen: wall0=%" PRIu64 "ns pos0=%u "
-                 "latency_ms=%u start_ntp=%" PRIu64 " audible_in_ms=%" PRId64,
-                 p->rt_anchor_wall0, p->rt_anchor_pos0, p->latency_ms,
+                 "lead_ms=%u start_ntp=%" PRIu64 " audible_in_ms=%" PRId64,
+                 p->rt_anchor_wall0, p->rt_anchor_pos0, p->lead_ms,
                  p->start_ntp, audible_in_ms);
     }
     int64_t wall_delta_ns = wall >= p->rt_anchor_wall0
                                 ? (int64_t)(wall - p->rt_anchor_wall0)
                                 : -(int64_t)(p->rt_anchor_wall0 - wall);
     int64_t elapsed_ns = wall_delta_ns
-                       - (int64_t)p->latency_ms * 1000000LL;
+                       - (int64_t)p->lead_ms * 1000000LL;
     uint32_t play_pos = p->rt_anchor_pos0
                       + (uint32_t)((elapsed_ns * p->format.sample_rate) / 1000000000LL);
     uint32_t frame_1 = play_pos + 11035;
@@ -2434,7 +2434,7 @@ static bool ap2_raop_compat_connect(struct ap2cl_s *p)
     if (!hostent) return false;
     memcpy(&player_addr.s_addr, hostent->h_addr_list[0], hostent->h_length);
 
-    int latency_frames = MS2TS(p->latency_ms, p->format.sample_rate);
+    int latency_frames = MS2TS(p->lead_ms, p->format.sample_rate);
     bool mfi_auth = p->am && strcasestr(p->am, "airport");
 
     p->raopcl = raopcl_create(
@@ -2474,7 +2474,7 @@ struct ap2cl_s *ap2cl_create(
     ap2_device_info_t *device, ap2_audio_format_t *format,
     const char *auth, const char *password,
     const char *dacp_id, const char *active_remote,
-    int latency_ms, int volume)
+    int lead_ms, int volume)
 {
     struct ap2cl_s *p = calloc(1, sizeof(struct ap2cl_s));
     if (!p) return NULL;
@@ -2482,7 +2482,7 @@ struct ap2cl_s *ap2cl_create(
     p->device = *device;
     p->format = *format;
     p->state = AP2_DOWN;
-    p->latency_ms = latency_ms;
+    p->lead_ms = lead_ms;
     p->volume = volume;
     p->sock_fd = -1;
     p->data_sock = -1;
@@ -3336,7 +3336,7 @@ static bool ap2_splice_pad_to_lead(struct ap2cl_s *p, uint64_t now_ts,
                                    uint64_t lapse_ts, const char *cause)
 {
     uint64_t window = ap2_pacing_window_frames(p);
-    uint64_t latency = MS2TS(p->latency_ms, p->format.sample_rate);
+    uint64_t latency = MS2TS(p->lead_ms, p->format.sample_rate);
     uint64_t recovery_lead = latency < window ? latency : window;
     uint64_t effective_head = p->head_ts + p->splice_pad_frames;
     if (effective_head > lapse_ts) return false;
@@ -3363,7 +3363,7 @@ bool ap2cl_recover_input_gap(struct ap2cl_s *p)
     uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
     uint64_t floor = MS2TS(250, p->format.sample_rate);
     uint64_t window = ap2_pacing_window_frames(p);
-    uint64_t latency = MS2TS(p->latency_ms, p->format.sample_rate);
+    uint64_t latency = MS2TS(p->lead_ms, p->format.sample_rate);
     uint64_t recovery_lead = latency < window ? latency : window;
 
     if (p->splice_timeline) {
@@ -4404,7 +4404,7 @@ void ap2cl_format_capabilities(struct ap2cl_s *p,
 
 void ap2cl_latency_info(struct ap2cl_s *p, int *lead_ms, uint32_t *dev_min, uint32_t *dev_max)
 {
-    if (lead_ms) *lead_ms = p ? p->latency_ms : 0;
+    if (lead_ms) *lead_ms = p ? p->lead_ms : 0;
     if (dev_min) *dev_min = p ? p->dev_latency_min : 0;
     if (dev_max) *dev_max = p ? p->dev_latency_max : 0;
 }
@@ -4417,7 +4417,7 @@ uint32_t ap2cl_audible_lag_frames(struct ap2cl_s *p)
     if (!p) return 0;
     if (p->flow == FLOW_NATIVE_AP2 && p->splice_timeline)
         return (uint32_t)ap2_pacing_window_frames(p);
-    return (uint32_t)MS2TS(p->latency_ms, p->format.sample_rate);
+    return (uint32_t)MS2TS(p->lead_ms, p->format.sample_rate);
 }
 
 /* Minimum lead (ms) a warm commanded START needs for the new content to begin

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -107,9 +107,12 @@ extern log_level *loglevel;
 /* Verification needs room to act before the initial fill starts releasing
  * real frames at anchor - pacing depth: anchors closer than the depth plus
  * one poll round plus slack can never be corrected, so they are not armed. */
-#define AP2_CLOCK_VERIFY_MIN_WINDOW_MS (AP2_SPLICE_PACING_MS + 500)
+#define AP2_CLOCK_VERIFY_MIN_WINDOW_MS(p) (ap2_splice_depth_ms(p) + 500)
 /* Receiver queue depth on the splice timeline (§ splice below): the
- * depth IS the audible latency of a warm splice, so it stays shallow. */
+ * depth IS the audible latency of a warm splice, so it stays shallow.
+ * ap2_splice_depth_ms() applies the caller's --splice-depth-ms override:
+ * LinkPlay receivers acting as native multiroom master starve the AirPlay
+ * renderer below ~1 s of queued audio, so their caller asks for more. */
 #define AP2_SPLICE_PACING_MS         600
 /* Delivery pacing depth (§ pacing below). A frame handed over more than the
  * receiver's buffer ahead of its deadline overflows that buffer and is
@@ -243,6 +246,8 @@ struct ap2cl_s {
                                      anchor line — the native default; false
                                      only for deny-listed receivers (see the
                                      splice comments at flush/resume/standby) */
+    int splice_depth_ms;          /* >0: --splice-depth-ms override of the
+                                     AP2_SPLICE_PACING_MS queue depth */
     uint32_t splice_pad_frames;   /* silence frames still to send before the
                                      next real sample so it lands exactly on
                                      the commanded splice instant */
@@ -2590,6 +2595,23 @@ void ap2cl_set_publish_ip(struct ap2cl_s *p, const char *ip)
     p->publish_ip = strdup(ip);
 }
 
+/* Effective splice queue depth: the compiled default unless the caller
+ * supplied --splice-depth-ms. Every consumer of the depth (pacing, warm
+ * lead, clock-verification windows, connect log) reads it from here so an
+ * override moves them all coherently. */
+static uint32_t ap2_splice_depth_ms(struct ap2cl_s *p)
+{
+    return p->splice_depth_ms > 0 ? (uint32_t)p->splice_depth_ms
+                                  : AP2_SPLICE_PACING_MS;
+}
+
+void ap2cl_set_splice_depth_ms(struct ap2cl_s *p, int ms)
+{
+    if (!p || ms <= 0) return;
+    p->splice_depth_ms = ms;
+    LOG_INFO("[AP2] splice queue depth override: %d ms", ms);
+}
+
 void ap2cl_set_ptp(struct ap2cl_s *p, bool enable)
 {
     if (!p) return;
@@ -2642,7 +2664,7 @@ bool ap2cl_connect(struct ap2cl_s *p)
         p->apple_model = ap2_apple_model(p->device.txt_records, p->am);
         if (p->splice_timeline) {
             LOG_INFO("[AP2] splice timeline (discard-free warm path, "
-                     "%d ms queue depth)", AP2_SPLICE_PACING_MS);
+                     "%u ms queue depth)", ap2_splice_depth_ms(p));
         } else {
             LOG_INFO("[AP2] deny-listed receiver: classic flush + re-anchor "
                      "warm path");
@@ -2846,7 +2868,7 @@ static void ap2_clock_verify_arm(struct ap2cl_s *p, uint64_t requested_unix_ms,
 {
     if (!p->splice_timeline || !p->use_ptp) return;
     uint64_t now_ms = ap2_ntp_to_unix_ms(raopcl_get_ntp(NULL));
-    if (at_unix_ms < now_ms + AP2_CLOCK_VERIFY_MIN_WINDOW_MS) return;
+    if (at_unix_ms < now_ms + AP2_CLOCK_VERIFY_MIN_WINDOW_MS(p)) return;
     pthread_mutex_lock(&p->clock_verify_lock);
     p->clock_verify_armed = true;
     p->clock_verify_enforce = enforce;
@@ -3256,7 +3278,7 @@ static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
      * are the LAN-local targets owntone has fed at realtime pacing for years,
      * so the reduced dropout headroom is field-proven there. */
     if (p->splice_timeline) {
-        uint64_t depth = (uint64_t)MS2TS(AP2_SPLICE_PACING_MS,
+        uint64_t depth = (uint64_t)MS2TS(ap2_splice_depth_ms(p),
                                          p->format.sample_rate);
         return depth < window ? depth : window;
     }
@@ -3541,7 +3563,7 @@ ap2_clock_verify_result_t ap2cl_clock_verify_poll(struct ap2cl_s *p,
                      "seat", ready_ms - anchor_ms);
         }
     } else if (sent || now_ms + AP2_CLOCK_VERIFY_POLL_MS >=
-                           anchor_ms - AP2_SPLICE_PACING_MS) {
+                           anchor_ms - ap2_splice_depth_ms(p)) {
         ev->requested_unix_ms = p->clock_verify_requested_unix_ms;
         ev->from_unix_ms = anchor_ms;
         ev->at_unix_ms = anchor_ms;
@@ -4404,7 +4426,7 @@ uint32_t ap2cl_audible_lag_frames(struct ap2cl_s *p)
  * anchor beyond it. 0 = no constraint (stock flush+re-anchor path). */
 int ap2cl_warm_lead_ms(struct ap2cl_s *p)
 {
-    return p && p->splice_timeline ? AP2_SPLICE_PACING_MS : 0;
+    return p && p->splice_timeline ? (int)ap2_splice_depth_ms(p) : 0;
 }
 
 /* Wall-clock instant (unix ms) at which the current delivery head becomes

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -110,7 +110,7 @@ extern log_level *loglevel;
 #define AP2_CLOCK_VERIFY_MIN_WINDOW_MS(p) (ap2_splice_depth_ms(p) + 500)
 /* Receiver queue depth on the splice timeline (§ splice below): the
  * depth IS the audible latency of a warm splice, so it stays shallow.
- * ap2_splice_depth_ms() applies the caller's --buffer-depth-ms override:
+ * ap2_splice_depth_ms() applies the caller's override (ap2cl_set_splice_depth_ms):
  * LinkPlay receivers acting as native multiroom master starve the AirPlay
  * renderer below ~1 s of queued audio, so their caller asks for more. */
 #define AP2_SPLICE_PACING_MS         600
@@ -246,7 +246,7 @@ struct ap2cl_s {
                                      anchor line — the native default; false
                                      only for deny-listed receivers (see the
                                      splice comments at flush/resume/standby) */
-    int splice_depth_ms;          /* >0: --buffer-depth-ms override of the
+    int splice_depth_ms;          /* >0: caller override of the
                                      AP2_SPLICE_PACING_MS queue depth */
     uint32_t splice_pad_frames;   /* silence frames still to send before the
                                      next real sample so it lands exactly on
@@ -2601,8 +2601,20 @@ void ap2cl_set_publish_ip(struct ap2cl_s *p, const char *ip)
  * override moves them all coherently. */
 static uint32_t ap2_splice_depth_ms(struct ap2cl_s *p)
 {
-    return p->splice_depth_ms > 0 ? (uint32_t)p->splice_depth_ms
-                                  : AP2_SPLICE_PACING_MS;
+    uint32_t depth = p->splice_depth_ms > 0 ? (uint32_t)p->splice_depth_ms
+                                            : AP2_SPLICE_PACING_MS;
+    /* Same cap as the pacing window - the receiver's reported buffer minus
+     * the delivery margin, or the assumed standard window when unreported -
+     * so every consumer (pacing, warm lead, verification windows, the
+     * connect log) sees one effective depth. */
+    uint32_t cap_ms = AP2_PACING_DEFAULT_BUFFER_MS - AP2_PACING_MARGIN_MS;
+    if (p->format.sample_rate > 0) {
+        uint64_t margin = MS2TS(AP2_PACING_MARGIN_MS, p->format.sample_rate);
+        if (p->dev_latency_max > margin)
+            cap_ms = (uint32_t)((p->dev_latency_max - margin) * 1000ULL /
+                                (uint32_t)p->format.sample_rate);
+    }
+    return depth < cap_ms ? depth : cap_ms;
 }
 
 void ap2cl_set_splice_depth_ms(struct ap2cl_s *p, int ms)

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -111,10 +111,8 @@ uint64_t ap2_txt_flags(const char *txt);
  * :param bit_depth: requested output bit depth (informational; hi-res rides
  *                   the realtime stream).
  * :param force_native: --ap2-native was given (forces the native AP2 flow).
- * :param ptp_forced: --ptp or --no-ptp was given (overrides the SupportsPTP
- *                    auto-detect).
- * :param ptp_enabled: the forced timing when ptp_forced: true for --ptp,
- *                     false for --no-ptp (which wins when both are given).
+ * :param ptp_forced: --ptp was given (overrides the SupportsPTP auto-detect).
+ * :param ptp_enabled: the value passed to --ptp.
  */
 ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char *pw,
                               bool have_credentials, bool have_password,
@@ -150,7 +148,7 @@ ap2_connect_error_t ap2cl_connect_error(struct ap2cl_s *p, int *http_status,
  * :param password: Device password, or NULL.
  * :param dacp_id: DACP identifier for remote control.
  * :param active_remote: Active-Remote identifier.
- * :param latency_ms: Output buffer duration in milliseconds.
+ * :param lead_ms: Anchor-to-render lead in milliseconds.
  * :param volume: Initial volume (0-100), or -1 for no initial set.
  */
 struct ap2cl_s *ap2cl_create(
@@ -160,7 +158,7 @@ struct ap2cl_s *ap2cl_create(
     const char *password,
     const char *dacp_id,
     const char *active_remote,
-    int latency_ms,
+    int lead_ms,
     int volume
 );
 

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -427,6 +427,16 @@ void ap2cl_force_native(struct ap2cl_s *p);
  * falls back to NTP timing. */
 void ap2cl_set_ptp(struct ap2cl_s *p, bool enable);
 
+/*
+ * Override the splice-timeline receiver queue depth (default 600 ms). The
+ * depth is the audible latency of every warm seek/next, but receivers that
+ * feed a native multiroom pipeline (LinkPlay masters) starve below ~1 s of
+ * queued audio and render silence, so their caller asks for more. Values
+ * <= 0 are ignored; the effective depth stays capped by the receiver's
+ * reported (or assumed) buffer window.
+ */
+void ap2cl_set_splice_depth_ms(struct ap2cl_s *p, int ms);
+
 /* Prefer a shared PTP daemon clock (multi-room) for the native AP2 flow. When
  * enabled and a live `cliairplay --ptp-daemon` is present on this host, the
  * client reads the elected clock from shared memory and does NOT bind UDP

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -2094,9 +2094,9 @@ int main(int argc, char *argv[])
      * cfg.route carries the AirPlay 2 sub-decisions applied in run_airplay2(). */
     bool have_creds = cfg.auth && strlen(cfg.auth) == 192;
     bool have_password = cfg.password && *cfg.password;
-    /* --no-ptp wins over --ptp and the SupportsPTP auto-detect: some receivers
-     * advertise PTP but never render a PTP-timed stream (old LinkPlay platform
-     * firmware), and the caller knows better than the TXT records. */
+    /* --no-ptp wins over --ptp and the SupportsPTP auto-detect. Diagnostic
+     * escape hatch only: no device is routed here by default (receivers that
+     * looked PTP-broken turned out to need a deeper splice queue instead). */
     bool ptp_forced = cfg.ptp || cfg.no_ptp;
     bool ptp_enabled = cfg.ptp && !cfg.no_ptp;
     cfg.route = ap2_resolve_route(cfg.proto_pref, cfg.ap2_txt, cfg.pw, have_creds,

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -1836,9 +1836,9 @@ static void print_usage(const char *name)
     printf("Common options:\n");
     printf("  --port <port>              Device port (default: 5000)\n");
     printf("  --volume <0-100>           Initial volume level\n");
-    printf("  --latency <ms>             Receiver buffer depth in ms (default 600;\n");
-    printf("                             deeper feeds devices whose pipeline starves,\n");
-    printf("                             at the cost of seek responsiveness)\n");
+    printf("  --latency <ms>             Receiver buffer depth in ms (native AirPlay 2\n");
+    printf("                             only; default 600; deeper feeds devices whose\n");
+    printf("                             pipeline starves, at the cost of seek response)\n");
     printf("  --dacp <id>                DACP ID\n");
     printf("  --activeremote <id>        Active Remote ID\n");
     printf("  --cmdpipe <path>           Required named pipe for commands and metadata\n");

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -1880,7 +1880,7 @@ static void print_usage(const char *name)
     printf("                             SupportsPTP feature bit)\n");
     printf("  --no-ptp                   Force NTP timing even when the device\n");
     printf("                             advertises SupportsPTP (wins over --ptp)\n");
-    printf("  --splice-depth-ms <ms>     Receiver queue depth on the splice timeline\n");
+    printf("  --buffer-depth-ms <ms>     Receiver queue depth on the splice timeline\n");
     printf("                             (default 600; deeper feeds multiroom masters,\n");
     printf("                             at the cost of seek responsiveness)\n");
     printf("  --ptp-shared               Prefer a shared PTP daemon clock (multi-room):\n");
@@ -1958,7 +1958,7 @@ int main(int argc, char *argv[])
         {"publish-ip",   required_argument, 0, 1008},
         {"ptp",          no_argument,       0, 1009},
         {"no-ptp",       no_argument,       0, 1014},
-        {"splice-depth-ms", required_argument, 0, 1015},
+        {"buffer-depth-ms", required_argument, 0, 1015},
         {"ptp-daemon",   no_argument,       0, 1011},
         {"ptp-shared",   no_argument,       0, 1012},
         {"check",        no_argument,       0, 1002},

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -101,6 +101,7 @@ typedef struct {
     char *publish_ip;       /* address advertised to devices (multi-homed hosts) */
     bool ptp;               /* force PTP grandmaster timing for native AP2 */
     bool no_ptp;            /* force NTP timing even when SupportsPTP is advertised */
+    int splice_depth_ms;    /* >0: override the splice receiver-queue depth */
     bool ptp_shared;        /* prefer a shared PTP daemon clock (multi-room) */
 
     /* Audio format */
@@ -1325,6 +1326,8 @@ static int run_airplay2(cli_config_t *cfg)
     if (cfg->publish_ip)
         ap2cl_set_publish_ip(client, cfg->publish_ip);
     ap2cl_set_ptp(client, cfg->route.ptp);
+    if (cfg->splice_depth_ms > 0)
+        ap2cl_set_splice_depth_ms(client, cfg->splice_depth_ms);
     ap2cl_set_ptp_shared(client, cfg->ptp_shared);
     ap2cl_set_remote_command_callback(
         client, remote_command_event, NULL);
@@ -1877,6 +1880,9 @@ static void print_usage(const char *name)
     printf("                             SupportsPTP feature bit)\n");
     printf("  --no-ptp                   Force NTP timing even when the device\n");
     printf("                             advertises SupportsPTP (wins over --ptp)\n");
+    printf("  --splice-depth-ms <ms>     Receiver queue depth on the splice timeline\n");
+    printf("                             (default 600; deeper feeds multiroom masters,\n");
+    printf("                             at the cost of seek responsiveness)\n");
     printf("  --ptp-shared               Prefer a shared PTP daemon clock (multi-room):\n");
     printf("                             read the elected clock from shared memory and do\n");
     printf("                             not bind 319/320 when a daemon is present; else\n");
@@ -1952,6 +1958,7 @@ int main(int argc, char *argv[])
         {"publish-ip",   required_argument, 0, 1008},
         {"ptp",          no_argument,       0, 1009},
         {"no-ptp",       no_argument,       0, 1014},
+        {"splice-depth-ms", required_argument, 0, 1015},
         {"ptp-daemon",   no_argument,       0, 1011},
         {"ptp-shared",   no_argument,       0, 1012},
         {"check",        no_argument,       0, 1002},
@@ -2003,6 +2010,7 @@ int main(int argc, char *argv[])
         case 1008: cfg.publish_ip = optarg; break;
         case 1009: cfg.ptp = true; break;
         case 1014: cfg.no_ptp = true; break;
+        case 1015: cfg.splice_depth_ms = atoi(optarg); break;
         case 1011: ptp_daemon_mode = true; break;
         case 1013: pair_setup_mode = true; break;
         case 1012: cfg.ptp_shared = true; break;

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -72,7 +72,7 @@ typedef struct {
     char *host;
     int port;
     int volume;
-    int latency_ms;
+    int lead_ms;            /* anchor->render lead (fixed 2000 ms; no external knob) */
     int debug_level;
     char *dacp_id;
     char *active_remote;
@@ -100,7 +100,6 @@ typedef struct {
     bool force_native;      /* force native AP2 flow (transient pairing) */
     char *publish_ip;       /* address advertised to devices (multi-homed hosts) */
     bool ptp;               /* force PTP grandmaster timing for native AP2 */
-    bool no_ptp;            /* force NTP timing even when SupportsPTP is advertised */
     int splice_depth_ms;    /* >0: override the splice receiver-queue depth */
     bool ptp_shared;        /* prefer a shared PTP daemon clock (multi-room) */
 
@@ -509,9 +508,9 @@ static void mrp_artwork_reject_local(const char *reason)
 
 /* Also emit the older human-readable status line; the [STATUS] lines from
  * status_connected/status_playing are what the MA provider parses. */
-static void status_connected_legacy(const char *host, int port, int latency_ms)
+static void status_connected_legacy(const char *host, int port, int lead_ms)
 {
-    LOG_INFO("connected to %s on port %d, player latency is %d ms", host, port, latency_ms);
+    LOG_INFO("connected to %s on port %d, player latency is %d ms", host, port, lead_ms);
     status_connected();
 }
 
@@ -1072,7 +1071,7 @@ static int run_raop(cli_config_t *cfg)
      * that was not supplied is rejected before any connect attempt (main). */
     char *password = (cfg->password && *cfg->password) ? cfg->password : NULL;
 
-    int latency = MS2TS(cfg->latency_ms, cfg->sample_rate);
+    int latency = MS2TS(cfg->lead_ms, cfg->sample_rate);
 
     /* Codec selection: default to compressed ALAC, which virtually every RAOP
      * receiver advertises and which saves LAN bandwidth. Fall back to uncompressed
@@ -1308,7 +1307,7 @@ static int run_airplay2(cli_config_t *cfg)
 
     struct ap2cl_s *client = ap2cl_create(
         &device, &format, cfg->auth, cfg->password,
-        cfg->dacp_id, cfg->active_remote, cfg->latency_ms, cfg->volume);
+        cfg->dacp_id, cfg->active_remote, cfg->lead_ms, cfg->volume);
     if (!client) {
         status_error_ex(ERROR_CODE_CONNECT_FAILED, 0,
                         "cannot create the AirPlay 2 client",
@@ -1492,7 +1491,7 @@ static int run_airplay2(cli_config_t *cfg)
              * burst on Apple receivers), while a later teardown with silence
              * still queued is clean. */
             bool drained = !ap2cl_is_playing(g_ap2cl) ||
-                           now - eof_time > MS2NTP(cfg->latency_ms + 2000);
+                           now - eof_time > MS2NTP(cfg->lead_ms + 2000);
             if (drained && !eof_reported) {
                 eof_reported = true;
                 status_eof();
@@ -1837,8 +1836,9 @@ static void print_usage(const char *name)
     printf("Common options:\n");
     printf("  --port <port>              Device port (default: 5000)\n");
     printf("  --volume <0-100>           Initial volume level\n");
-    printf("  --latency <ms>             Playback lead / buffer in ms (default: 2000,\n");
-    printf("                             clamped into the device-reported window)\n");
+    printf("  --latency <ms>             Receiver buffer depth in ms (default 600;\n");
+    printf("                             deeper feeds devices whose pipeline starves,\n");
+    printf("                             at the cost of seek responsiveness)\n");
     printf("  --dacp <id>                DACP ID\n");
     printf("  --activeremote <id>        Active Remote ID\n");
     printf("  --cmdpipe <path>           Required named pipe for commands and metadata\n");
@@ -1878,11 +1878,6 @@ static void print_usage(const char *name)
     printf("  --ptp                      Force PTP grandmaster timing (native AP2;\n");
     printf("                             binds UDP 319/320, needs root; else auto by\n");
     printf("                             SupportsPTP feature bit)\n");
-    printf("  --no-ptp                   Force NTP timing even when the device\n");
-    printf("                             advertises SupportsPTP (wins over --ptp)\n");
-    printf("  --buffer-depth-ms <ms>     Receiver queue depth on the splice timeline\n");
-    printf("                             (default 600; deeper feeds multiroom masters,\n");
-    printf("                             at the cost of seek responsiveness)\n");
     printf("  --ptp-shared               Prefer a shared PTP daemon clock (multi-room):\n");
     printf("                             read the elected clock from shared memory and do\n");
     printf("                             not bind 319/320 when a daemon is present; else\n");
@@ -1908,7 +1903,7 @@ int main(int argc, char *argv[])
         .proto_pref = AP2_PROTO_AUTO,
         .port = 5000,
         .volume = 0,
-        .latency_ms = 2000,
+        .lead_ms = 2000,
         .debug_level = 3,
         .dacp_id = "1A2B3D4EA1B2C3D4",
         .active_remote = "ap5918800d",
@@ -1957,8 +1952,6 @@ int main(int argc, char *argv[])
         {"ap2-native",   no_argument,       0, 1007},
         {"publish-ip",   required_argument, 0, 1008},
         {"ptp",          no_argument,       0, 1009},
-        {"no-ptp",       no_argument,       0, 1014},
-        {"buffer-depth-ms", required_argument, 0, 1015},
         {"ptp-daemon",   no_argument,       0, 1011},
         {"ptp-shared",   no_argument,       0, 1012},
         {"check",        no_argument,       0, 1002},
@@ -1982,7 +1975,7 @@ int main(int argc, char *argv[])
             break;
         case 'p': cfg.port = atoi(optarg); break;
         case 'v': cfg.volume = atoi(optarg); break;
-        case 'l': cfg.latency_ms = atoi(optarg); break;
+        case 'l': cfg.splice_depth_ms = atoi(optarg); break;
         case 'D': cfg.dacp_id = optarg; break;
         case 'R': cfg.active_remote = optarg; break;
         case 'C': cfg.cmdpipe = optarg; break;
@@ -2009,8 +2002,6 @@ int main(int argc, char *argv[])
         case 1007: cfg.force_native = true; break;
         case 1008: cfg.publish_ip = optarg; break;
         case 1009: cfg.ptp = true; break;
-        case 1014: cfg.no_ptp = true; break;
-        case 1015: cfg.splice_depth_ms = atoi(optarg); break;
         case 1011: ptp_daemon_mode = true; break;
         case 1013: pair_setup_mode = true; break;
         case 1012: cfg.ptp_shared = true; break;
@@ -2094,14 +2085,9 @@ int main(int argc, char *argv[])
      * cfg.route carries the AirPlay 2 sub-decisions applied in run_airplay2(). */
     bool have_creds = cfg.auth && strlen(cfg.auth) == 192;
     bool have_password = cfg.password && *cfg.password;
-    /* --no-ptp wins over --ptp and the SupportsPTP auto-detect. Diagnostic
-     * escape hatch only: no device is routed here by default (receivers that
-     * looked PTP-broken turned out to need a deeper splice queue instead). */
-    bool ptp_forced = cfg.ptp || cfg.no_ptp;
-    bool ptp_enabled = cfg.ptp && !cfg.no_ptp;
     cfg.route = ap2_resolve_route(cfg.proto_pref, cfg.ap2_txt, cfg.pw, have_creds,
                                   have_password, cfg.bit_depth, cfg.force_native,
-                                  ptp_forced, ptp_enabled);
+                                  cfg.ptp, cfg.ptp);
     cfg.protocol = cfg.route.use_raop ? PROTO_RAOP : PROTO_AIRPLAY2;
     LOG_INFO("[AP2] auto-selected: %s; timing=%s; features=0x%llx; flags=0x%llx; bitdepth=%d",
              cfg.route.reason,


### PR DESCRIPTION
Some receivers feed the AirPlay stream through an internal (multiroom) pipeline that starves below ~1 s of queued audio: at the 600 ms splice depth they render silence while the session looks perfectly healthy. LinkPlay devices are the known case - an Edifier MS50A even solo, a WiiM whenever it is master of a native multiroom group (worked before #25 shrank the window from 1750 ms to 600 ms).

`--latency <ms>` now sets the receiver buffer depth for such devices, at the cost of slower warm seeks (the option was unused externally; the anchor-to-render lead it used to feed keeps its fixed 2000 ms default, renamed `lead_ms` internally to match the status line). All consumers of the depth move together (pacing, warm lead reported to the caller, clock-verification windows). Verified live at 1000 ms on the MS50A - with PTP timing intact.

Also removes `--no-ptp` (#54): the receivers it was written for needed a deeper buffer, not NTP timing, and nothing passes it once music-assistant/server#5369 lands - which must merge right after this release's version pin.