### PR TITLE
Keep the Apple TV now-playing screen intact across pause and track changes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -566,8 +566,15 @@ Playback state is re-sent on every start/pause/resume/stop and now-playing on
 every metadata/progress/artwork change — all caller-driven; nothing on this
 path is pushed on a timer. Progress itself is never streamed — the receiver
 extrapolates position from `ElapsedTime` + `Timestamp` + `PlaybackRate`, so a
-steady state needs no push. The ~15 s defensive state re-push belongs to the
-type-130 channel below, which is off by default.
+steady state needs no push. That same extrapolation is why pause and resume
+each push a timeline update (the `mergePolicy: "update"` shape below) before
+their `updateMRPlaybackState`, matching the Apple sender's info-then-state
+order: a bare state flip leaves the receiver showing the last literal
+`ElapsedTime` it was sent (usually the track start) on pause, and
+extrapolating across the paused wall-time span on resume. The frozen/resumed
+elapsed with a fresh `Timestamp` pins both transitions; teardown (stop) stays
+state-only. The ~15 s defensive state re-push belongs to the type-130 channel
+below, which is off by default.
 
 **`updateMRNowPlayingInfo` envelope.** The `npi-text` / `mergePolicy` wrapper
 is mandatory; a bare or fabricated outer type string is rejected with HTTP 400:
@@ -619,23 +626,39 @@ rare by design (track/artwork change, play/pause), so per-push bytes cost a
 few tens of KB on the control channel at human-action frequency, and a
 receiver that dropped its art self-heals on the next push.
 
-Pure timeline corrections (seek) use `mergePolicy: "update"` instead,
-carrying only the timeline fields and no artwork keys: a bytes-carrying
-replace push makes tvOS visibly re-decode and re-set the cover on every seek.
-Measured on the same hardware, the update push returns 200, the new elapsed
-lands as an in-place content-item update (no `SET_STATE` re-render), and
-`artworkAvailable` stays true. A receiver that rejects the policy with an
-HTTP error automatically gets full replace pushes for the rest of the session
-(`ap2cl_mrp_push_progress`).
+Pure timeline corrections — seek, and the pause/resume pushes above — use
+`mergePolicy: "update"` instead, carrying only the timeline fields and no
+artwork keys: a bytes-carrying replace push makes tvOS visibly re-decode and
+re-set the cover on every seek. Measured on the same hardware, the update push
+returns 200, the new elapsed lands as an in-place content-item update (no
+`SET_STATE` re-render), and `artworkAvailable` stays true. A receiver that
+rejects the policy with an HTTP error automatically gets full replace pushes
+for the rest of the session (`ap2cl_mrp_push_progress`).
 
-Identity churn is equally destructive and equally guarded: `set_metadata`
-mints a fresh `UniqueIdentifier` only when title/artist/album actually change
-(a redundant re-send under a fresh uid reads as a new item and orphans
-delivered artwork), a track change drops the previous track's staged art so it
-cannot ride the new item, and re-staging byte-identical artwork is a reported
-no-op (`unchanged`) that keeps the current `ArtworkIdentifier` — an identifier
-flip alone makes the receiver invalidate and re-resolve what it is already
-showing, which re-renders its Now Playing UI.
+Identity churn is equally destructive and equally guarded: `set_track` mints
+a fresh `UniqueIdentifier` only when the item identity (item id, else the
+title/artist/album tuple) actually changes — a redundant re-send under a
+fresh uid reads as a new item and orphans delivered artwork — and a track
+change without new artwork drops the previous track's staged art so it cannot
+ride the new item. Byte-identical artwork is a reported no-op (`unchanged`)
+that keeps the current `ArtworkIdentifier`, including across a track change
+(one album's cover survives its track boundaries): an identifier flip alone
+makes the receiver invalidate and re-resolve what it is already showing,
+which re-renders its Now Playing UI.
+
+A track change is therefore pushed as one transaction. The `ARTWORKFILE`
+pipe key stages an artwork path and `ACTION=SENDMETA` consumes it one-shot,
+applying metadata and artwork to MRP state in a single change
+(`ap2_mrp_set_track`) and emitting a single replace push that carries item,
+duration, elapsed, rate and artwork together — the shape a real Apple sender
+emits at a track change. The earlier split sequence (a replace without art,
+a timeline correction, then a second replace re-minting the artwork
+identifier for byte-identical art) rewrote the receiver's now-playing state
+three times within ~100 ms of every track change; observed on tvOS, that
+burst left the Now Playing view degraded (progress bar gone, artwork not
+re-rendered) until the app was re-entered. The DMAP `SET_PARAMETER` copy is
+still re-sent on every identity change, byte-identical or not, since
+Sonos-class receivers consume only that path.
 
 The complete registration/now-playing/extended-state sequence is serialized;
 its return value carries request-scoped overall and `updateMRNowPlayingInfo`
@@ -896,7 +919,9 @@ capture.
   needed. `ARTWORK` accepts local files and MA's local HTTP imageproxy URLs;
   imageproxy requests are normalized to supported `size=512&fmt=jpeg` values,
   and fetches have a 5-second overall deadline so metadata I/O cannot starve
-  the feedback/event keepalive loop.
+  the feedback/event keepalive loop. `ARTWORKFILE` stages the same inputs
+  without pushing; the next `SENDMETA` consumes the staged path — success or
+  failure — and pushes metadata and artwork as one bundle (§8).
 
 ## 11. Device-behavior findings
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -573,8 +573,11 @@ order: a bare state flip leaves the receiver showing the last literal
 `ElapsedTime` it was sent (usually the track start) on pause, and
 extrapolating across the paused wall-time span on resume. The frozen/resumed
 elapsed with a fresh `Timestamp` pins both transitions; teardown (stop) stays
-state-only. The ~15 s defensive state re-push belongs to the type-130 channel
-below, which is off by default.
+state-only. A receiver demoted to full replace pushes (update-policy
+rejection, below) gets the artwork-bearing replace shape at pause/resume too:
+the correct frozen elapsed is judged worth the re-render on such receivers,
+none of which have been observed in practice. The ~15 s defensive state
+re-push belongs to the type-130 channel below, which is off by default.
 
 **`updateMRNowPlayingInfo` envelope.** The `npi-text` / `mergePolicy` wrapper
 is mandatory; a bare or fabricated outer type string is rejected with HTTP 400:

--- a/README.md
+++ b/README.md
@@ -266,8 +266,11 @@ stdin, the single persistent audio input for the whole process lifetime.
 - `VOLUME=<0-100>`.
 - Metadata: `TITLE=`, `ARTIST=`, `ALBUM=`, `DURATION=<s>`, `PROGRESS=<s>`,
   `ITEMID=<stable per-track id>`,
-  `ARTWORK=<local file path or http:// imageproxy URL>`, followed by
-  `ACTION=SENDMETA` to push the set.
+  `ARTWORKFILE=<local file path or http:// imageproxy URL>` (staged; an empty
+  value clears the staging), followed by `ACTION=SENDMETA` to push the set —
+  metadata and the staged artwork as one bundle; the staged path is consumed
+  by that push. `ARTWORK=<local file path or http:// imageproxy URL>` pushes
+  artwork on its own, outside a track change.
 
 `[STATUS] stopped` acknowledges `ACTION=STOP` once playback has been torn down.
 `STOP` is terminal: the audio loop exits, the connection is torn down and the
@@ -292,10 +295,11 @@ MediaRemote `POST /command`, including explicit play/pause/stop state. Set
 `ITEMID` keys the now-playing item identity: metadata re-sent under the same
 id updates the item in place (a tag refinement never presents as a new
 track), while a new id is a track change that starts at 0:00; without ids,
-identity falls back to the title/artist/album tuple. Byte-identical
-`ARTWORK=` re-sends are ignored, and a `PROGRESS=` correction rides a lean
-merge update on MediaRemote sessions, so a seek never redraws the receiver's
-now-playing screen.
+identity falls back to the title/artist/album tuple. Byte-identical artwork
+keeps its identity even across a track change, redundant `ARTWORK=` re-sends
+are ignored, and a `PROGRESS=` correction — like the pause/resume timeline —
+rides a lean merge update on MediaRemote sessions, so neither a seek nor a
+track change on one album redraws the receiver's now-playing screen.
 Metadata strings are encoded as Unicode binary-plist strings; artwork is
 signature-checked and capped at 5 MiB. MA imageproxy URLs are normalized to a
 supported `size=512&fmt=jpeg` request.

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -4113,14 +4113,21 @@ static void ap2_mrp_publish_playback(struct ap2cl_s *p,
      * (pause) or extrapolating across the paused span (resume). The timeline
      * push carries the elapsed just frozen/resumed by set_playing above with
      * a fresh timestamp, before the state post — info-then-state, the Apple
-     * sender order. A successful push already chains updateMRPlaybackState,
-     * so dropping force lets the explicit send below dedupe instead of
-     * posting the same state twice; any failure keeps the forced explicit
-     * send as the fallback. Teardown (STOPPED) stays state-only. */
-    if (state != AP2_MRP_PLAYBACK_STOPPED &&
-        ap2_mrp_status_ok(
-            ap2cl_mrp_push_progress_serialized(p).overall_status))
-        force = false;
+     * sender order. On a real transition a successful push already chains
+     * updateMRPlaybackState, so dropping force lets the explicit send below
+     * dedupe instead of posting the same state twice. A redundant publish
+     * (state already current) keeps force: the chained send dedupes there,
+     * and the forced explicit post is the caller's re-assert toward a
+     * receiver whose state may have drifted. Any push failure keeps the
+     * forced explicit send as the fallback. Teardown (STOPPED) stays
+     * state-only. */
+    if (state != AP2_MRP_PLAYBACK_STOPPED) {
+        bool state_was_current = p->mrp_last_playback_state == state;
+        if (ap2_mrp_status_ok(
+                ap2cl_mrp_push_progress_serialized(p).overall_status) &&
+            !state_was_current)
+            force = false;
+    }
     ap2_mrp_send_playback_state(p, state, force);
     pthread_mutex_unlock(&p->mrp_publish_lock);
 }
@@ -4294,6 +4301,7 @@ int ap2cl_mrp_register(struct ap2cl_s *p)
 static bool ap2_send_dmap_artwork(struct ap2cl_s *p, const char *content_type,
                                   int size, const char *data)
 {
+    if (!content_type || !*content_type || !data || size <= 0) return false;
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
         char rtpinfo[48];
         snprintf(rtpinfo, sizeof(rtpinfo), "RTP-Info: rtptime=%u\r\n", p->rtp_timestamp);
@@ -4316,11 +4324,13 @@ bool ap2cl_set_metadata_ex(struct ap2cl_s *p, const char *title,
                            const char *artist, const char *album,
                            int duration, const char *item_id,
                            const char *content_type, const uint8_t *art_data,
-                           int art_len, ap2_mrp_artwork_info_t *mrp_info,
+                           int art_len, bool *track_changed_out,
+                           ap2_mrp_artwork_info_t *mrp_info,
                            ap2_mrp_push_result_t *mrp_push)
 {
     ap2_mrp_artwork_info_t local_info;
     if (!mrp_info) mrp_info = &local_info;
+    if (track_changed_out) *track_changed_out = false;
     if (mrp_push) *mrp_push = ap2_mrp_push_result_empty();
     memset(mrp_info, 0, sizeof(*mrp_info));
     mrp_info->result = AP2_MRP_ARTWORK_NOT_APPLICABLE;
@@ -4337,6 +4347,7 @@ bool ap2cl_set_metadata_ex(struct ap2cl_s *p, const char *title,
                           item_id, content_type, art_data, art_len,
                           &track_changed, mrp_info);
     pthread_mutex_unlock(&p->mrp_lock);
+    if (track_changed_out) *track_changed_out = track_changed;
 
     bool dmap_ok;
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0)
@@ -4371,7 +4382,7 @@ bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist
                         const char *album, int duration, const char *item_id)
 {
     return ap2cl_set_metadata_ex(p, title, artist, album, duration, item_id,
-                                 NULL, NULL, 0, NULL, NULL);
+                                 NULL, NULL, 0, NULL, NULL, NULL);
 }
 
 bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size,
@@ -4592,7 +4603,9 @@ bool ap2cl_is_playing(struct ap2cl_s *p)
  * client takes ownership (ap2cl_destroy frees it). */
 void ap2cl_test_set_mrp(struct ap2cl_s *p, struct ap2_mrp_ctx *m)
 {
+    pthread_mutex_lock(&p->mrp_lock);
     p->mrp = m;
+    pthread_mutex_unlock(&p->mrp_lock);
 }
 
 void ap2cl_test_lock_mrp(struct ap2cl_s *p)

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -365,6 +365,8 @@ static int ap2_mrp_send_playback_state(struct ap2cl_s *p,
 static void ap2_mrp_publish_playback(struct ap2cl_s *p,
                                      ap2_mrp_playback_state_t state,
                                      bool force);
+static ap2_mrp_push_result_t ap2cl_mrp_push_progress_serialized(
+    struct ap2cl_s *p);
 static bool ap2_set_nonblocking(int fd, const char *name);
 static void ap2_raop_session_cleanup(struct ap2cl_s *p);
 static void ap2_clock_verify_disarm(struct ap2cl_s *p);
@@ -4105,6 +4107,20 @@ static void ap2_mrp_publish_playback(struct ap2cl_s *p,
                 p->mrp, state == AP2_MRP_PLAYBACK_PLAYING);
     }
     pthread_mutex_unlock(&p->mrp_lock);
+    /* Pause/resume must carry the transition's timeline: the receiver
+     * extrapolates position from ElapsedTime + Timestamp + PlaybackRate, so a
+     * bare state flip leaves it showing the last literal elapsed it received
+     * (pause) or extrapolating across the paused span (resume). The timeline
+     * push carries the elapsed just frozen/resumed by set_playing above with
+     * a fresh timestamp, before the state post — info-then-state, the Apple
+     * sender order. A successful push already chains updateMRPlaybackState,
+     * so dropping force lets the explicit send below dedupe instead of
+     * posting the same state twice; any failure keeps the forced explicit
+     * send as the fallback. Teardown (STOPPED) stays state-only. */
+    if (state != AP2_MRP_PLAYBACK_STOPPED &&
+        ap2_mrp_status_ok(
+            ap2cl_mrp_push_progress_serialized(p).overall_status))
+        force = false;
     ap2_mrp_send_playback_state(p, state, force);
     pthread_mutex_unlock(&p->mrp_publish_lock);
 }
@@ -4191,11 +4207,12 @@ int ap2cl_mrp_push(struct ap2cl_s *p)
     return ap2cl_mrp_push_ex(p).overall_status;
 }
 
-int ap2cl_mrp_push_progress(struct ap2cl_s *p)
+/* Timeline (mergePolicy "update") push for callers already holding
+ * mrp_publish_lock: seek progress and the pause/resume transitions. */
+static ap2_mrp_push_result_t ap2cl_mrp_push_progress_serialized(
+    struct ap2cl_s *p)
 {
     ap2_mrp_push_result_t result = ap2_mrp_push_result_empty();
-    if (!p) return result.overall_status;
-    pthread_mutex_lock(&p->mrp_publish_lock);
     if (!p->mrp_progress_push_full) {
         result = ap2cl_mrp_push_serialized_with(
             p, ap2_mrp_build_nowplaying_progress_command);
@@ -4212,6 +4229,15 @@ int ap2cl_mrp_push_progress(struct ap2cl_s *p)
     }
     if (p->mrp_progress_push_full)
         result = ap2cl_mrp_push_serialized(p);
+    return result;
+}
+
+int ap2cl_mrp_push_progress(struct ap2cl_s *p)
+{
+    ap2_mrp_push_result_t result = ap2_mrp_push_result_empty();
+    if (!p) return result.overall_status;
+    pthread_mutex_lock(&p->mrp_publish_lock);
+    result = ap2cl_mrp_push_progress_serialized(p);
     pthread_mutex_unlock(&p->mrp_publish_lock);
     return result.overall_status;
 }
@@ -4262,24 +4288,90 @@ int ap2cl_mrp_register(struct ap2cl_s *p)
     return status;
 }
 
-bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist,
-                        const char *album, int duration, const char *item_id)
+/* Artwork on the DMAP/SET_PARAMETER path for receivers such as Sonos, which
+ * consume only it; pair-verified Apple sessions mirror validated artwork over
+ * MRP separately. */
+static bool ap2_send_dmap_artwork(struct ap2cl_s *p, const char *content_type,
+                                  int size, const char *data)
 {
+    if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
+        char rtpinfo[48];
+        snprintf(rtpinfo, sizeof(rtpinfo), "RTP-Info: rtptime=%u\r\n", p->rtp_timestamp);
+        uint8_t *resp = NULL; int resp_len = 0;
+        int status = ap2_rtsp_send_ex(p, "SET_PARAMETER", p->session_url,
+                                      (const uint8_t *)data, size, content_type,
+                                      rtpinfo, &resp, &resp_len);
+        free(resp);
+        LOG_INFO("[AP2] native artwork SET_PARAMETER -> status %d (%d bytes, %s)",
+                 status, size, content_type);
+        return status >= 200 && status < 300;
+    }
+    if (p->raopcl)
+        return raopcl_set_artwork(
+            p->raopcl, (char *)content_type, size, (char *)data);
+    return false;
+}
+
+bool ap2cl_set_metadata_ex(struct ap2cl_s *p, const char *title,
+                           const char *artist, const char *album,
+                           int duration, const char *item_id,
+                           const char *content_type, const uint8_t *art_data,
+                           int art_len, ap2_mrp_artwork_info_t *mrp_info,
+                           ap2_mrp_push_result_t *mrp_push)
+{
+    ap2_mrp_artwork_info_t local_info;
+    if (!mrp_info) mrp_info = &local_info;
+    if (mrp_push) *mrp_push = ap2_mrp_push_result_empty();
+    memset(mrp_info, 0, sizeof(*mrp_info));
+    mrp_info->result = AP2_MRP_ARTWORK_NOT_APPLICABLE;
+    mrp_info->bytes = art_len > 0 ? (size_t)art_len : 0;
     if (!p) return false;
+    bool have_art = art_data && art_len > 0;
     pthread_mutex_lock(&p->mrp_publish_lock);
     pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
+    bool have_mrp = p->mrp != NULL;
+    bool track_changed = false;
     if (p->mrp)
-        ap2_mrp_set_metadata(p->mrp, title, artist, album, duration * 1000,
-                             item_id);
+        ap2_mrp_set_track(p->mrp, title, artist, album, duration * 1000,
+                          item_id, content_type, art_data, art_len,
+                          &track_changed, mrp_info);
     pthread_mutex_unlock(&p->mrp_lock);
-    pthread_mutex_unlock(&p->mrp_publish_lock);
+
+    bool dmap_ok;
     if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0)
-        return ap2_native_send_metadata(p, title, artist, album);
-    if (p->raopcl)
-        return raopcl_set_daap(p->raopcl, 4, "minm", 's', title,
-                                "asar", 's', artist, "asal", 's', album, "astn", 'i', 1);
-    return false;
+        dmap_ok = ap2_native_send_metadata(p, title, artist, album);
+    else if (p->raopcl)
+        dmap_ok = raopcl_set_daap(p->raopcl, 4, "minm", 's', title,
+                                  "asar", 's', artist, "asal", 's', album,
+                                  "astn", 'i', 1);
+    else
+        dmap_ok = false;
+    /* DMAP re-sends the art on any identity change, byte-identical or not:
+     * Sonos-class receivers key it to the track they were just told about.
+     * Only a same-item redundant image (MRP verdict "unchanged") is skipped,
+     * matching ap2cl_set_artwork; MRP-rejected bytes still go out on DMAP. */
+    if (have_art && (!have_mrp || track_changed ||
+                     mrp_info->result != AP2_MRP_ARTWORK_UNCHANGED))
+        ap2_send_dmap_artwork(p, content_type, art_len,
+                              (const char *)art_data);
+    if (have_mrp) {
+        /* One full replace push carries item + timeline + artwork together —
+         * the real Apple sender shape. Splitting it (a replace without art,
+         * then a second replace with it) makes tvOS tear down and rebuild
+         * its Now Playing view on every track change. */
+        ap2_mrp_push_result_t result = ap2cl_mrp_push_serialized(p);
+        if (mrp_push) *mrp_push = result;
+    }
+    pthread_mutex_unlock(&p->mrp_publish_lock);
+    return dmap_ok;
+}
+
+bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist,
+                        const char *album, int duration, const char *item_id)
+{
+    return ap2cl_set_metadata_ex(p, title, artist, album, duration, item_id,
+                                 NULL, NULL, 0, NULL, NULL);
 }
 
 bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size,
@@ -4308,24 +4400,7 @@ bool ap2cl_set_artwork(struct ap2cl_s *p, const char *content_type, int size,
         pthread_mutex_unlock(&p->mrp_publish_lock);
         return true;
     }
-    bool dmap_ok = false;
-    if (p->flow == FLOW_NATIVE_AP2 && p->sock_fd >= 0) {
-        /* Preserve the DMAP/SET_PARAMETER path for receivers such as Sonos;
-         * pair-verified Apple sessions mirror validated artwork over MRP. */
-        char rtpinfo[48];
-        snprintf(rtpinfo, sizeof(rtpinfo), "RTP-Info: rtptime=%u\r\n", p->rtp_timestamp);
-        uint8_t *resp = NULL; int resp_len = 0;
-        int status = ap2_rtsp_send_ex(p, "SET_PARAMETER", p->session_url,
-                                      (const uint8_t *)data, size, content_type,
-                                      rtpinfo, &resp, &resp_len);
-        free(resp);
-        LOG_INFO("[AP2] native artwork SET_PARAMETER -> status %d (%d bytes, %s)",
-                 status, size, content_type);
-        dmap_ok = status >= 200 && status < 300;
-    } else if (p->raopcl) {
-        dmap_ok = raopcl_set_artwork(
-            p->raopcl, (char *)content_type, size, (char *)data);
-    }
+    bool dmap_ok = ap2_send_dmap_artwork(p, content_type, size, data);
     if (have_mrp) {
         ap2_mrp_push_result_t result = ap2cl_mrp_push_serialized(p);
         if (mrp_push) *mrp_push = result;
@@ -4362,9 +4437,12 @@ bool ap2cl_set_progress(struct ap2cl_s *p, int elapsed_s, int duration_s)
     pthread_mutex_lock(&p->mrp_lock);
     ap2_mrp_ready(p);
     bool have_mrp = p->mrp != NULL;
+    /* The content flags, not the wire state, decide the published rate: a
+     * splice pause keeps the client AP2_STREAMING with content_paused set. */
     if (p->mrp)
         ap2_mrp_set_progress(p->mrp, elapsed_s * 1000, duration_s * 1000,
-                             p->state == AP2_STREAMING);
+                             ap2_mrp_current_playback_state(p) ==
+                                 AP2_MRP_PLAYBACK_PLAYING);
     pthread_mutex_unlock(&p->mrp_lock);
     pthread_mutex_unlock(&p->mrp_publish_lock);
     if (have_mrp) {
@@ -4509,6 +4587,14 @@ bool ap2cl_is_playing(struct ap2cl_s *p)
 }
 
 #ifdef AP2_TESTING
+/* Hand the client a ready MRP context without a paired session, so a test can
+ * drive the /command now-playing path against a scripted RTSP peer. The
+ * client takes ownership (ap2cl_destroy frees it). */
+void ap2cl_test_set_mrp(struct ap2cl_s *p, struct ap2_mrp_ctx *m)
+{
+    p->mrp = m;
+}
+
 void ap2cl_test_lock_mrp(struct ap2cl_s *p)
 {
     pthread_mutex_lock(&p->mrp_lock);

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -362,10 +362,26 @@ bool ap2cl_feedback(struct ap2cl_s *p);
 /* Set volume (0-100). */
 bool ap2cl_set_volume(struct ap2cl_s *p, int volume);
 
-/* Set metadata (DAAP format). item_id is the sender's stable per-track
- * identity ("" = none): MediaRemote keys its now-playing item on it, so
- * later tag refinements for the same item update in place instead of
- * presenting as a new track. */
+/*
+ * Set the track metadata and artwork as one bundle: DMAP metadata (and, when
+ * artwork is given, DMAP artwork) on the transport in use, plus exactly one
+ * serialized MediaRemote replace push carrying item, timeline and artwork
+ * together — the shape a real Apple sender emits at a track change. item_id
+ * is the sender's stable per-track identity ("" = none): MediaRemote keys
+ * its now-playing item on it, so later tag refinements for the same item
+ * update in place instead of presenting as a new track. Byte-identical
+ * artwork keeps its ArtworkIdentifier across a track change; NULL artwork
+ * drops retained MRP artwork when the track changed. mrp_info and mrp_push
+ * receive the request-scoped artwork verdict and push statuses.
+ */
+bool ap2cl_set_metadata_ex(struct ap2cl_s *p, const char *title,
+                           const char *artist, const char *album,
+                           int duration, const char *item_id,
+                           const char *content_type, const uint8_t *art_data,
+                           int art_len, ap2_mrp_artwork_info_t *mrp_info,
+                           ap2_mrp_push_result_t *mrp_push);
+
+/* ap2cl_set_metadata_ex without artwork or result reporting. */
 bool ap2cl_set_metadata(struct ap2cl_s *p, const char *title, const char *artist,
                         const char *album, int duration, const char *item_id);
 

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -371,14 +371,16 @@ bool ap2cl_set_volume(struct ap2cl_s *p, int volume);
  * its now-playing item on it, so later tag refinements for the same item
  * update in place instead of presenting as a new track. Byte-identical
  * artwork keeps its ArtworkIdentifier across a track change; NULL artwork
- * drops retained MRP artwork when the track changed. mrp_info and mrp_push
- * receive the request-scoped artwork verdict and push statuses.
+ * drops retained MRP artwork when the track changed. track_changed_out
+ * (optional) receives whether the item identity changed; mrp_info and
+ * mrp_push receive the request-scoped artwork verdict and push statuses.
  */
 bool ap2cl_set_metadata_ex(struct ap2cl_s *p, const char *title,
                            const char *artist, const char *album,
                            int duration, const char *item_id,
                            const char *content_type, const uint8_t *art_data,
-                           int art_len, ap2_mrp_artwork_info_t *mrp_info,
+                           int art_len, bool *track_changed_out,
+                           ap2_mrp_artwork_info_t *mrp_info,
                            ap2_mrp_push_result_t *mrp_push);
 
 /* ap2cl_set_metadata_ex without artwork or result reporting. */

--- a/src/ap2_mrp.c
+++ b/src/ap2_mrp.c
@@ -1581,11 +1581,19 @@ void ap2_mrp_stop(struct ap2_mrp_ctx *m)
     m->event_plain_len = 0;
 }
 
-bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
-                          const char *artist, const char *album,
-                          int duration_ms, const char *item_id)
+bool ap2_mrp_set_track(struct ap2_mrp_ctx *m, const char *title,
+                       const char *artist, const char *album,
+                       int duration_ms, const char *item_id,
+                       const char *mime, const uint8_t *art, int art_len,
+                       bool *track_changed_out, ap2_mrp_artwork_info_t *info)
 {
-    if (!m) return false;
+    ap2_mrp_artwork_info_t local_info;
+    if (!info) info = &local_info;
+    if (track_changed_out) *track_changed_out = false;
+    if (!m) {
+        mrp_artwork_info_init(info, art_len > 0 ? (size_t)art_len : 0);
+        return false;
+    }
     /* The UniqueIdentifier must stay stable across a track's pushes: the
      * receiver keys its now-playing item on it, so a fresh uid on a redundant
      * re-send (registration burst, warm seek, progress correction) reads as a
@@ -1618,9 +1626,6 @@ bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
         RAND_bytes((uint8_t *)&uid, sizeof(uid));
         m->np_uid = uid & 0x7FFFFFFFFFFFFFFFULL;
         if (track_changed) {
-            /* The old track's staged artwork must not ride the new item; the
-             * caller stages the new track's art (or none) right after this. */
-            mrp_reset_artwork(m);
             /* A new item starts at zero. Keeping the previous track's elapsed
              * would push the new title at the old position; the sender's
              * settled correction follows only when it starts elsewhere. */
@@ -1628,9 +1633,33 @@ bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
             m->elapsed_set_at = mrp_cf_now();
         }
     }
+    if (art && art_len > 0) {
+        /* The staged artwork survives the identity change long enough for
+         * set_artwork's identical-bytes comparison: the same cover riding a
+         * new track (one album) keeps its ArtworkIdentifier, because an
+         * identifier flip alone makes the receiver invalidate and re-render
+         * the art it is already showing. A rejected image clears staging the
+         * way set_artwork always does. */
+        ap2_mrp_set_artwork(m, mime, art, art_len, info);
+    } else {
+        mrp_artwork_info_init(info, 0);
+        info->result = AP2_MRP_ARTWORK_NOT_APPLICABLE;
+        /* The old track's staged artwork must not ride the new item; the same
+         * item without a new image keeps what it has (tag refinement). */
+        if (track_changed) mrp_reset_artwork(m);
+    }
     m->state_generation++;
     m->state_dirty = true;
+    if (track_changed_out) *track_changed_out = track_changed;
     return true;
+}
+
+bool ap2_mrp_set_metadata(struct ap2_mrp_ctx *m, const char *title,
+                          const char *artist, const char *album,
+                          int duration_ms, const char *item_id)
+{
+    return ap2_mrp_set_track(m, title, artist, album, duration_ms, item_id,
+                             NULL, NULL, 0, NULL, NULL);
 }
 
 bool ap2_mrp_set_artwork(struct ap2_mrp_ctx *m, const char *mime,

--- a/src/ap2_mrp.h
+++ b/src/ap2_mrp.h
@@ -149,14 +149,39 @@ bool ap2_mrp_start(struct ap2_mrp_ctx *m);
 void ap2_mrp_stop(struct ap2_mrp_ctx *m);
 
 /*
- * Set the now-playing track metadata. Values are copied; NULL is treated as
- * empty. Takes effect on the next feedback-worker state push.
+ * Set the now-playing track metadata and artwork in one state change.
  *
- * The now-playing item identity (UniqueIdentifier and retained artwork) is
- * keyed on item_id when both the stored and incoming ids are non-empty:
- * title/artist/album changes under the same item_id are tag refinements that
- * update the existing item in place. Without ids, identity falls back to the
- * title/artist/album tuple.
+ * The now-playing item identity (UniqueIdentifier) is keyed on item_id when
+ * both the stored and incoming ids are non-empty: title/artist/album changes
+ * under the same item_id are tag refinements that update the existing item in
+ * place. Without ids, identity falls back to the title/artist/album tuple.
+ * A track change resets elapsed to zero.
+ *
+ * Artwork resolves against the retained image (ap2_mrp_set_artwork rules):
+ * identical bytes keep the current ArtworkIdentifier even across a track
+ * change (an identifier flip alone re-renders the receiver's Now Playing UI),
+ * new bytes stage under a fresh identifier, a rejected image clears staging,
+ * and no artwork drops the retained image only when the track changed.
+ *
+ * :param duration_ms: track duration in milliseconds (0 = unknown/live).
+ * :param item_id: sender's stable per-track identity ("" or NULL = none).
+ * :param mime: artwork MIME type; must be "image/jpeg".
+ * :param art: artwork bytes (copied); NULL/empty = no artwork for this track.
+ * :param art_len: artwork byte count.
+ * :param track_changed_out: optional; receives whether the item identity changed.
+ * :param info: optional artwork probe result and best-effort telemetry.
+ */
+bool ap2_mrp_set_track(struct ap2_mrp_ctx *m, const char *title,
+                       const char *artist, const char *album,
+                       int duration_ms, const char *item_id,
+                       const char *mime, const uint8_t *art, int art_len,
+                       bool *track_changed_out, ap2_mrp_artwork_info_t *info);
+
+/*
+ * Set the now-playing track metadata without artwork: ap2_mrp_set_track with
+ * no image, so a track change drops the retained artwork. Values are copied;
+ * NULL is treated as empty. Takes effect on the next feedback-worker state
+ * push.
  *
  * :param duration_ms: track duration in milliseconds (0 = unknown/live).
  * :param item_id: sender's stable per-track identity ("" or NULL = none).

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -629,19 +629,24 @@ static void send_track_metadata(const cli_config_t *cfg, const char *title)
     } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
         ap2_mrp_artwork_info_t mrp_info;
         ap2_mrp_push_result_t push;
+        bool track_changed = false;
         ap2cl_set_metadata_ex(g_ap2cl, title, metadata_str(g_metadata.artist),
                               metadata_str(g_metadata.album),
                               g_metadata.duration,
                               metadata_str(g_metadata.item_id),
                               image ? content_type : NULL, image,
-                              (int)image_size, &mrp_info, &push);
-        if (artwork_failed && push.overall_status >= 0) {
-            /* The bundle push above already went out without artwork, so no
-             * separate clear+push follows; its status doubles as the clear
-             * status the artwork=rejected contract reports. */
+                              (int)image_size, &track_changed, &mrp_info,
+                              &push);
+        if (artwork_failed && track_changed && push.overall_status >= 0) {
+            /* The track changed, so the retained art was dropped and the
+             * bundle push above already went out without artwork: no
+             * separate clear+push follows, and its status doubles as the
+             * clear status the artwork=rejected contract reports. A load
+             * failure on the SAME item keeps the retained art (the warning
+             * above is the only report), so claiming a clear would lie. */
             status_print("[STATUS] mrp artwork=rejected reason=invalid_artwork "
                          "clear_status=%d", push.nowplaying_status);
-        } else {
+        } else if (!artwork_failed) {
             mrp_artwork_status_report(&mrp_info, push.nowplaying_status);
         }
         mrp_status_report(push.overall_status);

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -612,8 +612,9 @@ static void send_track_metadata(const cli_config_t *cfg, const char *title)
                          error, sizeof(error))) {
             LOG_INFO("Loaded artwork (%zu bytes, %s)", image_size, content_type);
         } else {
-            /* The bundle continues without artwork: a track change must drop
-             * the previous track's art rather than keep it riding. */
+            /* The bundle continues without artwork: on the MRP path a track
+             * change then drops the previous track's art rather than keep it
+             * riding; a RAOP receiver keeps whatever art it last received. */
             LOG_WARN("Cannot load artwork: %s", error);
             artwork_failed = true;
         }

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -560,6 +560,7 @@ static struct {
     char *artist;
     char *album;
     char *item_id;  /* sender's stable per-track identity (ITEMID key) */
+    char *artwork_file; /* staged path (ARTWORKFILE key); SENDMETA consumes it */
     int duration;
     int progress;
 } g_metadata;
@@ -579,6 +580,76 @@ static const char *metadata_str(const char *value)
     return value ? value : "";
 }
 
+/* One-shot claim of the staged ARTWORKFILE path: SENDMETA consumes it whether
+ * the load succeeds or fails, so a later SENDMETA without a fresh file can
+ * never re-push a stale one. NULL when nothing (or an empty value) is staged;
+ * caller frees. */
+static char *metadata_take_artwork_file(void)
+{
+    char *path = g_metadata.artwork_file;
+    g_metadata.artwork_file = NULL;
+    if (path && !*path) {
+        free(path);
+        path = NULL;
+    }
+    return path;
+}
+
+/* Push the current metadata — and any staged artwork file — as one track
+ * bundle. On AP2 this reaches the receiver as a single now-playing replace
+ * push carrying item + timeline + artwork (the real Apple sender shape);
+ * split pushes make tvOS re-render its Now Playing UI on every track change. */
+static void send_track_metadata(const cli_config_t *cfg, const char *title)
+{
+    char *artwork_file = metadata_take_artwork_file();
+    uint8_t *image = NULL;
+    size_t image_size = 0;
+    char content_type[32];
+    bool artwork_failed = false;
+    if (artwork_file) {
+        char error[160];
+        if (artwork_load(artwork_file, &image, &image_size, content_type,
+                         error, sizeof(error))) {
+            LOG_INFO("Loaded artwork (%zu bytes, %s)", image_size, content_type);
+        } else {
+            /* The bundle continues without artwork: a track change must drop
+             * the previous track's art rather than keep it riding. */
+            LOG_WARN("Cannot load artwork: %s", error);
+            artwork_failed = true;
+        }
+    }
+    if (cfg->protocol == PROTO_RAOP && g_raopcl) {
+        raopcl_set_daap(g_raopcl, 4, "minm", 's', title,
+                        "asar", 's', metadata_str(g_metadata.artist),
+                        "asal", 's', metadata_str(g_metadata.album),
+                        "astn", 'i', 1);
+        if (image)
+            raopcl_set_artwork(g_raopcl, content_type, (int)image_size,
+                               (char *)image);
+    } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
+        ap2_mrp_artwork_info_t mrp_info;
+        ap2_mrp_push_result_t push;
+        ap2cl_set_metadata_ex(g_ap2cl, title, metadata_str(g_metadata.artist),
+                              metadata_str(g_metadata.album),
+                              g_metadata.duration,
+                              metadata_str(g_metadata.item_id),
+                              image ? content_type : NULL, image,
+                              (int)image_size, &mrp_info, &push);
+        if (artwork_failed && push.overall_status >= 0) {
+            /* The bundle push above already went out without artwork, so no
+             * separate clear+push follows; its status doubles as the clear
+             * status the artwork=rejected contract reports. */
+            status_print("[STATUS] mrp artwork=rejected reason=invalid_artwork "
+                         "clear_status=%d", push.nowplaying_status);
+        } else {
+            mrp_artwork_status_report(&mrp_info, push.nowplaying_status);
+        }
+        mrp_status_report(push.overall_status);
+    }
+    free(image);
+    free(artwork_file);
+}
+
 static void handle_command(const char *key, const char *value, cli_config_t *cfg)
 {
     if (strcmp(key, "TITLE") == 0) {
@@ -589,6 +660,10 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         metadata_set(&g_metadata.album, value);
     } else if (strcmp(key, "ITEMID") == 0) {
         metadata_set(&g_metadata.item_id, value);
+    } else if (strcmp(key, "ARTWORKFILE") == 0) {
+        /* Stage-only, like TITLE: the next SENDMETA loads the file and pushes
+         * it bundled with the metadata. An empty value clears the staging. */
+        metadata_set(&g_metadata.artwork_file, value);
     } else if (strcmp(key, "DURATION") == 0) {
         g_metadata.duration = atoi(value);
     } else if (strcmp(key, "PROGRESS") == 0) {
@@ -747,18 +822,7 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         status_print("[STATUS] stopped");
         pthread_mutex_unlock(&g_audio_send_lock);
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "SENDMETA") == 0) {
-        if (cfg->protocol == PROTO_RAOP && g_raopcl) {
-            raopcl_set_daap(g_raopcl, 4, "minm", 's', metadata_str(g_metadata.title),
-                            "asar", 's', metadata_str(g_metadata.artist),
-                            "asal", 's', metadata_str(g_metadata.album),
-                            "astn", 'i', 1);
-        } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
-            ap2cl_set_metadata(g_ap2cl, metadata_str(g_metadata.title),
-                               metadata_str(g_metadata.artist),
-                               metadata_str(g_metadata.album), g_metadata.duration,
-                               metadata_str(g_metadata.item_id));
-            mrp_status_report(ap2cl_mrp_push(g_ap2cl));
-        }
+        send_track_metadata(cfg, metadata_str(g_metadata.title));
     }
 }
 
@@ -768,16 +832,7 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
 static void send_initial_metadata(const cli_config_t *cfg)
 {
     const char *title = (g_metadata.title && *g_metadata.title) ? g_metadata.title : "cliairplay";
-    if (cfg->protocol == PROTO_RAOP && g_raopcl) {
-        raopcl_set_daap(g_raopcl, 4, "minm", 's', title,
-                        "asar", 's', metadata_str(g_metadata.artist),
-                        "asal", 's', metadata_str(g_metadata.album), "astn", 'i', 1);
-    } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
-        ap2cl_set_metadata(g_ap2cl, title, metadata_str(g_metadata.artist),
-                           metadata_str(g_metadata.album), g_metadata.duration,
-                           metadata_str(g_metadata.item_id));
-        mrp_status_report(ap2cl_mrp_push(g_ap2cl));
-    }
+    send_track_metadata(cfg, title);
 }
 
 /* ---- Session engine transport callbacks ---- */

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -930,7 +930,7 @@ static bool find_artwork_identifier(const uint8_t *data, size_t len,
     return false;
 }
 
-#define COMMAND_PEER_MAX_REQUESTS 16
+#define COMMAND_PEER_MAX_REQUESTS 24
 #define COMMAND_PEER_BODY_MAX 8192
 
 typedef struct {
@@ -954,6 +954,11 @@ static void *run_command_peer(void *arg)
 {
     command_peer_t *peer = arg;
     peer->ok = true;
+    /* A client that regresses into sending fewer requests must fail the
+     * suite, not hang it in read()/pthread_join. */
+    struct timeval rcv_timeout = { .tv_sec = 5, .tv_usec = 0 };
+    setsockopt(peer->fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout,
+               sizeof(rcv_timeout));
     for (int i = 0; i < peer->expected_requests; i++) {
         uint8_t buffer[COMMAND_PEER_BODY_MAX + 2048];
         size_t fill = 0;
@@ -1038,7 +1043,7 @@ static void test_mrp_bundle_and_pause_publish(void)
     command_peer_t *peer = calloc(1, sizeof(*peer));
     assert(peer);
     peer->fd = sockets[1];
-    peer->expected_requests = 15;
+    peer->expected_requests = 17;
     pthread_t peer_thread;
     assert(pthread_create(&peer_thread, NULL, run_command_peer, peer) == 0);
 
@@ -1077,9 +1082,12 @@ static void test_mrp_bundle_and_pause_publish(void)
      * (requests 1-7). */
     ap2_mrp_artwork_info_t info;
     ap2_mrp_push_result_t push;
+    bool track_changed = false;
     assert(ap2cl_set_metadata_ex(client, "Track One", "Artist", "Album", 180,
                                  "item-1", "image/jpeg", k_baseline_jpeg,
-                                 (int)sizeof(k_baseline_jpeg), &info, &push));
+                                 (int)sizeof(k_baseline_jpeg), &track_changed,
+                                 &info, &push));
+    assert(track_changed);
     assert(info.result == AP2_MRP_ARTWORK_ACCEPTED);
     assert(push.overall_status == 200 && push.nowplaying_status == 200);
 
@@ -1103,21 +1111,27 @@ static void test_mrp_bundle_and_pause_publish(void)
                                      (size_t)paused_progress_len));
     free(paused_progress);
 
-    /* Resume: timeline push then playback state (requests 10-11), and stop:
-     * playback state only (request 12). */
+    /* Resume: timeline push then playback state (requests 10-11). A REDUNDANT
+     * play (state already Playing) must still post the forced state re-assert
+     * after its timeline push (requests 12-13) — the chained send dedupes on
+     * an unchanged state, so only the kept force reaches the wire. Then stop:
+     * playback state only (request 14). */
+    ap2cl_play(client);
     ap2cl_play(client);
     ap2cl_stop(client);
 
-    /* Next track with byte-identical artwork: one more bundle (13-15). */
+    /* Next track with byte-identical artwork: one more bundle (15-17). */
     assert(ap2cl_set_metadata_ex(client, "Track Two", "Artist", "Album", 200,
                                  "item-2", "image/jpeg", k_baseline_jpeg,
-                                 (int)sizeof(k_baseline_jpeg), &info, &push));
+                                 (int)sizeof(k_baseline_jpeg), &track_changed,
+                                 &info, &push));
+    assert(track_changed);
     assert(info.result == AP2_MRP_ARTWORK_UNCHANGED);
     assert(push.overall_status == 200 && push.nowplaying_status == 200);
 
     assert(pthread_join(peer_thread, NULL) == 0);
     assert(peer->ok);
-    assert(peer->request_count == 15);
+    assert(peer->request_count == 17);
 
     /* Bundle 1: DMAP metadata + artwork ride SET_PARAMETER first. */
     assert(strcmp(peer->requests[0].method, "SET_PARAMETER") == 0);
@@ -1160,30 +1174,38 @@ static void test_mrp_bundle_and_pause_publish(void)
                                       (size_t)peer->requests[9].body_len));
     assert(request_has(&peer->requests[10], "updateMRPlaybackState"));
 
+    /* Redundant play: timeline update, then the FORCED state re-assert the
+     * caller asked for — the chained send dedupes on the unchanged state, so
+     * without the kept force nothing would reach the wire. */
+    assert(request_has(&peer->requests[11], "updateMRNowPlayingInfo"));
+    assert(!request_has(&peer->requests[11], "replace"));
+    assert(request_has(&peer->requests[12], "updateMRPlaybackState"));
+    assert(!request_has(&peer->requests[12], "updateMRNowPlayingInfo"));
+
     /* Stop: state only, no now-playing body at teardown. */
-    assert(request_has(&peer->requests[11], "updateMRPlaybackState"));
-    assert(!request_has(&peer->requests[11], "updateMRNowPlayingInfo"));
+    assert(request_has(&peer->requests[13], "updateMRPlaybackState"));
+    assert(!request_has(&peer->requests[13], "updateMRNowPlayingInfo"));
 
     /* Bundle 2: the DMAP copy is re-sent for the new track even though the
      * bytes are identical, while the MRP push keeps the ArtworkIdentifier
      * (an identifier flip alone re-renders the receiver's UI) under a fresh
      * item UniqueIdentifier. */
-    assert(strcmp(peer->requests[12].method, "SET_PARAMETER") == 0);
-    assert(request_has(&peer->requests[12], "mlit"));
-    assert(strcmp(peer->requests[13].method, "SET_PARAMETER") == 0);
-    assert(bytes_contain(peer->requests[13].body,
-                         (size_t)peer->requests[13].body_len,
+    assert(strcmp(peer->requests[14].method, "SET_PARAMETER") == 0);
+    assert(request_has(&peer->requests[14], "mlit"));
+    assert(strcmp(peer->requests[15].method, "SET_PARAMETER") == 0);
+    assert(bytes_contain(peer->requests[15].body,
+                         (size_t)peer->requests[15].body_len,
                          k_baseline_jpeg, sizeof(k_baseline_jpeg)));
-    assert(request_has(&peer->requests[14], "updateMRNowPlayingInfo"));
-    assert(request_has(&peer->requests[14],
+    assert(request_has(&peer->requests[16], "updateMRNowPlayingInfo"));
+    assert(request_has(&peer->requests[16],
                        "kMRMediaRemoteNowPlayingInfoArtworkData"));
     char id_first[17];
     char id_second[17];
     assert(find_artwork_identifier(peer->requests[3].body,
                                    (size_t)peer->requests[3].body_len,
                                    id_first));
-    assert(find_artwork_identifier(peer->requests[14].body,
-                                   (size_t)peer->requests[14].body_len,
+    assert(find_artwork_identifier(peer->requests[16].body,
+                                   (size_t)peer->requests[16].body_len,
                                    id_second));
     assert(strcmp(id_first, id_second) == 0);
     uint64_t uid_first = 0;
@@ -1192,18 +1214,18 @@ static void test_mrp_bundle_and_pause_publish(void)
         peer->requests[3].body, (size_t)peer->requests[3].body_len,
         "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_first));
     assert(ap2_bplist_find_uint(
-        peer->requests[14].body, (size_t)peer->requests[14].body_len,
+        peer->requests[16].body, (size_t)peer->requests[16].body_len,
         "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_second));
     assert(uid_first != 0 && uid_second != 0 && uid_first != uid_second);
 
-    /* Exactly four now-playing posts in total: one per bundle, one per
-     * pause/resume transition — nothing doubled. */
+    /* Exactly five now-playing posts in total: one per bundle, one per
+     * pause/resume/redundant-play transition — nothing doubled. */
     int nowplaying_posts = 0;
     for (int i = 0; i < peer->request_count; i++) {
         if (request_has(&peer->requests[i], "updateMRNowPlayingInfo"))
             nowplaying_posts++;
     }
-    assert(nowplaying_posts == 4);
+    assert(nowplaying_posts == 5);
 
     ap2cl_test_detach_rtsp_socket(client);
     assert(close(sockets[0]) == 0);

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -20,11 +20,14 @@
 #include "ap2_io.h"
 #include "cross_log.h"
 
+#include "mrp_jpeg_fixture.h"
+
 static log_level test_log_level = lSILENCE;
 log_level *loglevel = &test_log_level;
 log_level util_loglevel = lSILENCE;
 log_level raop_loglevel = lSILENCE;
 
+void ap2cl_test_set_mrp(struct ap2cl_s *p, struct ap2_mrp_ctx *m);
 void ap2cl_test_lock_mrp(struct ap2cl_s *p);
 void ap2cl_test_unlock_mrp(struct ap2cl_s *p);
 void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd);
@@ -879,6 +882,337 @@ static void test_splice_pause_keeps_line_hot(void)
     puts("ap2_client splice pause keepalive tests passed");
 }
 
+static bool bytes_contain(const uint8_t *data, size_t data_len,
+                          const void *needle, size_t needle_len)
+{
+    if (!data || !needle || needle_len == 0 || needle_len > data_len)
+        return false;
+    for (size_t i = 0; i <= data_len - needle_len; i++) {
+        if (memcmp(data + i, needle, needle_len) == 0) return true;
+    }
+    return false;
+}
+
+static bool bytes_contain_string(const uint8_t *data, size_t data_len,
+                                 const char *needle)
+{
+    return bytes_contain(data, data_len, needle, strlen(needle));
+}
+
+/* Whether a serialized bplist carries a real with value 0.0 (marker 0x23 and
+ * eight zero bytes). The 32-byte trailer is excluded: a small top-object
+ * reference there is the one place the pattern could occur by coincidence. */
+static bool bplist_contains_zero_real(const uint8_t *data, size_t len)
+{
+    static const uint8_t zero_real[9] = {0x23, 0, 0, 0, 0, 0, 0, 0, 0};
+    if (len <= 32) return false;
+    return bytes_contain(data, len - 32, zero_real, sizeof(zero_real));
+}
+
+/* Locate the ArtworkIdentifier value in a now-playing body: the only
+ * 16-character ASCII string object (marker 0x5F 0x10 0x10, 16 hex chars). */
+static bool find_artwork_identifier(const uint8_t *data, size_t len,
+                                    char out[17])
+{
+    for (size_t i = 0; i + 19 <= len; i++) {
+        if (data[i] != 0x5F || data[i + 1] != 0x10 || data[i + 2] != 0x10)
+            continue;
+        bool hex = true;
+        for (size_t j = 0; j < 16 && hex; j++) {
+            uint8_t c = data[i + 3 + j];
+            hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+        }
+        if (!hex) continue;
+        memcpy(out, data + i + 3, 16);
+        out[16] = '\0';
+        return true;
+    }
+    return false;
+}
+
+#define COMMAND_PEER_MAX_REQUESTS 16
+#define COMMAND_PEER_BODY_MAX 8192
+
+typedef struct {
+    char method[16];
+    char uri[64];
+    uint8_t body[COMMAND_PEER_BODY_MAX];
+    int body_len;
+} command_peer_request_t;
+
+typedef struct {
+    int fd;
+    int expected_requests;
+    int request_count;
+    command_peer_request_t requests[COMMAND_PEER_MAX_REQUESTS];
+    bool ok;
+} command_peer_t;
+
+/* Receiver end for the MediaRemote publication tests: answer every RTSP
+ * request with 200 while capturing method, URI and body for inspection. */
+static void *run_command_peer(void *arg)
+{
+    command_peer_t *peer = arg;
+    peer->ok = true;
+    for (int i = 0; i < peer->expected_requests; i++) {
+        uint8_t buffer[COMMAND_PEER_BODY_MAX + 2048];
+        size_t fill = 0;
+        char *body_start = NULL;
+        while (!body_start) {
+            if (fill >= sizeof(buffer) - 1) {
+                peer->ok = false;
+                return NULL;
+            }
+            ssize_t n = read(peer->fd, buffer + fill,
+                             sizeof(buffer) - 1 - fill);
+            if (n <= 0) {
+                peer->ok = false;
+                return NULL;
+            }
+            fill += (size_t)n;
+            buffer[fill] = '\0';
+            body_start = strstr((char *)buffer, "\r\n\r\n");
+        }
+        body_start += 4;
+        size_t header_len = (size_t)((uint8_t *)body_start - buffer);
+        int cseq = 0;
+        long content_length = 0;
+        char *cseq_header = strstr((char *)buffer, "\r\nCSeq: ");
+        char *length_header = strstr((char *)buffer, "\r\nContent-Length: ");
+        if (!cseq_header || sscanf(cseq_header, "\r\nCSeq: %d", &cseq) != 1) {
+            peer->ok = false;
+            return NULL;
+        }
+        if (length_header)
+            content_length = strtol(length_header + 18, NULL, 10);
+        if (content_length < 0 || content_length > COMMAND_PEER_BODY_MAX ||
+            header_len + (size_t)content_length > sizeof(buffer) - 1) {
+            peer->ok = false;
+            return NULL;
+        }
+        while (fill < header_len + (size_t)content_length) {
+            ssize_t n = read(peer->fd, buffer + fill,
+                             header_len + (size_t)content_length - fill);
+            if (n <= 0) {
+                peer->ok = false;
+                return NULL;
+            }
+            fill += (size_t)n;
+        }
+        command_peer_request_t *req = &peer->requests[peer->request_count];
+        if (sscanf((char *)buffer, "%15s %63s", req->method, req->uri) != 2) {
+            peer->ok = false;
+            return NULL;
+        }
+        memcpy(req->body, buffer + header_len, (size_t)content_length);
+        req->body_len = (int)content_length;
+        peer->request_count++;
+        char response[96];
+        int response_len = snprintf(
+            response, sizeof(response),
+            "RTSP/1.0 200 OK\r\nCSeq: %d\r\nContent-Length: 0\r\n\r\n", cseq);
+        if (write(peer->fd, response, (size_t)response_len) != response_len) {
+            peer->ok = false;
+            return NULL;
+        }
+    }
+    return NULL;
+}
+
+static bool request_has(const command_peer_request_t *req, const char *needle)
+{
+    return bytes_contain_string(req->body, (size_t)req->body_len, needle);
+}
+
+/* MediaRemote publication over a scripted RTSP peer: the track bundle reaches
+ * the receiver as ONE now-playing replace push carrying the artwork; pause
+ * and resume each push a timeline (mergePolicy update) body BEFORE their
+ * updateMRPlaybackState with no duplicate state post; stop stays state-only;
+ * a progress set while content-paused reports rate 0; and a track change with
+ * byte-identical artwork keeps the ArtworkIdentifier while still re-sending
+ * the DMAP copy for receivers that consume only that path. */
+static void test_mrp_bundle_and_pause_publish(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    command_peer_t *peer = calloc(1, sizeof(*peer));
+    assert(peer);
+    peer->fd = sockets[1];
+    peer->expected_requests = 15;
+    pthread_t peer_thread;
+    assert(pthread_create(&peer_thread, NULL, run_command_peer, peer) == 0);
+
+    ap2_device_info_t device = {
+        .name = "mrp bundle test",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+    ap2cl_test_set_splice(client, true);
+    assert(ap2cl_start(client, 0, NULL) == AP2_COMMIT_OK);
+    ap2cl_test_set_first_packet(client, false);
+    ap2cl_test_set_anchor_valid(client, true);
+
+    /* The test bypasses pairing, so hand the client a ready MRP context; the
+     * client owns it from here (ap2cl_destroy frees it). */
+    struct ap2_mrp_ctx *mrp = ap2_mrp_create(
+        "127.0.0.1", 7000, NULL, "0011223344556677", "bundle sender",
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222", NULL);
+    assert(mrp);
+    ap2cl_test_set_mrp(client, mrp);
+
+    /* Track bundle: DMAP metadata, DMAP artwork, then registration and ONE
+     * now-playing replace push chained with the extended registration
+     * (requests 1-7). */
+    ap2_mrp_artwork_info_t info;
+    ap2_mrp_push_result_t push;
+    assert(ap2cl_set_metadata_ex(client, "Track One", "Artist", "Album", 180,
+                                 "item-1", "image/jpeg", k_baseline_jpeg,
+                                 (int)sizeof(k_baseline_jpeg), &info, &push));
+    assert(info.result == AP2_MRP_ARTWORK_ACCEPTED);
+    assert(push.overall_status == 200 && push.nowplaying_status == 200);
+
+    /* A progress set while playing stages state without wire traffic. */
+    assert(ap2cl_set_progress(client, 42, 180));
+
+    /* Splice pause: timeline push then playback state (requests 8-9). */
+    ap2cl_pause(client);
+
+    /* A progress set while content-paused must report rate 0: the splice
+     * pause keeps the client AP2_STREAMING, so the content flags own the
+     * published rate. */
+    assert(ap2cl_set_progress(client, 42, 180));
+    uint8_t *paused_progress = NULL;
+    int paused_progress_len = 0;
+    ap2cl_test_lock_mrp(client);
+    assert(ap2_mrp_build_nowplaying_progress_command(
+        mrp, &paused_progress, &paused_progress_len));
+    ap2cl_test_unlock_mrp(client);
+    assert(bplist_contains_zero_real(paused_progress,
+                                     (size_t)paused_progress_len));
+    free(paused_progress);
+
+    /* Resume: timeline push then playback state (requests 10-11), and stop:
+     * playback state only (request 12). */
+    ap2cl_play(client);
+    ap2cl_stop(client);
+
+    /* Next track with byte-identical artwork: one more bundle (13-15). */
+    assert(ap2cl_set_metadata_ex(client, "Track Two", "Artist", "Album", 200,
+                                 "item-2", "image/jpeg", k_baseline_jpeg,
+                                 (int)sizeof(k_baseline_jpeg), &info, &push));
+    assert(info.result == AP2_MRP_ARTWORK_UNCHANGED);
+    assert(push.overall_status == 200 && push.nowplaying_status == 200);
+
+    assert(pthread_join(peer_thread, NULL) == 0);
+    assert(peer->ok);
+    assert(peer->request_count == 15);
+
+    /* Bundle 1: DMAP metadata + artwork ride SET_PARAMETER first. */
+    assert(strcmp(peer->requests[0].method, "SET_PARAMETER") == 0);
+    assert(request_has(&peer->requests[0], "mlit"));
+    assert(strcmp(peer->requests[1].method, "SET_PARAMETER") == 0);
+    assert(bytes_contain(peer->requests[1].body,
+                         (size_t)peer->requests[1].body_len,
+                         k_baseline_jpeg, sizeof(k_baseline_jpeg)));
+    /* Registration, then the single replace push carrying the artwork. */
+    assert(strcmp(peer->requests[2].method, "POST") == 0);
+    assert(strcmp(peer->requests[2].uri, "/command") == 0);
+    assert(request_has(&peer->requests[3], "updateMRNowPlayingInfo"));
+    assert(request_has(&peer->requests[3], "replace"));
+    assert(request_has(&peer->requests[3],
+                       "kMRMediaRemoteNowPlayingInfoArtworkData"));
+    assert(bytes_contain(peer->requests[3].body,
+                         (size_t)peer->requests[3].body_len,
+                         k_baseline_jpeg, sizeof(k_baseline_jpeg)));
+    assert(request_has(&peer->requests[4], "updateMRSupportedCommands"));
+    assert(request_has(&peer->requests[5], "updateMRPlaybackState"));
+    assert(request_has(&peer->requests[6], "updateMRNowPlayingClient"));
+
+    /* Pause: a lean timeline body (no replace, no artwork keys, rate 0)
+     * BEFORE updateMRPlaybackState, and exactly one state post. */
+    assert(request_has(&peer->requests[7], "updateMRNowPlayingInfo"));
+    assert(!request_has(&peer->requests[7], "replace"));
+    assert(!request_has(&peer->requests[7],
+                        "kMRMediaRemoteNowPlayingInfoArtwork"));
+    assert(request_has(&peer->requests[7],
+                       "kMRMediaRemoteNowPlayingInfoElapsedTime"));
+    assert(bplist_contains_zero_real(peer->requests[7].body,
+                                     (size_t)peer->requests[7].body_len));
+    assert(request_has(&peer->requests[8], "updateMRPlaybackState"));
+    assert(!request_has(&peer->requests[8], "updateMRNowPlayingInfo"));
+
+    /* Resume: the same shape at rate 1 (elapsed is 42.x, so no zero real). */
+    assert(request_has(&peer->requests[9], "updateMRNowPlayingInfo"));
+    assert(!request_has(&peer->requests[9], "replace"));
+    assert(!bplist_contains_zero_real(peer->requests[9].body,
+                                      (size_t)peer->requests[9].body_len));
+    assert(request_has(&peer->requests[10], "updateMRPlaybackState"));
+
+    /* Stop: state only, no now-playing body at teardown. */
+    assert(request_has(&peer->requests[11], "updateMRPlaybackState"));
+    assert(!request_has(&peer->requests[11], "updateMRNowPlayingInfo"));
+
+    /* Bundle 2: the DMAP copy is re-sent for the new track even though the
+     * bytes are identical, while the MRP push keeps the ArtworkIdentifier
+     * (an identifier flip alone re-renders the receiver's UI) under a fresh
+     * item UniqueIdentifier. */
+    assert(strcmp(peer->requests[12].method, "SET_PARAMETER") == 0);
+    assert(request_has(&peer->requests[12], "mlit"));
+    assert(strcmp(peer->requests[13].method, "SET_PARAMETER") == 0);
+    assert(bytes_contain(peer->requests[13].body,
+                         (size_t)peer->requests[13].body_len,
+                         k_baseline_jpeg, sizeof(k_baseline_jpeg)));
+    assert(request_has(&peer->requests[14], "updateMRNowPlayingInfo"));
+    assert(request_has(&peer->requests[14],
+                       "kMRMediaRemoteNowPlayingInfoArtworkData"));
+    char id_first[17];
+    char id_second[17];
+    assert(find_artwork_identifier(peer->requests[3].body,
+                                   (size_t)peer->requests[3].body_len,
+                                   id_first));
+    assert(find_artwork_identifier(peer->requests[14].body,
+                                   (size_t)peer->requests[14].body_len,
+                                   id_second));
+    assert(strcmp(id_first, id_second) == 0);
+    uint64_t uid_first = 0;
+    uint64_t uid_second = 0;
+    assert(ap2_bplist_find_uint(
+        peer->requests[3].body, (size_t)peer->requests[3].body_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_first));
+    assert(ap2_bplist_find_uint(
+        peer->requests[14].body, (size_t)peer->requests[14].body_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_second));
+    assert(uid_first != 0 && uid_second != 0 && uid_first != uid_second);
+
+    /* Exactly four now-playing posts in total: one per bundle, one per
+     * pause/resume transition — nothing doubled. */
+    int nowplaying_posts = 0;
+    for (int i = 0; i < peer->request_count; i++) {
+        if (request_has(&peer->requests[i], "updateMRNowPlayingInfo"))
+            nowplaying_posts++;
+    }
+    assert(nowplaying_posts == 4);
+
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+    free(peer);
+    puts("ap2_client MRP bundle and pause publication tests passed");
+}
+
 /* An explicit --protocol airplay2 reaches the native flow on exactly the same
  * terms as auto, so an AirPlay-2-only receiver (no _raop service to fall back
  * on) is not routed into a RAOP-compatible flow it cannot answer. Only a real
@@ -1549,6 +1883,7 @@ int main(void)
     test_splice_timeline_warm_path();
     test_splice_delivery_gap_recovery();
     test_splice_pause_keeps_line_hot();
+    test_mrp_bundle_and_pause_publish();
     test_feedback_miss_tolerated_then_recovered();
     test_apple_model_resolution();
     test_pacing_window_rate_scaling();

--- a/tests/test_mrp_artwork.c
+++ b/tests/test_mrp_artwork.c
@@ -425,6 +425,172 @@ static bool test_nowplaying_command_payload(void)
     return true;
 }
 
+/* Locate the ArtworkIdentifier value in a serialized now-playing command: the
+ * identifier is the only 16-character ASCII string object in that payload
+ * (marker 0x5F, int-count 0x10 0x10, then 16 lowercase-hex characters). */
+static bool find_artwork_identifier(const uint8_t *data, size_t len,
+                                    char out[17])
+{
+    for (size_t i = 0; i + 19 <= len; i++) {
+        if (data[i] != 0x5F || data[i + 1] != 0x10 || data[i + 2] != 0x10)
+            continue;
+        bool hex = true;
+        for (size_t j = 0; j < 16 && hex; j++) {
+            uint8_t c = data[i + 3 + j];
+            hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+        }
+        if (!hex) continue;
+        memcpy(out, data + i + 3, 16);
+        out[16] = '\0';
+        return true;
+    }
+    return false;
+}
+
+static bool test_set_track_bundle(void)
+{
+    struct ap2_mrp_ctx *mrp = ap2_mrp_create(
+        "127.0.0.1", 7000, NULL, "0011223344556677", "Test sender",
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222", NULL);
+    CHECK(mrp != NULL);
+
+    /* First track with artwork: identity and image land in one state change. */
+    ap2_mrp_artwork_info_t info;
+    bool track_changed = false;
+    CHECK(ap2_mrp_set_track(mrp, "Track One", "Artist", "Album", 180000,
+                            "item-1", "image/jpeg", k_baseline_jpeg,
+                            (int)sizeof(k_baseline_jpeg), &track_changed,
+                            &info));
+    CHECK(track_changed);
+    CHECK(info.result == AP2_MRP_ARTWORK_ACCEPTED);
+    uint8_t *first = NULL;
+    int first_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &first, &first_len));
+    uint64_t uid_first = 0;
+    CHECK(ap2_bplist_find_uint(
+        first, (size_t)first_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_first));
+    CHECK(uid_first != 0);
+    char id_first[17];
+    CHECK(find_artwork_identifier(first, (size_t)first_len, id_first));
+    free(first);
+
+    /* Redundant bundle for the same item: uid stable, image a reported no-op
+     * that keeps the identifier. */
+    CHECK(ap2_mrp_set_track(mrp, "Track One", "Artist", "Album", 180000,
+                            "item-1", "image/jpeg", k_baseline_jpeg,
+                            (int)sizeof(k_baseline_jpeg), &track_changed,
+                            &info));
+    CHECK(!track_changed);
+    CHECK(info.result == AP2_MRP_ARTWORK_UNCHANGED);
+    uint8_t *again = NULL;
+    int again_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &again, &again_len));
+    uint64_t uid_again = 0;
+    CHECK(ap2_bplist_find_uint(
+        again, (size_t)again_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_again));
+    CHECK(uid_again == uid_first);
+    char id_again[17];
+    CHECK(find_artwork_identifier(again, (size_t)again_len, id_again));
+    CHECK(strcmp(id_again, id_first) == 0);
+    free(again);
+
+    /* Track change with byte-identical artwork (one album): fresh uid, but
+     * the ArtworkIdentifier survives — an identifier flip alone makes the
+     * receiver invalidate and re-render the art it is already showing. */
+    CHECK(ap2_mrp_set_track(mrp, "Track Two", "Artist", "Album", 200000,
+                            "item-2", "image/jpeg", k_baseline_jpeg,
+                            (int)sizeof(k_baseline_jpeg), &track_changed,
+                            &info));
+    CHECK(track_changed);
+    CHECK(info.result == AP2_MRP_ARTWORK_UNCHANGED);
+    uint8_t *second = NULL;
+    int second_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &second, &second_len));
+    uint64_t uid_second = 0;
+    CHECK(ap2_bplist_find_uint(
+        second, (size_t)second_len,
+        "kMRMediaRemoteNowPlayingInfoUniqueIdentifier", &uid_second));
+    CHECK(uid_second != uid_first);
+    char id_second[17];
+    CHECK(find_artwork_identifier(second, (size_t)second_len, id_second));
+    CHECK(strcmp(id_second, id_first) == 0);
+    CHECK(bytes_contain(second, (size_t)second_len,
+                        k_baseline_jpeg, sizeof(k_baseline_jpeg)));
+    free(second);
+
+    /* Track change with different artwork bytes: a new identifier. */
+    uint8_t *other = make_padded_jpeg(44032);
+    CHECK(other != NULL);
+    CHECK(ap2_mrp_set_track(mrp, "Track Three", "Artist", "Album", 210000,
+                            "item-3", "image/jpeg", other, 44032,
+                            &track_changed, &info));
+    CHECK(track_changed);
+    CHECK(info.result == AP2_MRP_ARTWORK_ACCEPTED);
+    uint8_t *third = NULL;
+    int third_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &third, &third_len));
+    char id_third[17];
+    CHECK(find_artwork_identifier(third, (size_t)third_len, id_third));
+    CHECK(strcmp(id_third, id_first) != 0);
+    free(third);
+
+    /* No artwork in the bundle for the same item (tag refinement): the
+     * retained image and identifier stay. */
+    CHECK(ap2_mrp_set_track(mrp, "Track Three (remastered)", "Artist", "Album",
+                            210000, "item-3", NULL, NULL, 0, &track_changed,
+                            &info));
+    CHECK(!track_changed);
+    CHECK(info.result == AP2_MRP_ARTWORK_NOT_APPLICABLE);
+    uint8_t *refined = NULL;
+    int refined_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &refined, &refined_len));
+    char id_refined[17];
+    CHECK(find_artwork_identifier(refined, (size_t)refined_len, id_refined));
+    CHECK(strcmp(id_refined, id_third) == 0);
+    free(refined);
+
+    /* A probe-rejected image clears staging like set_artwork always does. */
+    CHECK(ap2_mrp_set_track(mrp, "Track Three (remastered)", "Artist", "Album",
+                            210000, "item-3", "image/jpeg", k_baseline_jpeg,
+                            (int)sizeof(k_baseline_jpeg) - 1, &track_changed,
+                            &info));
+    CHECK(!track_changed);
+    CHECK(info.result == AP2_MRP_ARTWORK_INVALID_JPEG_ENVELOPE);
+    uint8_t *rejected = NULL;
+    int rejected_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &rejected, &rejected_len));
+    CHECK(!bytes_contain_string(
+        rejected, (size_t)rejected_len,
+        "kMRMediaRemoteNowPlayingInfoArtworkIdentifier"));
+    free(rejected);
+
+    /* No artwork in the bundle at a track change: the old track's image (a
+     * fresh re-stage here) must not ride the new item. */
+    CHECK(ap2_mrp_set_track(mrp, "Track Three (remastered)", "Artist", "Album",
+                            210000, "item-3", "image/jpeg", other, 44032,
+                            &track_changed, &info));
+    CHECK(info.result == AP2_MRP_ARTWORK_ACCEPTED);
+    CHECK(ap2_mrp_set_track(mrp, "Track Four", "Artist", "Album", 220000,
+                            "item-4", NULL, NULL, 0, &track_changed, &info));
+    CHECK(track_changed);
+    CHECK(info.result == AP2_MRP_ARTWORK_NOT_APPLICABLE);
+    uint8_t *bare = NULL;
+    int bare_len = 0;
+    CHECK(ap2_mrp_build_nowplaying_command(mrp, &bare, &bare_len));
+    CHECK(!bytes_contain_string(
+        bare, (size_t)bare_len,
+        "kMRMediaRemoteNowPlayingInfoArtworkIdentifier"));
+    free(bare);
+    free(other);
+
+    ap2_mrp_destroy(mrp);
+    puts("MRP set_track bundle tests passed");
+    return true;
+}
+
 typedef struct {
     ap2_mrp_serial_t serial;
     atomic_int active;
@@ -497,6 +663,7 @@ int main(int argc, char **argv)
         !test_mrp_probe_boundary() ||
         !test_decoder_valid_profile_fixtures() ||
         !test_nowplaying_command_payload() ||
+        !test_set_track_bundle() ||
         !test_push_result_scope())
         return 1;
     for (int i = 1; i < argc; i++) {


### PR DESCRIPTION
Fixes the remaining Apple TV now-playing issues from music-assistant/support#5279 (confirmed on real hardware with wire logs): the progress bar showing 0:00 while paused, the bar intermittently disappearing after a track skip, and cover art sometimes not refreshing on screen although the data reached the device.

tvOS shows the last literal `ElapsedTime` it was sent when paused — a bare `updateMRPlaybackState` left it at the track start. And every track change rewrote the receiver's now-playing state three times within ~100 ms (a replace without artwork, a timeline correction, then a second replace re-minting the artwork identifier for byte-identical art), which intermittently wedged the Now Playing view until the user re-entered the app.

- Pause and resume now push the frozen/resumed timeline (mergePolicy "update") before the playback state, matching the Apple sender's info-then-state order
- New stage-only `ARTWORKFILE` pipe key: `SENDMETA` applies metadata and artwork as one transaction and emits a single replace push carrying item, duration, elapsed, rate and artwork together
- Byte-identical artwork keeps its `ArtworkIdentifier` across a track change (one album's cover survives its track boundaries)
- A progress update during a splice pause now publishes rate 0
- DMAP/SET_PARAMETER behavior for Sonos-class receivers is unchanged