### PR TITLE
Let an explicit buffer depth outrank the assumed receiver window

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -478,7 +478,12 @@ therefore runs up to `window` ahead of the deadline — the device-reported
 window less a 250 ms margin when known, else 1.75 s (inside every AirPlay
 receiver's standard 2 s, the same assumption our own stream SETUP proposes as
 `latencyMax` 88200 frames) — which fills the receiver's buffer before a
-scheduled start no matter how far ahead T lies.
+scheduled start no matter how far ahead T lies. That 1.75 s is only a
+stand-in for a window the receiver never reported, so it bounds the compiled
+default but not an explicit `--latency`: a renderer that starves below its
+real buffer needs a depth the assumption cannot express (an Edifier MS50A
+stays silent until 2500 ms, matching the 2250 ms it declares as its RAOP
+latency). A reported window still clamps.
 
 **Per-process timeline offsets**: streams in one group share T, and with
 identical RTP positions two sessions from one host are wire-identical twins
@@ -1004,7 +1009,9 @@ callers:
   from one host; per-process RTP timeline offsets are required (§6).
 - **Receiver buffer windows are ~2 s** — the AirPlay standard our own stream
   SETUP proposes as `latencyMax` 88200 frames. The receiver's echo of the
-  window is optional (Sonos omits it), so pacing falls back to 1.75 s.
+  window is optional (Sonos omits it), so pacing falls back to 1.75 s — for
+  the compiled default only, since an explicit `--latency` outranks a window
+  that was never reported (§6).
 - **Pairing posture differs by vendor**: Sonos/JBL/WiiM accept transient
   pairing (no PIN); Apple TV/HomePod require stored credentials from a PIN
   pair-setup (transient returns 200 + an in-band TLV error and silence).

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2696,17 +2696,25 @@ static uint32_t ap2_splice_depth_ms(struct ap2cl_s *p)
     uint32_t depth = p->splice_depth_ms > 0 ? (uint32_t)p->splice_depth_ms
                                             : AP2_SPLICE_PACING_MS;
     /* Same cap as the pacing window - the receiver's reported buffer minus
-     * the delivery margin, or the assumed standard window when unreported -
-     * so every consumer (pacing, warm lead, verification windows, the
-     * connect log) sees one effective depth. */
-    uint32_t cap_ms = AP2_PACING_DEFAULT_BUFFER_MS - AP2_PACING_MARGIN_MS;
+     * the delivery margin - so every consumer (pacing, warm lead,
+     * verification windows, the connect log) sees one effective depth. A
+     * reported window is authoritative: the device named its limit and
+     * overflowing it drops frames. */
     if (p->format.sample_rate > 0) {
         uint64_t margin = MS2TS(AP2_PACING_MARGIN_MS, p->format.sample_rate);
-        if (p->dev_latency_max > margin)
-            cap_ms = (uint32_t)((p->dev_latency_max - margin) * 1000ULL /
-                                (uint32_t)p->format.sample_rate);
+        if (p->dev_latency_max > margin) {
+            uint32_t cap_ms = (uint32_t)((p->dev_latency_max - margin) * 1000ULL /
+                                         (uint32_t)p->format.sample_rate);
+            return depth < cap_ms ? depth : cap_ms;
+        }
     }
-    return depth < cap_ms ? depth : cap_ms;
+    /* Nothing reported: the standard window is only an assumption, so it caps
+     * the compiled default but not an explicit override - a caller naming a
+     * depth knows the device better than a stand-in value does. Receivers
+     * whose renderer starves below their real buffer need that headroom. */
+    if (p->splice_depth_ms > 0) return depth;
+    uint32_t assumed_ms = AP2_PACING_DEFAULT_BUFFER_MS - AP2_PACING_MARGIN_MS;
+    return depth < assumed_ms ? depth : assumed_ms;
 }
 
 void ap2cl_set_splice_depth_ms(struct ap2cl_s *p, int ms)
@@ -3378,11 +3386,11 @@ static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
     /* Frame counts, so every term is scaled to the stream rate: a receiver
      * reports latencyMax in frames at the rate it is being fed. */
     uint64_t margin = MS2TS(AP2_PACING_MARGIN_MS, p->format.sample_rate);
+    bool reported = p->dev_latency_max > margin;
     uint64_t window =
-        p->dev_latency_max > margin
-            ? p->dev_latency_max - margin
-            : MS2TS(AP2_PACING_DEFAULT_BUFFER_MS - AP2_PACING_MARGIN_MS,
-                    p->format.sample_rate);
+        reported ? p->dev_latency_max - margin
+                 : MS2TS(AP2_PACING_DEFAULT_BUFFER_MS - AP2_PACING_MARGIN_MS,
+                         p->format.sample_rate);
     /* The splice timeline keeps the receiver queue shallow: with warm
      * boundaries expressed as content splices on one immutable line, the
      * queue depth IS the audible latency of every seek/next. Apple receivers
@@ -3391,6 +3399,12 @@ static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
     if (p->splice_timeline) {
         uint64_t depth = (uint64_t)MS2TS(ap2_splice_depth_ms(p),
                                          p->format.sample_rate);
+        /* A reported window is authoritative and clamps the depth. Unreported,
+         * the standard buffer is only a stand-in, so an explicit override
+         * outranks it: a renderer that starves below its real buffer needs
+         * that headroom, and the caller naming a depth knows the device
+         * better than a default can. */
+        if (!reported && p->splice_depth_ms > 0) return depth;
         return depth < window ? depth : window;
     }
     return window;

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2698,8 +2698,10 @@ static uint32_t ap2_splice_depth_ms(struct ap2cl_s *p)
     /* Same cap as the pacing window - the receiver's reported buffer minus
      * the delivery margin - so every consumer (pacing, warm lead,
      * verification windows, the connect log) sees one effective depth. A
-     * reported window is authoritative: the device named its limit and
-     * overflowing it drops frames. */
+     * window wide enough to hold that margin back is authoritative: the
+     * device named its limit and overflowing it drops frames. A report at or
+     * under the margin leaves nothing to hold back and is treated as no
+     * report at all, same as the default path below. */
     if (p->format.sample_rate > 0) {
         uint64_t margin = MS2TS(AP2_PACING_MARGIN_MS, p->format.sample_rate);
         if (p->dev_latency_max > margin) {
@@ -3399,11 +3401,11 @@ static uint64_t ap2_pacing_window_frames(struct ap2cl_s *p)
     if (p->splice_timeline) {
         uint64_t depth = (uint64_t)MS2TS(ap2_splice_depth_ms(p),
                                          p->format.sample_rate);
-        /* A reported window is authoritative and clamps the depth. Unreported,
-         * the standard buffer is only a stand-in, so an explicit override
-         * outranks it: a renderer that starves below its real buffer needs
-         * that headroom, and the caller naming a depth knows the device
-         * better than a default can. */
+        /* A window wide enough to hold the margin back is authoritative and
+         * clamps the depth. Without one the standard buffer is only a
+         * stand-in, so an explicit override outranks it: a renderer that
+         * starves below its real buffer needs that headroom, and the caller
+         * naming a depth knows the device better than a default can. */
         if (!reported && p->splice_depth_ms > 0) return depth;
         return depth < window ? depth : window;
     }

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -1546,6 +1546,46 @@ static void test_pacing_window_rate_scaling(void)
     puts("ap2_client pacing window rate scaling tests passed");
 }
 
+/* An explicit depth override outranks the buffer the receiver never reported,
+ * but never the one it did: a starving renderer can be given the headroom it
+ * needs, while a device that named its limit still bounds the delivery. */
+static void test_splice_depth_override_vs_reported_buffer(void)
+{
+    ap2_device_info_t device = {
+        .name = "depth override test",
+        .address = "127.0.0.1",
+        .port = 7000,
+    };
+    ap2_audio_format_t format = {.sample_rate = 44100, .bit_depth = 16, .channels = 2};
+
+    struct ap2cl_s *client =
+        ap2cl_create(&device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_set_splice(client, true);
+
+    /* Nothing reported: 3000 ms clears the 1.75 s assumed window untouched. */
+    ap2cl_set_splice_depth_ms(client, 3000);
+    assert(ap2cl_test_pacing_window_frames(client) == 132300);
+
+    /* A reported 2.0 s buffer clamps the same override to that buffer less
+     * the 250 ms margin. */
+    ap2cl_test_set_dev_latency_max(client, 88200);
+    assert(ap2cl_test_pacing_window_frames(client) == 77175);
+
+    /* Without an override the assumed window still caps the compiled default. */
+    struct ap2cl_s *plain =
+        ap2cl_create(&device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(plain);
+    ap2cl_force_native(plain);
+    ap2cl_test_set_splice(plain, true);
+    assert(ap2cl_test_pacing_window_frames(plain) == 26460);
+
+    assert(ap2cl_destroy(plain));
+    assert(ap2cl_destroy(client));
+    puts("ap2_client splice depth override tests passed");
+}
+
 /* A start committed before the receiver's first timing probe arms the
  * post-commit verification; the poll then verifies, corrects forward, or
  * closes the window, exactly once per commit. */
@@ -1978,6 +2018,7 @@ int main(void)
     test_dead_channel_writes_farewell_teardown();
     test_apple_model_resolution();
     test_pacing_window_rate_scaling();
+    test_splice_depth_override_vs_reported_buffer();
     test_clock_verified_anchor();
     test_clock_readiness_report();
     test_clock_stall_detection();

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -1548,41 +1548,59 @@ static void test_pacing_window_rate_scaling(void)
 
 /* An explicit depth override outranks the buffer the receiver never reported,
  * but never the one it did: a starving renderer can be given the headroom it
- * needs, while a device that named its limit still bounds the delivery. */
+ * needs, while a device that named its limit still bounds the delivery. The
+ * depth drives ms-domain consumers (warm lead, clock-verification windows)
+ * as well as the frame-domain pacing window, so both are pinned. */
 static void test_splice_depth_override_vs_reported_buffer(void)
 {
+    static const struct {
+        int rate;
+        uint64_t override_unreported; /* a 3000 ms override, no window echoed */
+        uint32_t reported;            /* a 2.0 s receiver buffer, in frames */
+        uint64_t override_reported;   /* that buffer less the 250 ms margin */
+        uint32_t under_margin;        /* a buffer no deeper than the margin */
+    } cases[] = {
+        {44100, 132300, 88200, 77175, 4410},
+        {48000, 144000, 96000, 84000, 4800},
+    };
+
     ap2_device_info_t device = {
         .name = "depth override test",
         .address = "127.0.0.1",
         .port = 7000,
     };
-    ap2_audio_format_t format = {.sample_rate = 44100, .bit_depth = 16, .channels = 2};
 
-    struct ap2cl_s *client =
-        ap2cl_create(&device, &format, NULL, NULL, NULL, NULL, 2000, 100);
-    assert(client);
-    ap2cl_force_native(client);
-    ap2cl_test_set_splice(client, true);
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        ap2_audio_format_t format = {
+            .sample_rate = cases[i].rate,
+            .bit_depth = 16,
+            .channels = 2,
+        };
+        struct ap2cl_s *client =
+            ap2cl_create(&device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+        assert(client);
+        ap2cl_force_native(client);
+        ap2cl_test_set_splice(client, true);
 
-    /* Nothing reported: 3000 ms clears the 1.75 s assumed window untouched. */
-    ap2cl_set_splice_depth_ms(client, 3000);
-    assert(ap2cl_test_pacing_window_frames(client) == 132300);
+        /* Nothing reported: a 3000 ms override clears the 1.75 s assumed
+         * window untouched, in both the frame and the ms domain. */
+        ap2cl_set_splice_depth_ms(client, 3000);
+        assert(ap2cl_test_pacing_window_frames(client) == cases[i].override_unreported);
+        assert(ap2cl_warm_lead_ms(client) == 3000);
 
-    /* A reported 2.0 s buffer clamps the same override to that buffer less
-     * the 250 ms margin. */
-    ap2cl_test_set_dev_latency_max(client, 88200);
-    assert(ap2cl_test_pacing_window_frames(client) == 77175);
+        /* A reported 2.0 s buffer clamps the same override to that buffer
+         * less the 250 ms margin. */
+        ap2cl_test_set_dev_latency_max(client, cases[i].reported);
+        assert(ap2cl_test_pacing_window_frames(client) == cases[i].override_reported);
+        assert(ap2cl_warm_lead_ms(client) == 1750);
 
-    /* Without an override the assumed window still caps the compiled default. */
-    struct ap2cl_s *plain =
-        ap2cl_create(&device, &format, NULL, NULL, NULL, NULL, 2000, 100);
-    assert(plain);
-    ap2cl_force_native(plain);
-    ap2cl_test_set_splice(plain, true);
-    assert(ap2cl_test_pacing_window_frames(plain) == 26460);
+        /* A report at or under the margin leaves nothing to hold back, so it
+         * counts as no report and the override stands again. */
+        ap2cl_test_set_dev_latency_max(client, cases[i].under_margin);
+        assert(ap2cl_test_pacing_window_frames(client) == cases[i].override_unreported);
 
-    assert(ap2cl_destroy(plain));
-    assert(ap2cl_destroy(client));
+        assert(ap2cl_destroy(client));
+    }
     puts("ap2_client splice depth override tests passed");
 }
 


### PR DESCRIPTION
## Problem

An Edifier MS50A (LinkPlay `p20.Linkplay.` firmware) played nothing over native AirPlay 2 while the session looked perfectly healthy — PTP settled, RTP flowed at realtime rate, `[STATUS] playing` counted up, every SET_PARAMETER returned 200, and the receiver kept answering `/feedback streams=1` without ever requesting a retransmit.

The renderer was starving. It needs ~2.5 s of queued audio, but `--latency` could never ask for more than **1750 ms**: a receiver that reports no `latencyMax` falls back to the assumed 2 s standard buffer, and that assumption capped the depth. So the one knob that could have fixed the device was clamped below what it needs.

The 1750 ceiling was applied in two places — `ap2_splice_depth_ms()` and `ap2_pacing_window_frames()`, which computes its own window — so relaxing either alone changes nothing.

## Change

A device-**reported** window stays authoritative and still clamps: the device named its limit and overflowing it drops frames. When nothing is reported, the standard buffer is only a stand-in, so it caps the compiled default but no longer overrides an explicit `--latency` — a caller naming a depth knows the device better than a placeholder does.

## Verified on device

Edifier MS50A, native AP2 + PTP, one binary, depth varied:

| depth | 600 | 1000 | 1750 | 2000 | 2250 | 2500 | 3000 |
|---|---|---|---|---|---|---|---|
| result | silent | silent | silent | silent | silent | **plays** | **plays** |

`ahead=` on the wire tracks the requested depth (110219 frames at 2500 ms, 132287 at 3000 ms) instead of pinning at 77175 (1750 ms). Seek, track change and pause/resume all verified at 2500 ms.

The threshold is not arbitrary: the same device declares `player latency is 2250 ms` on RAOP, so it wants its full declared pipeline queued, and 2500 is that plus the delivery margin.

## Tests

`test_splice_depth_override_vs_reported_buffer` covers both directions — an override clearing the assumed window when nothing is reported, and a reported window still clamping the same override. Full suite passes.