### PR TITLE
Say goodbye to the receiver when the control channel dies

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -824,6 +824,17 @@ capture.
   CSeq, and bytes of a response that was mid-flight at an abandoned deadline
   carry over into the next exchange to keep the byte stream and the HAP
   read-nonce sequence intact. A succeeded beat resets the miss count.
+- **Farewell teardown** — giving up on the channel writes one last `TEARDOWN`
+  before the socket is shut down, because the regular teardown at disconnect
+  cannot pass the fail-closed send gate any more. Without it the receiver keeps
+  the session armed and pops audibly on its starved queue, over and over, until
+  another session displaces it. It is written only when the request that failed
+  went out whole and simply was not answered: a peer that reset or closed the
+  connection is already gone, and a request that died mid-write left a partial
+  frame no further write can follow. Its 250 ms budget keeps it inside the
+  receiver's queue depth, so it lands while audio is still queued — the clean
+  case. The response is never read; nothing depends on it, and only the write
+  nonce advances, so none is reused.
 - **Reverse event channel** — pair-verified sessions derive independent
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -828,13 +828,15 @@ capture.
   before the socket is shut down, because the regular teardown at disconnect
   cannot pass the fail-closed send gate any more. Without it the receiver keeps
   the session armed and pops audibly on its starved queue, over and over, until
-  another session displaces it. It is written only when the request that failed
-  went out whole and simply was not answered: a peer that reset or closed the
-  connection is already gone, and a request that died mid-write left a partial
-  frame no further write can follow. Its 250 ms budget keeps it inside the
-  receiver's queue depth, so it lands while audio is still queued — the clean
-  case. The response is never read; nothing depends on it, and only the write
-  nonce advances, so none is reused.
+  another session displaces it. It is written only when the failed request went
+  out in full and simply was not answered, so the goodbye appends at a frame
+  boundary: a peer that reset or closed the connection is already gone, and a
+  request that died mid-write left a partial frame no further write can follow.
+  Its 250 ms budget keeps it inside the queue the sender paces to, so it lands
+  while audio is still queued — the clean case. The response is never read;
+  nothing depends on it, and only the write nonce advances, so none is reused.
+  Best-effort by nature: a receiver wedged badly enough to miss three
+  keepalives may never read it, and the socket shutdown follows immediately.
 - **Reverse event channel** — pair-verified sessions derive independent
   `Events-Salt` keys, decrypt receiver HTTP requests, and return encrypted
   `200 OK` responses with echoed `CSeq`. Leaving this socket idle causes tvOS

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -71,9 +71,10 @@ extern log_level *loglevel;
 /* Budget for the farewell TEARDOWN written on a channel that is being
  * abandoned. It has to land while the receiver still has queued audio to play
  * out — a teardown with audio still queued is clean, an underrun on an armed
- * session pops — so it stays well inside the 600 ms queue depth. Nothing waits
- * on it, and the channel is going away either way, so a receiver that has
- * stopped reading costs only this. */
+ * session pops — so it stays well inside the queue the sender paces to
+ * (AP2_SPLICE_PACING_MS, only ever raised per device). A frame this small
+ * normally leaves in microseconds; the budget is what a receiver that has
+ * stopped reading altogether costs, and nothing waits on the answer. */
 #define AP2_RTSP_FAREWELL_TIMEOUT_MS 250
 #define AP2_FEEDBACK_INTERVAL_MS     2000
 /* A single missed keepalive beat must not kill an otherwise healthy session:
@@ -607,8 +608,8 @@ static void ap2_rtsp_farewell_teardown(struct ap2cl_s *p)
                                NULL, p->cseq++, started_ms,
                                started_ms + AP2_RTSP_FAREWELL_TIMEOUT_MS,
                                &phase)) {
-        LOG_INFO("[AP2] Wrote a farewell TEARDOWN for %s so the receiver drops "
-                 "the session instead of popping on its starved queue",
+        LOG_INFO("[AP2] Wrote a farewell TEARDOWN for %s so the receiver can "
+                 "drop the session instead of popping on its starved queue",
                  p->session_url);
         return;
     }
@@ -618,9 +619,10 @@ static void ap2_rtsp_farewell_teardown(struct ap2cl_s *p)
              p->session_url, phase, strerror(write_errno));
 }
 
-/* :param request_intact: Whether the request this failure belongs to reached
- *     the receiver whole, which decides if a farewell TEARDOWN can still be
- *     appended to the channel. */
+/* Give up on the channel, unless the failure is a tolerated keepalive miss.
+ * request_intact says whether the failed request went out in full, which is
+ * what decides if a farewell TEARDOWN can still be appended to the channel:
+ * appending to a half-written frame only desynchronizes the receiver. */
 static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
                                const char *uri, const char *phase,
                                uint64_t elapsed_ms, bool request_intact)
@@ -648,7 +650,8 @@ static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
         /* Only worth trying when the receiver simply stopped answering: a peer
          * that reset or closed the connection is already gone, and a request
          * that died mid-write left a partial frame no further write can follow.
-         * rtsp_dead is set by now, so the farewell cannot recurse into here. */
+         * The farewell cannot recurse into here: it writes through the helper,
+         * which reports failures back instead of killing the channel. */
         if (request_intact && saved_errno == ETIMEDOUT)
             ap2_rtsp_farewell_teardown(p);
         shutdown(p->sock_fd, SHUT_RDWR);
@@ -4698,6 +4701,14 @@ void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd)
     p->rtsp_carry_len = 0;
     atomic_store(&p->rtsp_dead, false);
     snprintf(p->session_url, sizeof(p->session_url), "rtsp://test/session");
+}
+
+/* Leave the miss budget with one beat left, so the next failed beat is the one
+ * that spends it whatever the budget is set to. */
+void ap2cl_test_prime_feedback_misses(struct ap2cl_s *p)
+{
+    atomic_store(&p->feedback_failures,
+                 AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES - 1);
 }
 
 void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p)

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -68,6 +68,13 @@ extern log_level *loglevel;
 #define AP2_RTSP_FEEDBACK_TIMEOUT_MS 2000
 #define AP2_RTSP_METADATA_TIMEOUT_MS 5000
 #define AP2_RTSP_ARTWORK_TIMEOUT_MS  15000
+/* Budget for the farewell TEARDOWN written on a channel that is being
+ * abandoned. It has to land while the receiver still has queued audio to play
+ * out — a teardown with audio still queued is clean, an underrun on an armed
+ * session pops — so it stays well inside the 600 ms queue depth. Nothing waits
+ * on it, and the channel is going away either way, so a receiver that has
+ * stopped reading costs only this. */
+#define AP2_RTSP_FAREWELL_TIMEOUT_MS 250
 #define AP2_FEEDBACK_INTERVAL_MS     2000
 /* A single missed keepalive beat must not kill an otherwise healthy session:
  * receivers ride out multi-second local network blackouts (wifi roams, DFS
@@ -500,9 +507,123 @@ static void ap2_report_failed_exchange(struct ap2cl_s *p, const char *label,
 
 /* ---- Native AP2 RTSP I/O ---- */
 
+/* Put one RTSP request on the wire, HAP-framed while the channel is encrypted.
+ * A failure leaves errno set and names the phase it died in, so the caller can
+ * report it and decide whether it kills the channel. Only a "write" failure can
+ * have left part of the request behind, which desynchronizes the receiver's
+ * frame stream. */
+static bool ap2_rtsp_write_request(struct ap2cl_s *p, const char *method,
+                                   const char *uri, const uint8_t *body,
+                                   int body_len, const char *ct,
+                                   const char *extra_hdr, int cseq,
+                                   uint64_t started_ms, uint64_t deadline_ms,
+                                   const char **phase)
+{
+    char hdr[1024];
+    int hdr_len = snprintf(hdr, sizeof(hdr),
+        "%s %s RTSP/1.0\r\nCSeq: %d\r\nUser-Agent: AirPlay/670.6.2\r\n"
+        "DACP-ID: %s\r\nActive-Remote: %s\r\n%s%s%s%s"
+        "Content-Length: %d\r\n\r\n",
+        method, uri, cseq,
+        p->dacp_id ? p->dacp_id : "0",
+        p->active_remote ? p->active_remote : "0",
+        ct ? "Content-Type: " : "", ct ? ct : "", ct ? "\r\n" : "",
+        extra_hdr ? extra_hdr : "",
+        body_len);
+    if (hdr_len <= 0 || hdr_len >= (int)sizeof(hdr)) {
+        errno = EMSGSIZE;
+        *phase = "construct";
+        return false;
+    }
+
+    uint8_t *msg = NULL;
+    int msg_len = 0;
+
+    if (p->hap) {
+        /* Encrypt RTSP via HAP framing */
+        int raw_len = hdr_len + body_len;
+        uint8_t *raw = malloc(raw_len);
+        if (!raw) {
+            errno = ENOMEM;
+            *phase = "allocate";
+            return false;
+        }
+        memcpy(raw, hdr, hdr_len);
+        if (body && body_len > 0) memcpy(raw + hdr_len, body, body_len);
+        msg_len = ap2_hap_encrypt(p->hap, raw, raw_len, &msg);
+        free(raw);
+        if (msg_len <= 0) {
+            free(msg);
+            errno = EPROTO;
+            *phase = "encrypt";
+            return false;
+        }
+    } else {
+        msg_len = hdr_len + body_len;
+        msg = malloc(msg_len);
+        if (!msg) {
+            errno = ENOMEM;
+            *phase = "allocate";
+            return false;
+        }
+        memcpy(msg, hdr, hdr_len);
+        if (body && body_len > 0) memcpy(msg + hdr_len, body, body_len);
+    }
+
+    LOG_DEBUG("[AP2] RTSP TX cseq=%d %s %s body=%d wire=%d timeout=%dms",
+              cseq, method, uri, body_len, msg_len,
+              (int)(deadline_ms - started_ms));
+    bool sent = ap2_io_write_all_deadline(p->sock_fd, msg, msg_len,
+                                          deadline_ms);
+    /* Keep the failed write's errno: the caller reports it, and free() is not
+     * guaranteed to preserve it. */
+    int write_errno = errno;
+    free(msg);
+    errno = write_errno;
+    if (!sent) *phase = "write";
+    return sent;
+}
+
+/* Say goodbye on a control channel that is about to be abandoned.
+ *
+ * A receiver whose sender disappears keeps the session armed: it plays out what
+ * is queued and then pops audibly on the starved queue, over and over, until
+ * something else displaces it. The TEARDOWN in ap2cl_disconnect() cannot get
+ * there any more — the regular send path is fail-closed once the channel is
+ * dead, and the socket is shut down right after this — so it goes out from
+ * here, while the socket is still open and the receiver still has audio queued
+ * (a teardown with audio still queued is clean).
+ *
+ * The response is deliberately not read: nothing depends on it, and the read
+ * direction is exactly what just proved unreliable. Writing is safe regardless,
+ * because the two directions carry their own keys and counters and the write
+ * nonce only ever advances. */
+static void ap2_rtsp_farewell_teardown(struct ap2cl_s *p)
+{
+    if (!p->rtsp_established || p->sock_fd < 0 || !*p->session_url) return;
+    uint64_t started_ms = ap2_io_monotonic_ms();
+    const char *phase = NULL;
+    if (ap2_rtsp_write_request(p, "TEARDOWN", p->session_url, NULL, 0, NULL,
+                               NULL, p->cseq++, started_ms,
+                               started_ms + AP2_RTSP_FAREWELL_TIMEOUT_MS,
+                               &phase)) {
+        LOG_INFO("[AP2] Wrote a farewell TEARDOWN for %s so the receiver drops "
+                 "the session instead of popping on its starved queue",
+                 p->session_url);
+        return;
+    }
+    int write_errno = errno;
+    LOG_WARN("[AP2] Farewell TEARDOWN for %s failed during %s: %s; the "
+             "receiver may hold the session until something displaces it",
+             p->session_url, phase, strerror(write_errno));
+}
+
+/* :param request_intact: Whether the request this failure belongs to reached
+ *     the receiver whole, which decides if a farewell TEARDOWN can still be
+ *     appended to the channel. */
 static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
                                const char *uri, const char *phase,
-                               uint64_t elapsed_ms)
+                               uint64_t elapsed_ms, bool request_intact)
 {
     int saved_errno = errno;
     unsigned prior_misses = atomic_load(&p->feedback_failures);
@@ -524,6 +645,12 @@ static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
         LOG_ERROR("[AP2] RTSP channel failed during %s %s %s after %" PRIu64
                   "ms: %s; terminating native session",
                   method, uri, phase, elapsed_ms, strerror(saved_errno));
+        /* Only worth trying when the receiver simply stopped answering: a peer
+         * that reset or closed the connection is already gone, and a request
+         * that died mid-write left a partial frame no further write can follow.
+         * rtsp_dead is set by now, so the farewell cannot recurse into here. */
+        if (request_intact && saved_errno == ETIMEDOUT)
+            ap2_rtsp_farewell_teardown(p);
         shutdown(p->sock_fd, SHUT_RDWR);
     }
     errno = saved_errno;
@@ -561,69 +688,15 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
     }
     if (request_started) *request_started = true;
     int cseq = p->cseq++;
-    char hdr[1024];
-    int hdr_len = snprintf(hdr, sizeof(hdr),
-        "%s %s RTSP/1.0\r\nCSeq: %d\r\nUser-Agent: AirPlay/670.6.2\r\n"
-        "DACP-ID: %s\r\nActive-Remote: %s\r\n%s%s%s%s"
-        "Content-Length: %d\r\n\r\n",
-        method, uri, cseq,
-        p->dacp_id ? p->dacp_id : "0",
-        p->active_remote ? p->active_remote : "0",
-        ct ? "Content-Type: " : "", ct ? ct : "", ct ? "\r\n" : "",
-        extra_hdr ? extra_hdr : "",
-        body_len);
-    if (hdr_len <= 0 || hdr_len >= (int)sizeof(hdr)) {
-        errno = EMSGSIZE;
-        ap2_mark_rtsp_dead(p, method, uri, "construct", 0);
+    const char *write_phase = NULL;
+    if (!ap2_rtsp_write_request(p, method, uri, body, body_len, ct, extra_hdr,
+                                cseq, started_ms, deadline_ms, &write_phase)) {
+        ap2_mark_rtsp_dead(p, method, uri, write_phase,
+                           ap2_io_monotonic_ms() - started_ms, false);
+        *resp_body = NULL;
+        *resp_len = 0;
         return 0;
     }
-
-    uint8_t *msg = NULL;
-    int msg_len = 0;
-
-    if (p->hap) {
-        /* Encrypt RTSP via HAP framing */
-        int raw_len = hdr_len + body_len;
-        uint8_t *raw = malloc(raw_len);
-        if (!raw) {
-            errno = ENOMEM;
-            ap2_mark_rtsp_dead(p, method, uri, "allocate", 0);
-            return 0;
-        }
-        memcpy(raw, hdr, hdr_len);
-        if (body && body_len > 0) memcpy(raw + hdr_len, body, body_len);
-        msg_len = ap2_hap_encrypt(p->hap, raw, raw_len, &msg);
-        free(raw);
-        if (msg_len <= 0) {
-            free(msg);
-            errno = EPROTO;
-            ap2_mark_rtsp_dead(p, method, uri, "encrypt", 0);
-            return 0;
-        }
-    } else {
-        msg_len = hdr_len + body_len;
-        msg = malloc(msg_len);
-        if (!msg) {
-            errno = ENOMEM;
-            ap2_mark_rtsp_dead(p, method, uri, "allocate", 0);
-            return 0;
-        }
-        memcpy(msg, hdr, hdr_len);
-        if (body && body_len > 0) memcpy(msg + hdr_len, body, body_len);
-    }
-
-    LOG_DEBUG("[AP2] RTSP TX cseq=%d %s %s body=%d wire=%d timeout=%dms",
-              cseq, method, uri, body_len, msg_len,
-              (int)(deadline_ms - started_ms));
-    if (!ap2_io_write_all_deadline(p->sock_fd, msg, msg_len, deadline_ms)) {
-        /* mark first: it keys off errno from the failed write, which a
-         * free() in between is not guaranteed to preserve */
-        ap2_mark_rtsp_dead(p, method, uri, "write",
-                           ap2_io_monotonic_ms() - started_ms);
-        free(msg);
-        return 0;
-    }
-    free(msg);
 
     /* Read encrypted response.
      * HAP framing: [2-byte LE length][encrypted chunk + 16-byte tag]
@@ -676,7 +749,7 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
         }
         if (total >= (int)sizeof(buf)) errno = EMSGSIZE;
         ap2_mark_rtsp_dead(p, method, uri, "read",
-                           ap2_io_monotonic_ms() - started_ms);
+                           ap2_io_monotonic_ms() - started_ms, true);
         if (!atomic_load(&p->rtsp_dead) && total > 0) {
             memcpy(p->rtsp_carry, buf, (size_t)total);
             p->rtsp_carry_len = total;
@@ -743,7 +816,7 @@ static int ap2_rtsp_send_ex_unlocked(struct ap2cl_s *p, const char *method, cons
 
     if (total >= (int)sizeof(buf)) errno = EMSGSIZE;
     ap2_mark_rtsp_dead(p, method, uri, "read",
-                       ap2_io_monotonic_ms() - started_ms);
+                       ap2_io_monotonic_ms() - started_ms, true);
     if (!atomic_load(&p->rtsp_dead) && total > 0) {
         memcpy(p->rtsp_carry, buf, (size_t)total);
         p->rtsp_carry_len = total;

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -304,6 +304,74 @@ static void test_feedback_miss_tolerated_then_recovered(void)
     puts("ap2_client feedback miss tolerance test passed");
 }
 
+/* Mirrors AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES in ap2_client.c. */
+#define TEST_FEEDBACK_MISS_BUDGET 3
+
+static void *run_farewell_teardown_peer(void *arg)
+{
+    feedback_peer_t *peer = arg;
+    peer->ok = false;
+    /* Swallow every beat of the budget so the sender gives up on the channel. */
+    for (int beat = 0; beat < TEST_FEEDBACK_MISS_BUDGET; beat++) {
+        int cseq = 0;
+        if (!read_rtsp_request_cseq(peer->fd, "POST /feedback ", &cseq))
+            return NULL;
+    }
+    /* The goodbye has to arrive on the channel the sender is abandoning. */
+    int teardown_cseq = 0;
+    if (!read_rtsp_request_cseq(peer->fd, "TEARDOWN rtsp://test/session ",
+                                &teardown_cseq))
+        return NULL;
+    peer->ok = true;
+    return NULL;
+}
+
+/* Spending the miss budget kills the channel, and the receiver must still be
+ * told: without the farewell TEARDOWN it holds the session armed and pops
+ * audibly on the starved queue until something else displaces it. */
+static void test_dead_channel_writes_farewell_teardown(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    feedback_peer_t peer = {
+        .fd = sockets[1],
+    };
+    pthread_t peer_thread;
+    assert(pthread_create(
+               &peer_thread, NULL, run_farewell_teardown_peer, &peer) == 0);
+
+    ap2_device_info_t device = {
+        .name = "farewell test",
+        .address = "127.0.0.1",
+        .port = 7000,
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+
+    for (int beat = 1; beat <= TEST_FEEDBACK_MISS_BUDGET; beat++) {
+        assert(!ap2cl_feedback(client));
+        /* Only the budget's last beat gives up on the channel. */
+        assert(ap2cl_control_healthy(client) ==
+               (beat < TEST_FEEDBACK_MISS_BUDGET));
+    }
+
+    assert(pthread_join(peer_thread, NULL) == 0);
+    assert(peer.ok);
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+    puts("ap2_client farewell teardown test passed");
+}
+
 typedef struct {
     struct ap2cl_s *client;
     atomic_bool done;
@@ -1907,6 +1975,7 @@ int main(void)
     test_splice_pause_keeps_line_hot();
     test_mrp_bundle_and_pause_publish();
     test_feedback_miss_tolerated_then_recovered();
+    test_dead_channel_writes_farewell_teardown();
     test_apple_model_resolution();
     test_pacing_window_rate_scaling();
     test_clock_verified_anchor();

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -31,6 +31,7 @@ void ap2cl_test_set_mrp(struct ap2cl_s *p, struct ap2_mrp_ctx *m);
 void ap2cl_test_lock_mrp(struct ap2cl_s *p);
 void ap2cl_test_unlock_mrp(struct ap2cl_s *p);
 void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd);
+void ap2cl_test_prime_feedback_misses(struct ap2cl_s *p);
 void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p);
 bool ap2cl_test_first_packet(struct ap2cl_s *p);
 void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet);
@@ -304,23 +305,20 @@ static void test_feedback_miss_tolerated_then_recovered(void)
     puts("ap2_client feedback miss tolerance test passed");
 }
 
-/* Mirrors AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES in ap2_client.c. */
-#define TEST_FEEDBACK_MISS_BUDGET 3
-
 static void *run_farewell_teardown_peer(void *arg)
 {
     feedback_peer_t *peer = arg;
     peer->ok = false;
-    /* Swallow every beat of the budget so the sender gives up on the channel. */
-    for (int beat = 0; beat < TEST_FEEDBACK_MISS_BUDGET; beat++) {
-        int cseq = 0;
-        if (!read_rtsp_request_cseq(peer->fd, "POST /feedback ", &cseq))
-            return NULL;
-    }
-    /* The goodbye has to arrive on the channel the sender is abandoning. */
+    /* Swallow the beat that spends the budget. */
+    int missed_cseq = 0;
+    if (!read_rtsp_request_cseq(peer->fd, "POST /feedback ", &missed_cseq))
+        return NULL;
+    /* The goodbye has to arrive on the channel the sender is abandoning, as
+     * the next request in that channel's sequence. */
     int teardown_cseq = 0;
     if (!read_rtsp_request_cseq(peer->fd, "TEARDOWN rtsp://test/session ",
-                                &teardown_cseq))
+                                &teardown_cseq) ||
+        teardown_cseq != missed_cseq + 1)
         return NULL;
     peer->ok = true;
     return NULL;
@@ -328,7 +326,12 @@ static void *run_farewell_teardown_peer(void *arg)
 
 /* Spending the miss budget kills the channel, and the receiver must still be
  * told: without the farewell TEARDOWN it holds the session armed and pops
- * audibly on the starved queue until something else displaces it. */
+ * audibly on the starved queue until something else displaces it.
+ *
+ * The budget is primed rather than spent beat by beat, so the test costs one
+ * feedback timeout instead of the whole ladder and does not mirror the budget
+ * constant — a raised budget would otherwise leave the peer waiting for a
+ * goodbye the sender never sends, hanging the suite instead of failing it. */
 static void test_dead_channel_writes_farewell_teardown(void)
 {
     int sockets[2];
@@ -355,13 +358,10 @@ static void test_dead_channel_writes_farewell_teardown(void)
     assert(client);
     ap2cl_force_native(client);
     ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+    ap2cl_test_prime_feedback_misses(client);
 
-    for (int beat = 1; beat <= TEST_FEEDBACK_MISS_BUDGET; beat++) {
-        assert(!ap2cl_feedback(client));
-        /* Only the budget's last beat gives up on the channel. */
-        assert(ap2cl_control_healthy(client) ==
-               (beat < TEST_FEEDBACK_MISS_BUDGET));
-    }
+    assert(!ap2cl_feedback(client));
+    assert(!ap2cl_control_healthy(client));
 
     assert(pthread_join(peer_thread, NULL) == 0);
     assert(peer.ok);


### PR DESCRIPTION
## Problem

When the control channel to a receiver is given up on (three unanswered keepalives), the session is abandoned without ever telling the device. The receiver keeps the audio session armed: it plays out whatever is queued, then pops audibly on the starved queue — over and over, until something else displaces it. A user reported a HomePod popping through the night after exactly this, until they power-cycled it.

The `TEARDOWN` at disconnect cannot reach the device in that state: the send path is fail-closed once the channel is marked dead, and the socket is shut down immediately after marking it.

## Changes

- Write one last `TEARDOWN` at the point the channel is given up on, while the socket is still open and the receiver still has audio queued — the case we already know tears down cleanly.
- Only for a request that went out whole and simply was not answered. A reset or closed peer is already gone, and a request that died mid-write left a partial frame no further write can follow.
- 250 ms budget, response never read: nothing depends on it, and only the write nonce advances so none is reused.
- Extract the request-write path out of `ap2_rtsp_send_ex_unlocked()` so both senders share it.
- Test drives the real miss ladder and asserts the `TEARDOWN` reaches the peer; it fails without the fix.

Not yet confirmed against hardware — the reporter's next incident should show the receiver going quiet instead of popping.