### PR TITLE
Play announcements over the music instead of interrupting it

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -185,6 +185,7 @@ on stderr that Music Assistant parses:
 | `play_failed` | `ACTION=PLAY` was rejected by the transport, or the resolved protocol had no client to resume; the status stays where it was either way |
 | `pause_failed` | `ACTION=PAUSE` was rejected by the transport; `[STATUS] paused` still follows, because sends stop regardless |
 | `stop_failed` | `ACTION=STOP` found no client to stop; `[STATUS] stopped` still follows, because the caller treats STOP as terminal |
+| `announce_failed` | `ACTION=ANNOUNCE` armed nothing (no playing session, or an unusable clip file), so no announce status lines follow (§6a) |
 
 The connect/auth slugs are terminal — the process exits. The command slugs are
 not: the connection survives and the caller decides whether to retry or fall
@@ -494,6 +495,46 @@ lead and the raw window are surfaced on stdout
 so the caller plans group starts from device reality. The SETUP echo of the
 window is receiver-optional (Sonos omits it — then the 1.75 s default
 applies); parsing `audioLatencies` from GET /info is an open item.
+
+## 6a. Announcements (ANNOUNCE)
+
+A short clip (doorbell, TTS) is mixed **inside the binary** over the music at
+the frame-pull point, with the music ducked under it, so the group timeline is
+untouched — announcement frames are ordinary content frames on the existing
+anchor, the duck is gapless, and elapsed reporting never notices. The caller
+pre-renders the clip to **exactly the session's stdin PCM format** (raw,
+headerless) into a local file and commands:
+
+```
+ANNOUNCE_FILE=/tmp/<player>-announce.pcm
+ANNOUNCE_AT_UNIX_MS=<T>       # unix epoch ms; 0 = earliest feasible
+ANNOUNCE_DUCK_DB=-12          # music gain during the clip (dB, <= 0; <= -60 mutes)
+ACTION=ANNOUNCE
+```
+
+**Mapping contract.** T maps onto the flow's audible timeline the same way a
+START does: when the chunk being assembled covers T, mixing begins at the
+exact frame offset within it; a T of 0 or one already behind the earliest
+unsent frame starts at that frame instead. The clip is never entered mid-way —
+it always plays from its first byte at the (possibly corrected) instant, and
+`[STATUS] announce_started at_unix_ms= duration_ms=` reports the true audible
+instant of its first sample once that sample is committed into an outgoing
+chunk. The music gain ramps 1.0 → duck over 200 ms from the clip's first
+sample, holds for the clip, and ramps back over 200 ms after its last sample;
+`[STATUS] announce_done` follows once that tail is mixed out. Mixing happens
+on the finalized PCM chunk right before encoding, so splice pad silence under
+a starving feed is simply part of the bed, and on the splice timeline a clip
+outlives its input: the post-EOF silence keepalive keeps carrying it.
+
+**Cancellation.** Anything that invalidates the timeline the clip was mapped
+onto cancels it with `[STATUS] announce_done cancelled=1`: FLUSH, a new START,
+PAUSE, STANDBY, STOP and teardown, plus end-of-input on the paths that have no
+silence keepalive to carry the clip (legacy RAOP, deny-listed receivers). A
+new ANNOUNCE while one is active replaces it the same way — the recovery path
+for a clip left armed by a caller restart. Arming requires an anchored,
+playing session and a readable, non-empty clip file; anything else is one
+non-terminal `announce_failed` error (§3a) and the caller falls back to its
+generic interrupt-and-restore flow.
 
 ## 7. Audio wire formats
 
@@ -1008,6 +1049,8 @@ verbosity, never its stream.
 | `[STATUS] playing` / `paused` | stderr | `ACTION=PLAY` / `ACTION=PAUSE`, carrying `elapsed_ms=` |
 | `[STATUS] stopped` | stderr | `ACTION=STOP`; the process then exits 0 |
 | `[STATUS] mrp artwork=` | stderr | every artwork attempt (§8) |
+| `[STATUS] announce_started at_unix_ms= duration_ms=` | stderr | once per armed clip: its first sample was committed, at the reported audible instant (§6a) |
+| `[STATUS] announce_done` (optional `cancelled=1`) | stderr | the clip and its tail ramp finished — or were cancelled (§6a) |
 | `[STATUS] eof` | stderr | the stdin input ended |
 | `[STATUS] idle_timeout` | stderr | the orphan timer fired; the process then exits 0 |
 | `[STATUS] error code=` | stderr | immediately before the `[ERROR]` line (§3a) |

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ AP2_SOURCES = ap2_client.c ap2_hap.c ap2_io.c ap2_ptp.c ap2_ptp_shm.c ap2_plist.
 
 # Common/CLI sources
 CLI_SOURCES = cross_log.c cross_ssl.c cross_util.c cross_net.c platform.c \
-	cliairplay.c raop_session.c artwork.c pairing.cpp bplist.cpp ap2_bplist.cpp alac_ext.cpp
+	cliairplay.c raop_session.c artwork.c announce.c pairing.cpp bplist.cpp ap2_bplist.cpp alac_ext.cpp
 
 # Pre-built static libraries
 # We use a patched copy of libcodecs.a with the buggy alac_create_encoder removed,
@@ -165,6 +165,7 @@ RAOP_LIFECYCLE_TEST_DEFINES = \
 	-Draopcl_latency=ap2_test_raopcl_latency \
 	-Draopcl_sample_rate=ap2_test_raopcl_sample_rate
 RAOP_SESSION_TEST = build/tests/test_raop_session
+ANNOUNCE_TEST = build/tests/test_announce
 
 all: directory $(EXECUTABLE)
 
@@ -211,7 +212,7 @@ clean:
 
 test: directory $(EXECUTABLE) $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(CLIENT_TEST) \
 		$(SESSION_TEST) $(TEST_EXECUTABLE) $(RAOP_LIFECYCLE_TEST_EXECUTABLE) \
-		$(RAOP_SESSION_TEST)
+		$(RAOP_SESSION_TEST) $(ANNOUNCE_TEST)
 	$(TIMELINE_TEST)
 	$(EVENT_TEST)
 	$(IO_TEST)
@@ -220,6 +221,7 @@ test: directory $(EXECUTABLE) $(TIMELINE_TEST) $(EVENT_TEST) $(IO_TEST) $(CLIENT
 	$(TEST_EXECUTABLE)
 	$(RAOP_LIFECYCLE_TEST_EXECUTABLE)
 	$(RAOP_SESSION_TEST)
+	$(ANNOUNCE_TEST)
 	python3 tests/mrp_artwork_matrix.py --help >/dev/null
 	@missing_pipe="$$($(EXECUTABLE) --protocol raop \
 		127.0.0.1 2>&1 || true)"; \
@@ -251,6 +253,11 @@ $(RAOP_SESSION_TEST): tests/test_raop_session.c src/raop_session.c \
 	@mkdir -p $(dir $@)
 	$(CC) $(TEST_CFLAGS) $(INCLUDE) tests/test_raop_session.c \
 		src/raop_session.c $(EXTRA_LDFLAGS) -o $@
+
+$(ANNOUNCE_TEST): tests/test_announce.c src/announce.c src/announce.h Makefile
+	@mkdir -p $(dir $@)
+	$(CC) $(TEST_CFLAGS) -Isrc tests/test_announce.c src/announce.c \
+		$(EXTRA_LDFLAGS) -lm -o $@
 
 $(SESSION_TEST): tests/test_ap2_session.c src/ap2_session.c src/ap2_session.h \
 		src/ap2_io.c src/ap2_io.h Makefile

--- a/src/announce.c
+++ b/src/announce.c
@@ -163,8 +163,10 @@ void announce_mix_chunk(announce_t *a, uint8_t *buf, int frames,
 
 int32_t announce_gain_q15_from_db(double duck_db)
 {
+    /* NaN fails every comparison below and would reach the pow/lround with
+     * an unspecified result; treat it as "no duck". */
+    if (isnan(duck_db) || duck_db >= 0.0) return Q15_UNITY;
     if (duck_db <= ANNOUNCE_MUTE_DB) return 0;
-    if (duck_db >= 0.0) return Q15_UNITY;
     return (int32_t)lround(pow(10.0, duck_db / 20.0) * Q15_UNITY);
 }
 

--- a/src/announce.c
+++ b/src/announce.c
@@ -43,6 +43,11 @@ bool announce_arm(announce_t *a, const char *path, uint64_t at_unix_ms,
         snprintf(error, error_len, "announce module not initialised");
         return false;
     }
+    if (a->bytes_per_sample != 2 && a->bytes_per_sample != 4) {
+        snprintf(error, error_len, "unsupported PCM sample size (%u bytes)",
+                 a->bytes_per_sample);
+        return false;
+    }
     /* The caller reports an active clip's cancellation before re-arming; this
      * is only the leak guard for a caller that did not. */
     if (a->active) announce_cancel(a);

--- a/src/announce.c
+++ b/src/announce.c
@@ -1,0 +1,265 @@
+/*
+ * Announcement mixing over the outgoing PCM stream (see announce.h).
+ *
+ * Copyright (C) 2024-2026 Music Assistant Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "announce.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define Q15_UNITY 32768
+
+static int clip_stage_frames(announce_t *a, int max_frames,
+                             unsigned frame_bytes);
+static void mix_slice_s16(announce_t *a, int16_t *music, const int16_t *clip,
+                          int frames, unsigned channels);
+static void mix_slice_s32(announce_t *a, int32_t *music, const int32_t *clip,
+                          int frames, unsigned channels);
+
+void announce_init(announce_t *a, unsigned sample_rate, unsigned channels,
+                   unsigned bytes_per_sample)
+{
+    memset(a, 0, sizeof(*a));
+    a->sample_rate = sample_rate;
+    a->channels = channels;
+    a->bytes_per_sample = bytes_per_sample;
+    a->fd = -1;
+}
+
+bool announce_arm(announce_t *a, const char *path, uint64_t at_unix_ms,
+                  double duck_db, char *error, size_t error_len)
+{
+    unsigned frame_bytes = a->channels * a->bytes_per_sample;
+    if (!a->sample_rate || !frame_bytes) {
+        snprintf(error, error_len, "announce module not initialised");
+        return false;
+    }
+    /* The caller reports an active clip's cancellation before re-arming; this
+     * is only the leak guard for a caller that did not. */
+    if (a->active) announce_cancel(a);
+
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        snprintf(error, error_len, "cannot open the announcement clip: %s",
+                 strerror(errno));
+        return false;
+    }
+    struct stat st;
+    if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)) {
+        close(fd);
+        snprintf(error, error_len,
+                 "the announcement clip is not a regular file");
+        return false;
+    }
+    uint64_t clip_bytes =
+        (uint64_t)st.st_size - (uint64_t)st.st_size % frame_bytes;
+    if (!clip_bytes) {
+        close(fd);
+        snprintf(error, error_len, "the announcement clip is empty");
+        return false;
+    }
+
+    a->active = true;
+    a->started = false;
+    a->fd = fd;
+    a->clip_bytes = clip_bytes;
+    a->clip_bytes_read = 0;
+    a->clip_frames = clip_bytes / frame_bytes;
+    a->at_unix_ms = at_unix_ms;
+    a->duration_ms =
+        clip_bytes * 1000ULL / ((uint64_t)a->sample_rate * frame_bytes);
+    a->mixed_frames = 0;
+    a->ramp_frames =
+        (uint32_t)((uint64_t)ANNOUNCE_RAMP_MS * a->sample_rate / 1000);
+    a->duck_q15 = announce_gain_q15_from_db(duck_db);
+    return true;
+}
+
+bool announce_active(const announce_t *a)
+{
+    return a->active;
+}
+
+bool announce_cancel(announce_t *a)
+{
+    if (!a->active) return false;
+    if (a->fd >= 0) close(a->fd);
+    a->fd = -1;
+    a->active = false;
+    a->started = false;
+    return true;
+}
+
+void announce_mix_chunk(announce_t *a, uint8_t *buf, int frames,
+                        uint64_t head_unix_ms, announce_mix_result_t *result)
+{
+    memset(result, 0, sizeof(*result));
+    if (!a->active || frames <= 0 || !head_unix_ms) return;
+
+    int offset = 0;
+    if (!a->started) {
+        /* Map the commanded instant onto this chunk's audible window. An
+         * instant at or behind the chunk head (including 0) starts at its
+         * first frame — the earliest unsent one — and the reported instant is
+         * the corrected truth. The clip always plays from byte 0. */
+        if (a->at_unix_ms > head_unix_ms) {
+            uint64_t off =
+                (a->at_unix_ms - head_unix_ms) * a->sample_rate / 1000;
+            if (off >= (uint64_t)frames) return;   /* not reached yet */
+            offset = (int)off;
+        }
+        a->started = true;
+        result->started = true;
+        result->at_unix_ms =
+            head_unix_ms + (uint64_t)offset * 1000 / a->sample_rate;
+        result->duration_ms = a->duration_ms;
+    }
+
+    unsigned frame_bytes = a->channels * a->bytes_per_sample;
+    while (offset < frames) {
+        int slice = clip_stage_frames(a, frames - offset, frame_bytes);
+        bool have_clip = slice > 0;
+        if (!have_clip) {
+            /* Clip exhausted: the tail ramp keeps scaling the music with no
+             * clip data added until the envelope returns to unity. */
+            uint64_t total = a->clip_frames + a->ramp_frames;
+            if (a->mixed_frames >= total) break;
+            uint64_t left = total - a->mixed_frames;
+            slice = frames - offset;
+            if ((uint64_t)slice > left) slice = (int)left;
+        }
+        uint8_t *dst = buf + (size_t)offset * frame_bytes;
+        const uint8_t *clip = have_clip ? a->staging.bytes : NULL;
+        if (a->bytes_per_sample == 2)
+            mix_slice_s16(a, (int16_t *)dst, (const int16_t *)clip, slice,
+                          a->channels);
+        else
+            mix_slice_s32(a, (int32_t *)dst, (const int32_t *)clip, slice,
+                          a->channels);
+        offset += slice;
+    }
+
+    if (a->mixed_frames >= a->clip_frames + a->ramp_frames) {
+        announce_cancel(a);
+        result->done = true;
+    }
+}
+
+int32_t announce_gain_q15_from_db(double duck_db)
+{
+    if (duck_db <= ANNOUNCE_MUTE_DB) return 0;
+    if (duck_db >= 0.0) return Q15_UNITY;
+    return (int32_t)lround(pow(10.0, duck_db / 20.0) * Q15_UNITY);
+}
+
+/* Music gain at frame t since the clip's first sample: linear ramp down over
+ * ramp_frames, hold at duck for the clip, linear ramp back up after its last
+ * sample. A clip shorter than the ramp never reaches the full duck, so its
+ * tail ramps back from the gain the down ramp actually got to. */
+int32_t announce_music_gain_q15(const announce_t *a, uint64_t t_frames)
+{
+    uint32_t ramp = a->ramp_frames;
+    if (!ramp) return t_frames < a->clip_frames ? a->duck_q15 : Q15_UNITY;
+    if (t_frames < a->clip_frames) {
+        if (t_frames >= ramp) return a->duck_q15;
+        return Q15_UNITY + (int32_t)((int64_t)(a->duck_q15 - Q15_UNITY) *
+                                     (int64_t)t_frames / ramp);
+    }
+    uint64_t tail = t_frames - a->clip_frames;
+    if (tail >= ramp) return Q15_UNITY;
+    int32_t from = a->clip_frames >= ramp
+        ? a->duck_q15
+        : Q15_UNITY + (int32_t)((int64_t)(a->duck_q15 - Q15_UNITY) *
+                                (int64_t)a->clip_frames / ramp);
+    return from + (int32_t)((int64_t)(Q15_UNITY - from) * (int64_t)tail / ramp);
+}
+
+/* ---- private helpers ---- */
+
+/* Stage the next run of clip frames (0 = clip fully consumed). A read that
+ * delivers less than the fstat'd size promised ends the clip at the last
+ * whole frame delivered, so the tail ramp begins from the gain reached. */
+static int clip_stage_frames(announce_t *a, int max_frames,
+                             unsigned frame_bytes)
+{
+    uint64_t left = (a->clip_bytes - a->clip_bytes_read) / frame_bytes;
+    if (!left) return 0;
+    int want = max_frames;
+    if ((uint64_t)want > left) want = (int)left;
+    int cap = (int)(ANNOUNCE_STAGING_BYTES / frame_bytes);
+    if (want > cap) want = cap;
+    int want_bytes = want * (int)frame_bytes;
+    int got = 0;
+    while (got < want_bytes) {
+        ssize_t n =
+            read(a->fd, a->staging.bytes + got, (size_t)(want_bytes - got));
+        if (n < 0 && errno == EINTR) continue;
+        if (n <= 0) break;
+        got += (int)n;
+    }
+    if (got < want_bytes) {
+        got -= got % (int)frame_bytes;
+        a->clip_bytes_read += (uint64_t)got;
+        a->clip_bytes = a->clip_bytes_read;
+        a->clip_frames = a->clip_bytes / frame_bytes;
+        return got / (int)frame_bytes;
+    }
+    a->clip_bytes_read += (uint64_t)got;
+    return want;
+}
+
+static inline int16_t clamp_s16(int32_t v)
+{
+    if (v > INT16_MAX) return INT16_MAX;
+    if (v < INT16_MIN) return INT16_MIN;
+    return (int16_t)v;
+}
+
+static inline int32_t clamp_s32(int64_t v)
+{
+    if (v > INT32_MAX) return INT32_MAX;
+    if (v < INT32_MIN) return INT32_MIN;
+    return (int32_t)v;
+}
+
+/* Interleaved samples are mixed channel-agnostically: one envelope gain per
+ * frame, applied to every sample in it. clip == NULL mixes the tail (music
+ * scaling only). */
+static void mix_slice_s16(announce_t *a, int16_t *music, const int16_t *clip,
+                          int frames, unsigned channels)
+{
+    for (int f = 0; f < frames; f++) {
+        int32_t gain = announce_music_gain_q15(a, a->mixed_frames);
+        for (unsigned c = 0; c < channels; c++) {
+            unsigned i = (unsigned)f * channels + c;
+            int32_t acc = (int32_t)(((int64_t)music[i] * gain) >> 15);
+            if (clip) acc += clip[i];
+            music[i] = clamp_s16(acc);
+        }
+        a->mixed_frames++;
+    }
+}
+
+static void mix_slice_s32(announce_t *a, int32_t *music, const int32_t *clip,
+                          int frames, unsigned channels)
+{
+    for (int f = 0; f < frames; f++) {
+        int32_t gain = announce_music_gain_q15(a, a->mixed_frames);
+        for (unsigned c = 0; c < channels; c++) {
+            unsigned i = (unsigned)f * channels + c;
+            int64_t acc = ((int64_t)music[i] * gain) >> 15;
+            if (clip) acc += clip[i];
+            music[i] = clamp_s32(acc);
+        }
+        a->mixed_frames++;
+    }
+}

--- a/src/announce.c
+++ b/src/announce.c
@@ -47,7 +47,10 @@ bool announce_arm(announce_t *a, const char *path, uint64_t at_unix_ms,
      * is only the leak guard for a caller that did not. */
     if (a->active) announce_cancel(a);
 
-    int fd = open(path, O_RDONLY);
+    /* O_NONBLOCK so a FIFO with no writer cannot block the open (and with it
+     * the caller's audio lock) before the regular-file check below rejects
+     * it; reads from the regular files this accepts are unaffected. */
+    int fd = open(path, O_RDONLY | O_NONBLOCK);
     if (fd < 0) {
         snprintf(error, error_len, "cannot open the announcement clip: %s",
                  strerror(errno));

--- a/src/announce.c
+++ b/src/announce.c
@@ -115,8 +115,12 @@ void announce_mix_chunk(announce_t *a, uint8_t *buf, int frames,
          * first frame — the earliest unsent one — and the reported instant is
          * the corrected truth. The clip always plays from byte 0. */
         if (a->at_unix_ms > head_unix_ms) {
-            uint64_t off =
-                (a->at_unix_ms - head_unix_ms) * a->sample_rate / 1000;
+            uint64_t delta_ms = a->at_unix_ms - head_unix_ms;
+            /* An instant so far out that the frame math would wrap can only
+             * be a corrupt command; keep the clip waiting instead of starting
+             * it on a wrapped offset. */
+            if (delta_ms > UINT64_MAX / a->sample_rate) return;
+            uint64_t off = delta_ms * a->sample_rate / 1000;
             if (off >= (uint64_t)frames) return;   /* not reached yet */
             offset = (int)off;
         }

--- a/src/announce.h
+++ b/src/announce.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024-2026 Music Assistant Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __ANNOUNCE_H_
+#define __ANNOUNCE_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Announcement mixing (ACTION=ANNOUNCE): a short PCM clip, pre-rendered by the
+ * caller to exactly the session's stdin format, is mixed over the outgoing
+ * music at the frame-pull point with the music ducked under it. The group
+ * timeline is untouched — announcement frames are ordinary content frames.
+ *
+ * The module is pure state + arithmetic plus incremental reads of the clip
+ * file; it emits nothing and takes no locks. The caller owns the locking and
+ * reports the returned lifecycle events on its status channel.
+ */
+
+/* Music duck ramp on either side of the clip (ms): the music gain runs
+ * 1.0 -> duck over this window from the clip's first sample, holds for the
+ * clip, and returns duck -> 1.0 over the same window after its last sample. */
+#define ANNOUNCE_RAMP_MS 200
+
+/* Duck levels at or below this many dB mute the music outright. */
+#define ANNOUNCE_MUTE_DB (-60.0)
+
+/* Per-slice clip staging buffer: the clip is consumed incrementally, never
+ * loaded whole (a hi-res clip can run past 100 MB). */
+#define ANNOUNCE_STAGING_BYTES 4096
+
+typedef struct announce_s {
+    /* Session PCM format, fixed at announce_init. */
+    unsigned sample_rate;
+    unsigned channels;
+    unsigned bytes_per_sample;   /* 2 = s16le, 4 = s32le carrier (24-bit) */
+
+    /* Armed clip; live between announce_arm and done/cancel. */
+    bool active;
+    bool started;                /* first clip sample committed to a chunk */
+    int fd;                      /* clip file, owned while active */
+    uint64_t clip_bytes;         /* frame-aligned clip payload size */
+    uint64_t clip_bytes_read;
+    uint64_t clip_frames;
+    uint64_t at_unix_ms;         /* requested instant; 0 = earliest feasible */
+    uint64_t duration_ms;
+    uint64_t mixed_frames;       /* frames mixed since the clip's first sample */
+    uint32_t ramp_frames;
+    int32_t duck_q15;            /* music gain during the hold (Q15) */
+
+    union {
+        uint8_t bytes[ANNOUNCE_STAGING_BYTES];
+        int32_t words[ANNOUNCE_STAGING_BYTES / 4];
+    } staging;
+} announce_t;
+
+/* One mix call's observable outcome, for the caller's status lines. */
+typedef struct {
+    bool started;            /* the clip's first sample went into this chunk */
+    uint64_t at_unix_ms;     /* audible instant of that first sample */
+    uint64_t duration_ms;    /* clip length (valid with started) */
+    bool done;               /* clip and tail ramp fully mixed; state idle */
+} announce_mix_result_t;
+
+/* Bind the module to the session's PCM format. Resets any armed state. */
+void announce_init(announce_t *a, unsigned sample_rate, unsigned channels,
+                   unsigned bytes_per_sample);
+
+/*
+ * Arm a clip file for mixing. The file is raw headerless PCM in exactly the
+ * session format; a trailing partial frame is dropped. at_unix_ms of 0 (or one
+ * already behind the delivery head) starts at the earliest unsent frame.
+ * duck_db is the music gain during the clip (dB, <= 0; <= -60 mutes). On
+ * failure writes a one-line reason into error and arms nothing.
+ */
+bool announce_arm(announce_t *a, const char *path, uint64_t at_unix_ms,
+                  double duck_db, char *error, size_t error_len);
+
+bool announce_active(const announce_t *a);
+
+/* Drop an armed clip. Returns true when one was active (the caller reports
+ * the cancellation). */
+bool announce_cancel(announce_t *a);
+
+/*
+ * Mix the active clip into one finalized PCM chunk about to be sent.
+ * head_unix_ms is the audible wall-clock instant of the chunk's first frame
+ * (0 = unknown: the chunk is left untouched). Music samples are scaled by the
+ * duck envelope, clip samples added at unity, with a saturating clamp.
+ */
+void announce_mix_chunk(announce_t *a, uint8_t *buf, int frames,
+                        uint64_t head_unix_ms, announce_mix_result_t *result);
+
+/* Pure gain math, exposed for the unit tests. Q15: 32768 = unity. */
+int32_t announce_gain_q15_from_db(double duck_db);
+int32_t announce_music_gain_q15(const announce_t *a, uint64_t t_frames);
+
+#endif /* __ANNOUNCE_H_ */

--- a/src/announce.h
+++ b/src/announce.h
@@ -66,7 +66,8 @@ typedef struct {
     bool done;               /* clip and tail ramp fully mixed; state idle */
 } announce_mix_result_t;
 
-/* Bind the module to the session's PCM format. Resets any armed state. */
+/* Bind the module to the session's PCM format, before any clip is armed.
+ * Call on an idle instance only: a live clip's file descriptor would leak. */
 void announce_init(announce_t *a, unsigned sample_rate, unsigned channels,
                    unsigned bytes_per_sample);
 

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -193,6 +193,11 @@ struct ap2cl_s {
 
     /* RAOP-compat flow: libraop client */
     struct raopcl_s *raopcl;
+    /* Last sent chunk's playtime and frame count: the delivery-head
+     * projection for ap2cl_head_audible_unix_ms. Zeroed on every raopcl
+     * re-anchor (0 = head unknown until the next chunk is sent). */
+    uint64_t raop_last_playtime;
+    uint32_t raop_last_chunk_frames;
 
     /* Native AP2 flow */
     int sock_fd;                  /* TCP connection */
@@ -2599,8 +2604,17 @@ struct ap2cl_s *ap2cl_create(
     return p;
 }
 
+/* The RAOP-compat timeline re-anchored (start/flush/pause/resume/stop): the
+ * delivery-head projection from the last sent chunk no longer holds. */
+static void ap2_raop_head_reset(struct ap2cl_s *p)
+{
+    p->raop_last_playtime = 0;
+    p->raop_last_chunk_frames = 0;
+}
+
 static void ap2_raop_session_cleanup(struct ap2cl_s *p)
 {
+    ap2_raop_head_reset(p);
     if (p->raopcl) {
         raopcl_destroy(p->raopcl);
         p->raopcl = NULL;
@@ -3095,6 +3109,7 @@ ap2_commit_result_t ap2cl_start(struct ap2cl_s *p, uint64_t start_unix_ms,
         return AP2_COMMIT_OK;
     }
     if (!p->raopcl) return AP2_COMMIT_FAILED;
+    ap2_raop_head_reset(p);
     int latency = raopcl_latency(p->raopcl);
     raopcl_start_at(p->raopcl, ntp_start - TS2NTP(latency, p->format.sample_rate));
     p->state = AP2_STREAMING;
@@ -3118,6 +3133,7 @@ void ap2cl_standby(struct ap2cl_s *p)
     p->content_stopped = false;
     ap2_content_skip_reset(p, "standby");
     if (p->flow != FLOW_NATIVE_AP2) {
+        ap2_raop_head_reset(p);
         if (p->raopcl) raop_session_standby(p->raopcl);
         p->state = AP2_CONNECTED;
         return;
@@ -3164,8 +3180,10 @@ bool ap2cl_flush(struct ap2cl_s *p)
     ap2_clock_verify_disarm(p);
     ap2_content_skip_reset(p, "FLUSH");
 
-    if (p->flow != FLOW_NATIVE_AP2)
+    if (p->flow != FLOW_NATIVE_AP2) {
+        ap2_raop_head_reset(p);
         return raop_session_flush(p->raopcl);
+    }
 
     if (atomic_load(&p->rtsp_dead)) return false;
     if (p->splice_timeline) {
@@ -3219,6 +3237,7 @@ ap2_commit_result_t ap2cl_resume(struct ap2cl_s *p, uint64_t start_unix_ms,
     ap2_content_skip_reset(p, "resume");
 
     if (p->flow != FLOW_NATIVE_AP2) {
+        ap2_raop_head_reset(p);
         ap2_commit_result_t r =
             raop_session_start_at(p->raopcl, start_unix_ms, at_unix_ms);
         if (r == AP2_COMMIT_OK) p->state = AP2_STREAMING;
@@ -3347,9 +3366,11 @@ ap2_send_result_t ap2cl_send_chunk(struct ap2cl_s *p, uint8_t *sample,
     }
     if (!p->raopcl) return AP2_SEND_FATAL;
     uint64_t playtime;
-    return raopcl_send_chunk(p->raopcl, sample, frames, &playtime)
-               ? AP2_SEND_SENT
-               : AP2_SEND_FATAL;
+    if (!raopcl_send_chunk(p->raopcl, sample, frames, &playtime))
+        return AP2_SEND_FATAL;
+    p->raop_last_playtime = playtime;
+    p->raop_last_chunk_frames = (uint32_t)frames;
+    return AP2_SEND_SENT;
 }
 
 static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
@@ -3790,7 +3811,11 @@ void ap2cl_pause(struct ap2cl_s *p)
 {
     if (!p) return;
     p->content_stopped = false;
-    if (p->raopcl) { raopcl_pause(p->raopcl); raopcl_flush(p->raopcl); }
+    if (p->raopcl) {
+        ap2_raop_head_reset(p);
+        raopcl_pause(p->raopcl);
+        raopcl_flush(p->raopcl);
+    }
     if (p->splice_timeline) {
         /* Splice pause stops the CONTENT, never the wire: an Apple receiver
          * whose queue underruns while the session stays armed emits a noise
@@ -3817,6 +3842,7 @@ void ap2cl_play(struct ap2cl_s *p)
     p->content_paused = false;
     p->content_stopped = false;
     if (p->raopcl) {
+        ap2_raop_head_reset(p);
         int lat = raopcl_latency(p->raopcl);
         uint64_t now = raopcl_get_ntp(NULL);
         raopcl_start_at(p->raopcl, now + MS2NTP(200) - TS2NTP(lat, raopcl_sample_rate(p->raopcl)));
@@ -3860,7 +3886,10 @@ void ap2cl_stop(struct ap2cl_s *p)
     p->content_paused = false;
     p->content_stopped = false;
     ap2_content_skip_reset(p, "stop");
-    if (p->raopcl) raopcl_stop(p->raopcl);
+    if (p->raopcl) {
+        ap2_raop_head_reset(p);
+        raopcl_stop(p->raopcl);
+    }
     ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_STOPPED, true);
     p->rt_anchor_valid = false;
     p->state = AP2_DOWN;
@@ -4621,6 +4650,25 @@ uint64_t ap2cl_splice_head_unix_ms(struct ap2cl_s *p)
     /* head_ts lives in the frame-clock domain of the unix-epoch NTP wall
      * clock, so its audible instant is the direct inverse mapping. */
     return ap2_ntp_to_unix_ms(TS2NTP(p->head_ts, p->format.sample_rate));
+}
+
+/* Audible wall-clock instant (unix ms) of the next frame the audio loop will
+ * send, whatever the flow. Native sessions — splice or not — anchor every
+ * frame audible at its frame-clock position (see ap2cl_accept_frames), so the
+ * delivery head maps directly; the RAOP-compat flow projects it from the last
+ * sent chunk's playtime plus that chunk's duration (RAOP timestamps are
+ * contiguous between re-anchors). 0 while the head is unknown: no timeline
+ * anchored yet, or no chunk sent since the last re-anchor. */
+uint64_t ap2cl_head_audible_unix_ms(struct ap2cl_s *p)
+{
+    if (!p) return 0;
+    if (p->flow == FLOW_NATIVE_AP2) {
+        if (!p->head_ts) return 0;
+        return ap2_ntp_to_unix_ms(TS2NTP(p->head_ts, p->format.sample_rate));
+    }
+    return raop_session_next_head_unix_ms(p->raop_last_playtime,
+                                          p->raop_last_chunk_frames,
+                                          (uint32_t)p->format.sample_rate);
 }
 
 /* Silence frames the audio loop still owes the wire before the next real

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -507,6 +507,11 @@ int ap2cl_warm_lead_ms(struct ap2cl_s *p);
  * every member's queued audio. 0 = no constraint (not on the splice path). */
 uint64_t ap2cl_splice_head_unix_ms(struct ap2cl_s *p);
 
+/* Audible instant (unix ms) of the next frame the audio loop will send, on
+ * every flow (announcement mapping). 0 = head unknown: no timeline anchored
+ * yet, or no chunk sent since the last re-anchor. */
+uint64_t ap2cl_head_audible_unix_ms(struct ap2cl_s *p);
+
 /* Silence frames still owed to the wire before the next real sample (splice
  * timeline): the audio loop prepends them as ordinary encoded chunks so the
  * bitstream stays contiguous, and consumes the pad as it sends. */

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -41,6 +41,7 @@
 #include "ap2_hap.h"
 #include "raop_session.h"
 #include "artwork.h"
+#include "announce.h"
 
 #define VERSION "0.4.0"
 /* Overridden at build time from the git tag for tagged releases (see Makefile). */
@@ -414,6 +415,7 @@ static void clock_verify_tick(void)
 #define ERROR_CODE_PLAY_FAILED    "play_failed"
 #define ERROR_CODE_PAUSE_FAILED   "pause_failed"
 #define ERROR_CODE_STOP_FAILED    "stop_failed"
+#define ERROR_CODE_ANNOUNCE_FAILED "announce_failed"
 
 /*
  * Report a failure as one machine-readable line followed by the
@@ -449,6 +451,54 @@ static void status_error_ex(const char *code, int http, const char *detail,
 static bool session_is_live(void)
 {
     return ap2_session_state(g_session) != AP2_SESSION_ENDED;
+}
+
+/* ---- Announcement mixing (ACTION=ANNOUNCE) ---- */
+
+/* All announce state is owned by g_audio_send_lock: armed on the cmdpipe
+ * thread, mixed at the audio loops' send points, cancelled by whichever side
+ * invalidates the timeline the clip was mapped onto (see announce_abort call
+ * sites). The staged command values follow the START_UNIX_MS pattern. */
+static announce_t g_announce;
+#define ANNOUNCE_DEFAULT_DUCK_DB (-12.0)
+static char *g_pend_announce_file = NULL;
+static uint64_t g_pend_announce_at_ms = 0;
+static double g_pend_announce_duck_db = ANNOUNCE_DEFAULT_DUCK_DB;
+
+/* Cancel an active clip and report it. Caller holds g_audio_send_lock. */
+static void announce_abort(void)
+{
+    if (announce_cancel(&g_announce))
+        status_print("[STATUS] announce_done cancelled=1");
+}
+
+/* Mix an active clip into the finalized PCM chunk about to be sent and report
+ * the lifecycle lines. head_unix_ms is the audible instant of the chunk's
+ * first frame. Caller holds g_audio_send_lock. */
+static void announce_service(uint8_t *buf, int frames, uint64_t head_unix_ms)
+{
+    if (!announce_active(&g_announce)) return;
+    announce_mix_result_t r;
+    announce_mix_chunk(&g_announce, buf, frames, head_unix_ms, &r);
+    if (r.started)
+        status_print("[STATUS] announce_started at_unix_ms=%" PRIu64
+                     " duration_ms=%" PRIu64, r.at_unix_ms, r.duration_ms);
+    if (r.done)
+        status_print("[STATUS] announce_done");
+}
+
+/* Delivery-head projection for the legacy RAOP path: the last sent chunk's
+ * playtime and frame count give the next chunk's audible instant (see
+ * raop_session_next_head_unix_ms). Owned by g_audio_send_lock. */
+static uint64_t g_raop_last_playtime = 0;
+static uint32_t g_raop_last_chunk_frames = 0;
+
+/* The RAOP timeline re-anchored (start/flush/pause/resume/stop): the head is
+ * unknown until the next chunk is sent. Caller holds g_audio_send_lock. */
+static void raop_head_reset(void)
+{
+    g_raop_last_playtime = 0;
+    g_raop_last_chunk_frames = 0;
 }
 
 static void remote_command_event(
@@ -656,6 +706,47 @@ static void send_track_metadata(const cli_config_t *cfg, const char *title)
     free(artwork_file);
 }
 
+/* ACTION=ANNOUNCE: arm the staged clip for mixing at the commanded instant.
+ * Arming needs an anchored, playing timeline to map the clip onto; a clip
+ * already active is replaced, with its cancellation reported first (the
+ * recovery path for a stale clip after a caller restart). */
+static void handle_announce(const cli_config_t *cfg)
+{
+    char *path = g_pend_announce_file;
+    uint64_t at_ms = g_pend_announce_at_ms;
+    double duck_db = g_pend_announce_duck_db;
+    g_pend_announce_file = NULL;
+    g_pend_announce_at_ms = 0;
+    g_pend_announce_duck_db = ANNOUNCE_DEFAULT_DUCK_DB;
+
+    bool have_client = cfg->protocol == PROTO_RAOP ? g_raopcl != NULL
+                                                   : g_ap2cl != NULL;
+    char detail[192];
+    bool armed = false;
+    const char *reject = NULL;
+    pthread_mutex_lock(&g_audio_send_lock);
+    if (!session_is_live() || !have_client) {
+        reject = "no live session to announce into";
+    } else if (!g_first_start_done || g_status != STATUS_PLAYING) {
+        reject = "session is not playing";
+    } else if (!path || !*path) {
+        reject = "no announcement file staged";
+    } else {
+        announce_abort();
+        armed = announce_arm(&g_announce, path, at_ms, duck_db,
+                             detail, sizeof(detail));
+        if (!armed) reject = detail;
+    }
+    pthread_mutex_unlock(&g_audio_send_lock);
+    if (!armed)
+        status_error_ex(ERROR_CODE_ANNOUNCE_FAILED, 0, reject,
+                        "ANNOUNCE failed");
+    else
+        LOG_INFO("Announcement armed: %s at_unix_ms=%" PRIu64 " duck_db=%.1f",
+                 path, at_ms, duck_db);
+    free(path);
+}
+
 static void handle_command(const char *key, const char *value, cli_config_t *cfg)
 {
     if (strcmp(key, "TITLE") == 0) {
@@ -723,6 +814,14 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         g_pend_start_unix_ms = strtoull(value, NULL, 10);
     } else if (strcmp(key, "START_JOIN") == 0) {
         g_pend_start_join = atoi(value) != 0;
+    } else if (strcmp(key, "ANNOUNCE_FILE") == 0) {
+        metadata_set(&g_pend_announce_file, value);
+    } else if (strcmp(key, "ANNOUNCE_AT_UNIX_MS") == 0) {
+        g_pend_announce_at_ms = strtoull(value, NULL, 10);
+    } else if (strcmp(key, "ANNOUNCE_DUCK_DB") == 0) {
+        g_pend_announce_duck_db = atof(value);
+    } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "ANNOUNCE") == 0) {
+        handle_announce(cfg);
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "START") == 0) {
         /* The verified start contract: the ack always reports the true
          * scheduled instant, so the caller compares it with the request,
@@ -770,7 +869,10 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         if (g_status == STATUS_PLAYING) {
             pthread_mutex_lock(&g_audio_send_lock);
             if (g_status == STATUS_PLAYING) {
+                /* A pause freezes the content the clip rode on. */
+                announce_abort();
                 if (cfg->protocol == PROTO_RAOP && g_raopcl) {
+                    raop_head_reset();
                     if (!raop_session_pause(g_raopcl))
                         status_error_ex(ERROR_CODE_PAUSE_FAILED, 0,
                                         "the RAOP transport rejected the pause",
@@ -787,6 +889,7 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         pthread_mutex_lock(&g_audio_send_lock);
         bool play_ok = true;
         if (cfg->protocol == PROTO_RAOP && g_raopcl) {
+            raop_head_reset();
             if (!raop_session_resume(g_raopcl)) {
                 status_error_ex(ERROR_CODE_PLAY_FAILED, 0,
                                 "the RAOP transport rejected the resume",
@@ -811,8 +914,10 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
         pthread_mutex_unlock(&g_audio_send_lock);
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "STOP") == 0) {
         pthread_mutex_lock(&g_audio_send_lock);
+        announce_abort();
         g_status = STATUS_STOPPED;
         if (cfg->protocol == PROTO_RAOP && g_raopcl) {
+            raop_head_reset();
             raopcl_stop(g_raopcl);
         } else if (cfg->protocol == PROTO_AIRPLAY2 && g_ap2cl) {
             ap2cl_stop(g_ap2cl);
@@ -849,6 +954,8 @@ static ap2_commit_result_t session_commit(void *transport,
 {
     cli_config_t *cfg = transport;
     ap2_commit_result_t committed;
+    /* A START re-anchors the timeline an active clip was mapped onto. */
+    announce_abort();
     /* One ack per START: a previous join's withheld ack is answered with the
      * instant that stood, before this commit replaces the timeline it
      * described. */
@@ -864,6 +971,7 @@ static ap2_commit_result_t session_commit(void *transport,
     if (cfg->protocol == PROTO_RAOP) {
         struct raopcl_s *client = g_raopcl;
         if (!client) return AP2_COMMIT_FAILED;
+        raop_head_reset();
         committed = !g_first_start_done
             ? raop_session_commit(client, start_unix_ms, at_unix_ms)
             : raop_session_start_at(client, start_unix_ms, at_unix_ms);
@@ -900,7 +1008,10 @@ static bool session_flush_op(void *transport)
 {
     cli_config_t *cfg = transport;
     bool flushed = false;
+    /* The flush discards the timeline an active clip was mapped onto. */
+    announce_abort();
     if (cfg->protocol == PROTO_RAOP) {
+        raop_head_reset();
         flushed = g_raopcl && raop_session_flush(g_raopcl);
     } else if (g_ap2cl) {
         flushed = ap2cl_flush(g_ap2cl);
@@ -916,7 +1027,10 @@ static bool session_flush_op(void *transport)
 static void session_stop_op(void *transport)
 {
     cli_config_t *cfg = transport;
+    /* A standby park stops the content an active clip rode on. */
+    announce_abort();
     if (cfg->protocol == PROTO_RAOP) {
+        raop_head_reset();
         if (g_raopcl && !raop_session_standby(g_raopcl))
             status_error_ex(ERROR_CODE_STANDBY_FAILED, 0,
                             "the RAOP transport rejected the standby",
@@ -1060,6 +1174,10 @@ static bool start_command_thread(cli_config_t *cfg)
 static bool start_stream_session(cli_config_t *cfg, int input_bpf,
                                  int frames_per_chunk)
 {
+    /* Before the command thread exists: ACTION=ANNOUNCE arms into this. */
+    announce_init(&g_announce, (unsigned)cfg->sample_rate,
+                  (unsigned)cfg->channels,
+                  (unsigned)(input_bpf / cfg->channels));
     ap2_session_ops_t ops = {
         .quiesce = session_quiesce,
         .flush = session_flush_op,
@@ -1252,6 +1370,11 @@ static int run_raop(cli_config_t *cfg)
         }
 
         if (input_ended) {
+            /* The legacy path has no silence keepalive to carry a clip past
+             * the input, so an armed announcement ends here. */
+            pthread_mutex_lock(&g_audio_send_lock);
+            announce_abort();
+            pthread_mutex_unlock(&g_audio_send_lock);
             bool drained = !raopcl_is_playing(g_raopcl) ||
                            now - eof_time > MS2NTP(
                                TS2MS(raopcl_latency(g_raopcl),
@@ -1302,6 +1425,11 @@ static int run_raop(cli_config_t *cfg)
                 buf, n, DEFAULT_FRAMES_PER_CHUNK * input_bpf, input_bpf);
 
             int audio_frames = n / input_bpf;
+            announce_service(buf, audio_frames,
+                             raop_session_next_head_unix_ms(
+                                 g_raop_last_playtime,
+                                 g_raop_last_chunk_frames,
+                                 (uint32_t)cfg->sample_rate));
             uint8_t *send_buf = buf;
             /* For 24-bit: truncate s32le input to s24le (packed 3 bytes) for ALAC encoder */
             if (alac_buf && cfg->bit_depth > 16) {
@@ -1316,6 +1444,8 @@ static int run_raop(cli_config_t *cfg)
                 pthread_mutex_unlock(&g_audio_send_lock);
                 break;
             }
+            g_raop_last_playtime = playtime;
+            g_raop_last_chunk_frames = (uint32_t)audio_frames;
             frames += audio_frames;
             pthread_mutex_unlock(&g_audio_send_lock);
         } else {
@@ -1323,6 +1453,10 @@ static int run_raop(cli_config_t *cfg)
         }
     }
 
+    /* Teardown ends an armed clip with its cancellation reported. */
+    pthread_mutex_lock(&g_audio_send_lock);
+    announce_abort();
+    pthread_mutex_unlock(&g_audio_send_lock);
     request_command_stop();
     bool command_joined = join_command_thread();
     ap2_session_destroy(g_session);
@@ -1342,6 +1476,11 @@ static bool ap2_send_silence_chunk(const cli_config_t *cfg, uint8_t *buf,
                                    uint8_t *alac_buf, int input_bpf)
 {
     memset(buf, 0, (size_t)AP2_FRAMES_PER_CHUNK * input_bpf);
+    /* The input_ended drain keeps an active clip playing over the silence
+     * bed; the paused/standby call site can never carry one (those actions
+     * cancel it). */
+    announce_service(buf, AP2_FRAMES_PER_CHUNK,
+                     ap2cl_head_audible_unix_ms(g_ap2cl));
     uint8_t *send = buf;
     if (alac_buf && cfg->bit_depth > 16) {
         truncate_32to24(buf, AP2_FRAMES_PER_CHUNK * input_bpf, alac_buf);
@@ -1572,6 +1711,11 @@ static int run_airplay2(cli_config_t *cfg)
                 pthread_mutex_unlock(&g_audio_send_lock);
                 usleep(1000);
             } else {
+                /* No silence keepalive on this path to carry a clip past the
+                 * input, so an armed announcement ends here. */
+                pthread_mutex_lock(&g_audio_send_lock);
+                announce_abort();
+                pthread_mutex_unlock(&g_audio_send_lock);
                 usleep(drained ? 50000 : 10000);
             }
             continue;
@@ -1704,6 +1848,9 @@ static int run_airplay2(cli_config_t *cfg)
                 ap2_input_bpf);
 
             int af = n / ap2_input_bpf;
+            /* Any splice pad silence at the head of the chunk is mixed over
+             * uniformly — the desired silence bed during starvation. */
+            announce_service(buf, af, ap2cl_head_audible_unix_ms(g_ap2cl));
             uint8_t *send = buf;
             if (ap2_alac_buf && cfg->bit_depth > 16) {
                 truncate_32to24(buf, n, ap2_alac_buf);
@@ -1757,7 +1904,11 @@ static int run_airplay2(cli_config_t *cfg)
 
     /* The loop ends on teardown, and a join whose verification never resolved
      * is still owed its one ack. A cut caught mid-drain is settled short by
-     * the teardown, so it reports what it managed to take. */
+     * the teardown, so it reports what it managed to take. An armed clip ends
+     * with its cancellation reported. */
+    pthread_mutex_lock(&g_audio_send_lock);
+    announce_abort();
+    pthread_mutex_unlock(&g_audio_send_lock);
     start_ack_flush();
     content_cut_report(ap2_input_byte_rate);
     request_command_stop();
@@ -2220,6 +2371,8 @@ int main(int argc, char *argv[])
     free(g_metadata.artist);
     free(g_metadata.album);
     g_metadata.title = g_metadata.artist = g_metadata.album = NULL;
+    free(g_pend_announce_file);
+    g_pend_announce_file = NULL;
     netsock_close();
     cross_ssl_free();
 

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include <fcntl.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
@@ -819,7 +820,13 @@ static void handle_command(const char *key, const char *value, cli_config_t *cfg
     } else if (strcmp(key, "ANNOUNCE_AT_UNIX_MS") == 0) {
         g_pend_announce_at_ms = strtoull(value, NULL, 10);
     } else if (strcmp(key, "ANNOUNCE_DUCK_DB") == 0) {
-        g_pend_announce_duck_db = atof(value);
+        /* A NaN would sail through every gain comparison into the Q15 math;
+         * an unparseable or non-finite value falls back to the default duck. */
+        char *end = NULL;
+        double duck_db = strtod(value, &end);
+        g_pend_announce_duck_db = (end != value && isfinite(duck_db))
+                                      ? duck_db
+                                      : ANNOUNCE_DEFAULT_DUCK_DB;
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "ANNOUNCE") == 0) {
         handle_announce(cfg);
     } else if (strcmp(key, "ACTION") == 0 && strcmp(value, "START") == 0) {

--- a/src/raop_session.c
+++ b/src/raop_session.c
@@ -126,3 +126,11 @@ bool raop_session_resume(struct raopcl_s *client)
         TS2NTP(raopcl_latency(client), raopcl_sample_rate(client));
     return raopcl_start_at(client, audible_ntp - latency_ntp);
 }
+
+uint64_t raop_session_next_head_unix_ms(uint64_t playtime_ntp,
+                                        uint32_t chunk_frames,
+                                        uint32_t sample_rate)
+{
+    if (!playtime_ntp) return 0;
+    return ntp_to_unix_ms(playtime_ntp + TS2NTP(chunk_frames, sample_rate));
+}

--- a/src/raop_session.h
+++ b/src/raop_session.h
@@ -44,4 +44,13 @@ bool raop_session_pause(struct raopcl_s *client);
 /* Resume a paused stream without discarding libraop's retained backlog. */
 bool raop_session_resume(struct raopcl_s *client);
 
+/* Audible instant (unix ms) of the chunk that follows one sent with
+ * raopcl_send_chunk, from that send's playtime and frame count. RAOP
+ * timestamps are contiguous between re-anchors, so the projection tracks the
+ * delivery head exactly. 0 while playtime_ntp is 0 (no chunk sent since the
+ * last re-anchor: head unknown). */
+uint64_t raop_session_next_head_unix_ms(uint64_t playtime_ntp,
+                                        uint32_t chunk_frames,
+                                        uint32_t sample_rate);
+
 #endif /* RAOP_SESSION_H */

--- a/tests/test_announce.c
+++ b/tests/test_announce.c
@@ -274,6 +274,16 @@ static void test_at_clamp(void)
     assert(!r.started);
     for (int i = 0; i < 10 * 2; i++) assert(buf[i] == 100);
     announce_cancel(&a);
+
+    /* an instant so far out the frame math would wrap keeps the clip
+     * waiting instead of starting it on a wrapped offset */
+    write_clip_s16(500, 5, 2);
+    assert(announce_arm(&a, clip_path, UINT64_MAX - 1, 0.0, err, sizeof(err)));
+    fill_s16(buf, 10, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 1000000, &r);
+    assert(!r.started);
+    for (int i = 0; i < 10 * 2; i++) assert(buf[i] == 100);
+    announce_cancel(&a);
 }
 
 /* started and done can land in one call when clip + tail fit one chunk. */

--- a/tests/test_announce.c
+++ b/tests/test_announce.c
@@ -375,6 +375,13 @@ static void test_file_validation(void)
                          err, sizeof(err)));
     assert(!announce_active(&a));
 
+    /* only s16le and the s32le carrier are mixable sample sizes */
+    announce_t bad;
+    announce_init(&bad, 1000, 2, 3);
+    write_clip("abcdef", 6);
+    assert(!announce_arm(&bad, clip_path, 0, 0.0, err, sizeof(err)));
+    assert(!announce_active(&bad));
+
     write_clip("", 0);
     assert(!announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
 

--- a/tests/test_announce.c
+++ b/tests/test_announce.c
@@ -52,6 +52,12 @@ static void fill_s32(int32_t *buf, int frames, int channels, int32_t v)
     for (int i = 0; i < frames * channels; i++) buf[i] = v;
 }
 
+static void test_gain_nan(void)
+{
+    /* a NaN duck must degrade to "no duck", never reach the pow/lround */
+    assert(announce_gain_q15_from_db((double)NAN) == 32768);
+}
+
 static void test_gain_from_db(void)
 {
     assert(announce_gain_q15_from_db(0.0) == Q15);
@@ -393,6 +399,7 @@ int main(void)
              tmp && *tmp ? tmp : "/tmp", (int)getpid());
 
     test_gain_from_db();
+    test_gain_nan();
     test_envelope_shape();
     test_s16_mix_and_mapping();
     test_s16_saturation();

--- a/tests/test_announce.c
+++ b/tests/test_announce.c
@@ -1,0 +1,400 @@
+#include <assert.h>
+#include <limits.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "announce.h"
+
+#define Q15 32768
+
+static char clip_path[512];
+
+static void write_clip(const void *data, size_t len)
+{
+    FILE *f = fopen(clip_path, "wb");
+    assert(f);
+    if (len) assert(fwrite(data, 1, len, f) == len);
+    assert(fclose(f) == 0);
+}
+
+/* One constant-valued s16 stereo clip of `frames` frames. */
+static void write_clip_s16(int16_t value, int frames, int channels)
+{
+    int samples = frames * channels;
+    int16_t *data = malloc((size_t)samples * sizeof(*data));
+    assert(data);
+    for (int i = 0; i < samples; i++) data[i] = value;
+    write_clip(data, (size_t)samples * sizeof(*data));
+    free(data);
+}
+
+static void write_clip_s32(int32_t value, int frames, int channels)
+{
+    int samples = frames * channels;
+    int32_t *data = malloc((size_t)samples * sizeof(*data));
+    assert(data);
+    for (int i = 0; i < samples; i++) data[i] = value;
+    write_clip(data, (size_t)samples * sizeof(*data));
+    free(data);
+}
+
+static void fill_s16(int16_t *buf, int frames, int channels, int16_t v)
+{
+    for (int i = 0; i < frames * channels; i++) buf[i] = v;
+}
+
+static void fill_s32(int32_t *buf, int frames, int channels, int32_t v)
+{
+    for (int i = 0; i < frames * channels; i++) buf[i] = v;
+}
+
+static void test_gain_from_db(void)
+{
+    assert(announce_gain_q15_from_db(0.0) == Q15);
+    assert(announce_gain_q15_from_db(3.0) == Q15);   /* clamped to unity */
+    assert(announce_gain_q15_from_db(-12.0) ==
+           (int32_t)lround(pow(10.0, -12.0 / 20.0) * Q15));
+    assert(announce_gain_q15_from_db(-60.0) == 0);   /* full mute */
+    assert(announce_gain_q15_from_db(-80.0) == 0);
+    /* monotonic in between */
+    assert(announce_gain_q15_from_db(-6.0) > announce_gain_q15_from_db(-12.0));
+}
+
+static void test_envelope_shape(void)
+{
+    announce_t a;
+    memset(&a, 0, sizeof(a));
+    a.ramp_frames = 100;
+    a.clip_frames = 500;
+    a.duck_q15 = 8192;
+
+    /* down ramp: unity at the clip's first sample, linear to the duck */
+    assert(announce_music_gain_q15(&a, 0) == Q15);
+    assert(announce_music_gain_q15(&a, 50) == 20480);
+    /* hold */
+    assert(announce_music_gain_q15(&a, 100) == 8192);
+    assert(announce_music_gain_q15(&a, 499) == 8192);
+    /* tail ramp: duck at the clip end, linear back to unity */
+    assert(announce_music_gain_q15(&a, 500) == 8192);
+    assert(announce_music_gain_q15(&a, 550) == 20480);
+    assert(announce_music_gain_q15(&a, 600) == Q15);
+    assert(announce_music_gain_q15(&a, 10000) == Q15);
+
+    /* a clip shorter than the ramp never reaches the duck; its tail ramps
+     * back from the gain the down ramp actually got to */
+    a.clip_frames = 40;
+    assert(announce_music_gain_q15(&a, 20) == 32768 - 4915);
+    int32_t at_end = 32768 - 9830;
+    assert(announce_music_gain_q15(&a, 40) == at_end);
+    assert(announce_music_gain_q15(&a, 90) == at_end + (Q15 - at_end) * 50 / 100);
+    assert(announce_music_gain_q15(&a, 140) == Q15);
+}
+
+/* s16, unity duck: clip added sample-for-sample, offset mapping, chunk
+ * crossing, tail, done. rate 1000 makes 1 frame == 1 ms. */
+static void test_s16_mix_and_mapping(void)
+{
+    announce_t a;
+    announce_init(&a, 1000, 2, 2);
+    write_clip_s16(1000, 100, 2);
+
+    char err[128];
+    assert(announce_arm(&a, clip_path, 1000020, 0.0, err, sizeof(err)));
+    assert(announce_active(&a));
+
+    int16_t buf[50 * 2];
+    announce_mix_result_t r;
+
+    /* commanded instant beyond this chunk: untouched, not started */
+    fill_s16(buf, 50, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 50, 999900, &r);
+    assert(!r.started && !r.done);
+    for (int i = 0; i < 50 * 2; i++) assert(buf[i] == 100);
+
+    /* chunk covering the instant: mixing begins at the exact frame offset */
+    fill_s16(buf, 50, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 50, 1000000, &r);
+    assert(r.started);
+    assert(r.at_unix_ms == 1000020);
+    assert(r.duration_ms == 100);
+    assert(!r.done);
+    for (int i = 0; i < 20 * 2; i++) assert(buf[i] == 100);
+    for (int i = 20 * 2; i < 50 * 2; i++) assert(buf[i] == 1100);
+
+    /* clip continues across the chunk boundary */
+    fill_s16(buf, 50, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 50, 1000050, &r);
+    assert(!r.started && !r.done);
+    for (int i = 0; i < 50 * 2; i++) assert(buf[i] == 1100);
+
+    /* clip EOF mid-chunk: the tail (unity duck) leaves the music untouched */
+    fill_s16(buf, 50, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 50, 1000100, &r);
+    assert(!r.done);
+    for (int i = 0; i < 20 * 2; i++) assert(buf[i] == 1100);
+    for (int i = 20 * 2; i < 50 * 2; i++) assert(buf[i] == 100);
+
+    /* drain the 200-frame tail; done fires when its last frame is mixed */
+    int done_calls = 0;
+    for (uint64_t head = 1000150; head <= 1000300; head += 50) {
+        fill_s16(buf, 50, 2, 100);
+        announce_mix_chunk(&a, (uint8_t *)buf, 50, head, &r);
+        assert(!r.started);
+        if (r.done) done_calls++;
+    }
+    assert(done_calls == 1);
+    assert(!announce_active(&a));
+
+    /* mixing after done is a no-op */
+    fill_s16(buf, 50, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 50, 1000350, &r);
+    assert(!r.started && !r.done);
+    for (int i = 0; i < 50 * 2; i++) assert(buf[i] == 100);
+}
+
+static void test_s16_saturation(void)
+{
+    announce_t a;
+    announce_init(&a, 1000, 2, 2);
+    write_clip_s16(32000, 10, 2);
+
+    char err[128];
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+
+    int16_t buf[10 * 2];
+    announce_mix_result_t r;
+    fill_s16(buf, 10, 2, 32000);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 500, &r);
+    assert(r.started && r.at_unix_ms == 500);
+    for (int i = 0; i < 10 * 2; i++) assert(buf[i] == INT16_MAX);
+    announce_cancel(&a);
+
+    write_clip_s16(-32000, 10, 2);
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+    fill_s16(buf, 10, 2, -32000);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 500, &r);
+    for (int i = 0; i < 10 * 2; i++) assert(buf[i] == INT16_MIN);
+    announce_cancel(&a);
+}
+
+/* Duck applied to the music: mute duck zeroes it in the hold, halves it at
+ * the ramp midpoint, leaves it whole at the clip's first sample. */
+static void test_s16_duck_envelope(void)
+{
+    announce_t a;
+    announce_init(&a, 1000, 2, 2);
+    write_clip_s16(1234, 500, 2);
+
+    char err[128];
+    assert(announce_arm(&a, clip_path, 0, -60.0, err, sizeof(err)));
+    assert(a.ramp_frames == 200);
+
+    int16_t buf[500 * 2];
+    announce_mix_result_t r;
+    fill_s16(buf, 500, 2, 999);
+    announce_mix_chunk(&a, (uint8_t *)buf, 500, 1000, &r);
+    assert(r.started);
+    /* frame 0: unity gain */
+    assert(buf[0] == 999 + 1234);
+    /* frame 100: mid-ramp, gain 16384 -> music 999*16384>>15 = 499 */
+    assert(buf[100 * 2] == 499 + 1234);
+    /* frames 200..499: hold, music fully muted */
+    assert(buf[200 * 2] == 1234);
+    assert(buf[499 * 2] == 1234);
+}
+
+static void test_s32_mix_and_saturation(void)
+{
+    announce_t a;
+    announce_init(&a, 1000, 2, 4);
+    write_clip_s32(100000, 10, 2);
+
+    char err[128];
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+
+    int32_t buf[10 * 2];
+    announce_mix_result_t r;
+    fill_s32(buf, 10, 2, 200000);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 500, &r);
+    assert(r.started);
+    for (int i = 0; i < 10 * 2; i++) assert(buf[i] == 300000);
+    announce_cancel(&a);
+
+    /* positive rail */
+    write_clip_s32(100000, 10, 2);
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+    fill_s32(buf, 10, 2, INT32_MAX - 10);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 500, &r);
+    for (int i = 0; i < 10 * 2; i++) assert(buf[i] == INT32_MAX);
+    announce_cancel(&a);
+
+    /* negative rail */
+    write_clip_s32(-100000, 10, 2);
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+    fill_s32(buf, 10, 2, INT32_MIN + 10);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 500, &r);
+    for (int i = 0; i < 10 * 2; i++) assert(buf[i] == INT32_MIN);
+    announce_cancel(&a);
+}
+
+/* An instant already behind the head (or 0) starts at the chunk's first
+ * frame, and the reported instant is the corrected truth. */
+static void test_at_clamp(void)
+{
+    announce_t a;
+    announce_init(&a, 1000, 2, 2);
+    char err[128];
+    int16_t buf[10 * 2];
+    announce_mix_result_t r;
+
+    write_clip_s16(500, 5, 2);
+    assert(announce_arm(&a, clip_path, 900000, 0.0, err, sizeof(err)));
+    fill_s16(buf, 10, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 1000000, &r);
+    assert(r.started && r.at_unix_ms == 1000000);
+    assert(buf[0] == 600);
+    announce_cancel(&a);
+
+    write_clip_s16(500, 5, 2);
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+    fill_s16(buf, 10, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 1000000, &r);
+    assert(r.started && r.at_unix_ms == 1000000);
+    announce_cancel(&a);
+
+    /* an unknown head (0) leaves the chunk untouched and the clip waiting */
+    write_clip_s16(500, 5, 2);
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+    fill_s16(buf, 10, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 0, &r);
+    assert(!r.started);
+    for (int i = 0; i < 10 * 2; i++) assert(buf[i] == 100);
+    announce_cancel(&a);
+}
+
+/* started and done can land in one call when clip + tail fit one chunk. */
+static void test_tiny_clip_single_chunk(void)
+{
+    announce_t a;
+    announce_init(&a, 1000, 2, 2);
+    write_clip_s16(500, 2, 2);
+
+    char err[128];
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+    int16_t buf[300 * 2];
+    announce_mix_result_t r;
+    fill_s16(buf, 300, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 300, 1000, &r);
+    assert(r.started && r.done);
+    assert(r.duration_ms == 2);
+    assert(!announce_active(&a));
+    assert(buf[0] == 600 && buf[1 * 2] == 600 && buf[2 * 2] == 100);
+}
+
+/* A chunk larger than the staging buffer is consumed in slices. */
+static void test_staging_boundary(void)
+{
+    announce_t a;
+    announce_init(&a, 1000, 2, 2);   /* 4 B/frame; staging holds 1024 frames */
+    write_clip_s16(7, 3000, 2);
+
+    char err[128];
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+    int16_t *buf = malloc(2000 * 2 * sizeof(*buf));
+    assert(buf);
+    announce_mix_result_t r;
+
+    fill_s16(buf, 2000, 2, 5);
+    announce_mix_chunk(&a, (uint8_t *)buf, 2000, 1000, &r);
+    assert(r.started && !r.done);
+    for (int i = 0; i < 2000 * 2; i++) assert(buf[i] == 12);
+
+    fill_s16(buf, 2000, 2, 5);
+    announce_mix_chunk(&a, (uint8_t *)buf, 2000, 3000, &r);
+    assert(r.done);
+    for (int i = 0; i < 1000 * 2; i++) assert(buf[i] == 12);
+    for (int i = 1000 * 2; i < 2000 * 2; i++) assert(buf[i] == 5);
+    free(buf);
+}
+
+static void test_replace_and_cancel(void)
+{
+    announce_t a;
+    announce_init(&a, 1000, 2, 2);
+    write_clip_s16(500, 100, 2);
+
+    char err[128];
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+    int16_t buf[10 * 2];
+    announce_mix_result_t r;
+    fill_s16(buf, 10, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 1000, &r);
+    assert(r.started && announce_active(&a));
+
+    /* cancel reports exactly once */
+    assert(announce_cancel(&a));
+    assert(!announce_active(&a));
+    assert(!announce_cancel(&a));
+
+    /* re-arm after cancel plays the new clip from byte 0 */
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+    fill_s16(buf, 10, 2, 100);
+    announce_mix_chunk(&a, (uint8_t *)buf, 10, 2000, &r);
+    assert(r.started);
+    assert(buf[0] == 600);
+    assert(announce_cancel(&a));
+}
+
+static void test_file_validation(void)
+{
+    announce_t a;
+    announce_init(&a, 1000, 2, 2);
+    char err[128];
+
+    assert(!announce_arm(&a, "/nonexistent/announce-clip.pcm", 0, 0.0,
+                         err, sizeof(err)));
+    assert(!announce_active(&a));
+
+    write_clip("", 0);
+    assert(!announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+
+    /* less than one frame is empty after alignment */
+    write_clip("abc", 3);
+    assert(!announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+
+    /* a trailing partial frame is dropped */
+    uint8_t ten[10] = {0};
+    write_clip(ten, sizeof(ten));
+    assert(announce_arm(&a, clip_path, 0, 0.0, err, sizeof(err)));
+    assert(a.clip_bytes == 8);
+    assert(a.clip_frames == 2);
+    assert(a.duration_ms == 2);
+    assert(announce_cancel(&a));
+}
+
+int main(void)
+{
+    const char *tmp = getenv("TMPDIR");
+    snprintf(clip_path, sizeof(clip_path), "%s/test_announce_clip_%d.pcm",
+             tmp && *tmp ? tmp : "/tmp", (int)getpid());
+
+    test_gain_from_db();
+    test_envelope_shape();
+    test_s16_mix_and_mapping();
+    test_s16_saturation();
+    test_s16_duck_envelope();
+    test_s32_mix_and_saturation();
+    test_at_clamp();
+    test_tiny_clip_single_chunk();
+    test_staging_boundary();
+    test_replace_and_cancel();
+    test_file_validation();
+
+    remove(clip_path);
+    puts("announce mixing tests passed");
+    return 0;
+}

--- a/tests/test_raop_session.c
+++ b/tests/test_raop_session.c
@@ -184,6 +184,17 @@ int main(void)
     assert(raop_session_start_at(&client, resume_ms, NULL) != AP2_COMMIT_OK);
     assert(start_calls == 0);
 
+    /* The delivery-head projection: a sent chunk's playtime plus its duration
+     * is the audible instant of the chunk that follows it. 352 frames is
+     * 7.98 ms at 44100 Hz and 7.33 ms at 48000 Hz, so a playtime on an exact
+     * second projects 7 whole ms forward at either rate. No playtime yet (0)
+     * means the head is unknown. */
+    assert(raop_session_next_head_unix_ms(0, 352, 44100) == 0);
+    assert(raop_session_next_head_unix_ms(unix_ms_to_ntp(now_ms), 352, 44100) ==
+           now_ms + 7);
+    assert(raop_session_next_head_unix_ms(unix_ms_to_ntp(now_ms), 352, 48000) ==
+           now_ms + 7);
+
     client.state = RAOP_DOWN;
     assert(raop_session_commit(&client, future_ms, NULL) != AP2_COMMIT_OK);
     assert(!raop_session_standby(&client));


### PR DESCRIPTION
Adds native announcement support: a short PCM clip (TTS/doorbell) is mixed over the music at the frame-pull point, with the music ducked underneath. The music keeps playing in place — no flush, no re-anchor, the group timeline is untouched — so an announcement no longer needs the interrupt-and-restore dance in Music Assistant.

Commanded over the existing cmdpipe:

```
ANNOUNCE_FILE=/tmp/<player>-announce.pcm    # raw PCM, exactly the stdin format
ANNOUNCE_AT_UNIX_MS=<T>                     # 0 = earliest feasible
ANNOUNCE_DUCK_DB=-12                        # <= -60 mutes the music
ACTION=ANNOUNCE
```

The commanded instant maps onto the audible timeline like a START does; all members of a group given the same instant render the clip sample-synced. `[STATUS] announce_started` reports the true audible instant, `[STATUS] announce_done` the completion (with `cancelled=1` when a flush/seek/pause ended it early).

- New `src/announce.c` module: clip file staging, Q15 duck envelope (200 ms ramps), saturating s16/s32 mixing, instant→frame mapping
- Mix hooks in the RAOP and AirPlay 2 send paths plus the splice silence keepalive (a clip survives end-of-input on the splice timeline)
- Delivery-head instant per flow: native sessions map `head_ts` directly; RAOP flows project it from the last sent chunk's playtime (no libraop changes)
- Cancellation on everything that invalidates the mapped timeline: FLUSH, START, PAUSE, STANDBY, STOP, teardown
- `announce_failed` error slug for a rejected arm, so the caller can fall back to its generic flow
- Covered by a new `test_announce` suite; DESIGN.md §6a documents the contract
