### PR TITLE
Bound the --latency buffer depth and fix its documentation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -483,7 +483,9 @@ stand-in for a window the receiver never reported, so it bounds the compiled
 default but not an explicit `--latency`: a renderer that starves below its
 real buffer needs a depth the assumption cannot express (an Edifier MS50A
 stays silent until 2500 ms, matching the 2250 ms it declares as its RAOP
-latency). A reported window still clamps.
+latency). A reported window still clamps, and with none reported the flag is
+bounded at 3000 ms so an unreviewed value cannot outrun the EOF drain budget
+(§10).
 
 **Per-process timeline offsets**: streams in one group share T, and with
 identical RTP positions two sessions from one host are wire-identical twins
@@ -493,10 +495,14 @@ offsets its on-wire RTP timeline (and sequence numbers) by a pid-derived
 constant; the anchor line carries the same offset, so the audible schedule is
 untouched.
 
-**Lead**: `--latency` defaults to 2000 ms and is clamped into the
-device-reported `latencyMin..latencyMax` from stream SETUP. The effective
-lead and the raw window are surfaced on stdout
-(`[STATUS] latency lead_ms=... device_min_frames=... device_max_frames=... device_render_ms=...`)
+**Lead**: the anchor→render lead is a fixed 2000 ms request (the
+AirPlay-standard 2 s) with no external knob, clamped into the device-reported
+`latencyMin..latencyMax` from stream SETUP. `--latency` sets the queue depth
+instead (above), bounded at 3000 ms — an unreported window leaves nothing to
+clamp an override, and a depth past the EOF drain budget (§10) would have
+`[STATUS] eof` arrive while the receiver is still playing what it holds. The
+effective lead, the depth and the raw window are surfaced on stdout
+(`[STATUS] latency lead_ms=... device_min_frames=... device_max_frames=... device_render_ms=... warm_lead_ms=...`)
 so the caller plans group starts from device reality. The SETUP echo of the
 window is receiver-optional (Sonos omits it — then the 1.75 s default
 applies); parsing `audioLatencies` from GET /info is an open item.
@@ -960,10 +966,14 @@ capture.
   allocation, encryption, socket, and control failures are terminal and produce
   a nonzero process exit rather than a false EOF.
 - **EOF drain** — `[STATUS] eof` means the single stdin input ended (the whole
-  feed, not one track). The receiver then drains at most `latency + 2 s`, and
-  the connection idles awaiting the next `START`, the orphan idle timeout, or
-  `DISCONNECT`. The session stays in its playing state across EOF, so the
-  timeout arms on the input closing rather than on that state (§12).
+  feed, not one track). The receiver then drains at most 4 s — the 2 s lead
+  request plus 2 s, not the clamped effective lead — a budget the 3000 ms depth
+  ceiling (§6) keeps the queued audio inside, since the splice timeline keeps
+  feeding silence past the input and so never reports the drain complete on its
+  own — and the connection idles
+  awaiting the next `START`, the orphan idle timeout, or `DISCONNECT`. The
+  session stays in its playing state across EOF, so the timeout arms on the
+  input closing rather than on that state (§12).
 - **Initial metadata** — pushed at the first START with a placeholder title if the
   caller has not set any (Sonos withholds audio until it has metadata; the
   native flow also requires `RTP-Info` on the metadata request — Sonos 400s

--- a/README.md
+++ b/README.md
@@ -104,14 +104,23 @@ Starting before readiness is still supported and still corrected — see
 `START_JOIN=1` below.
 
 Delivery is not gated on the start time: frames are released up to the
-receiver's buffer window ahead of each frame's deadline (the device-reported
-`latencyMax`, or 1.75 s when the receiver does not report one), so receiver
-buffers fill before a scheduled start and the start cannot underrun.
+receiver's queue depth ahead of each frame's deadline (600 ms by default — see
+`--latency` below), itself bounded by the device-reported `latencyMax` less a
+250 ms margin, or by 1.75 s when the receiver reports no window. Receiver
+buffers therefore fill before a scheduled start and the start cannot underrun.
 
-`--latency <ms>` is the playback lead (default 2000 ms, the AirPlay-standard
-2 s), clamped into the window the device reports at stream SETUP. The
-effective lead and the device window are printed as a `[STATUS] latency ...`
-line so the caller can plan group starts from real device capabilities.
+`--latency <ms>` overrides the receiver's queue depth on the native AirPlay 2
+splice timeline (default 600 ms, maximum 3000 ms — deeper values are clamped
+with a warning). That depth is the audible latency of every warm seek and
+track change, so it stays shallow; raise it only for a receiver whose renderer
+starves at the stock depth and plays silence behind a perfectly healthy
+session. A window the device reports at stream SETUP still clamps the
+effective depth, but the 1.75 s stand-in for a window it never reported does
+not — a caller naming a depth knows the device better than an assumption does.
+
+The effective depth (`warm_lead_ms`), the render lead and the device window are
+printed as a `[STATUS] latency ...` line so the caller can plan group starts
+from real device capabilities.
 
 ### Pairing
 
@@ -175,7 +184,7 @@ cliairplay [options] --cmdpipe <path> <host_ip>
 |--------|-------------|
 | `--port <port>` | Device RTSP port (default: 5000; AirPlay 2 devices use 7000). |
 | `--volume <0-100>` | Initial volume. Mapped linear-in-dB onto -30..0 dB (the AirPlay ecosystem convention); 0 mutes. |
-| `--latency <ms>` | Playback lead / buffer (default: 2000, clamped into the device-reported window). |
+| `--latency <ms>` | Receiver queue depth on the native AirPlay 2 splice timeline (default: 600, maximum: 3000). Raise only for receivers whose renderer starves at the stock depth; a device-reported window still clamps it. |
 | `--samplerate <rate>` | Input sample rate (default: 44100). |
 | `--bitdepth <16\|24>` | Input bit depth (default: 16). 24 requires the native AirPlay 2 flow and s32le input. |
 | `--channels <n>` | Input channel count (default: 2). |

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -122,6 +122,14 @@ extern log_level *loglevel;
  * LinkPlay receivers acting as native multiroom master starve the AirPlay
  * renderer below ~1 s of queued audio, so their caller asks for more. */
 #define AP2_SPLICE_PACING_MS         600
+/* Ceiling on that override. A receiver reporting no window of its own has
+ * nothing left to clamp the depth, so the bound lives here. It sits under the
+ * caller's EOF drain budget (cliairplay.c reports eof once the input has been
+ * closed for the render lead plus 2 s): a depth past that budget leaves the
+ * last content still queued when eof fires, so it is reported mid-playback.
+ * Raising this means raising that budget too. Well clear of the deepest depth
+ * a device has needed (2500 ms on an Edifier MS50A). */
+#define AP2_SPLICE_DEPTH_MAX_MS      3000
 /* Delivery pacing depth (§ pacing below). A frame handed over more than the
  * receiver's buffer ahead of its deadline overflows that buffer and is
  * dropped, so delivery runs at most the reported latencyMax less a margin
@@ -2688,9 +2696,9 @@ void ap2cl_set_publish_ip(struct ap2cl_s *p, const char *ip)
 }
 
 /* Effective splice queue depth: the compiled default unless the caller
- * supplied --buffer-depth-ms. Every consumer of the depth (pacing, warm
- * lead, clock-verification windows, connect log) reads it from here so an
- * override moves them all coherently. */
+ * supplied --latency. Every consumer of the depth (pacing, warm lead,
+ * clock-verification windows, connect log) reads it from here so an override
+ * moves them all coherently. */
 static uint32_t ap2_splice_depth_ms(struct ap2cl_s *p)
 {
     uint32_t depth = p->splice_depth_ms > 0 ? (uint32_t)p->splice_depth_ms
@@ -2722,6 +2730,11 @@ static uint32_t ap2_splice_depth_ms(struct ap2cl_s *p)
 void ap2cl_set_splice_depth_ms(struct ap2cl_s *p, int ms)
 {
     if (!p || ms <= 0) return;
+    if (ms > AP2_SPLICE_DEPTH_MAX_MS) {
+        LOG_WARN("[AP2] splice queue depth %d ms exceeds the %d ms maximum, clamping",
+                 ms, AP2_SPLICE_DEPTH_MAX_MS);
+        ms = AP2_SPLICE_DEPTH_MAX_MS;
+    }
     p->splice_depth_ms = ms;
     LOG_INFO("[AP2] splice queue depth override: %d ms", ms);
 }

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -448,8 +448,9 @@ void ap2cl_set_ptp(struct ap2cl_s *p, bool enable);
  * depth is the audible latency of every warm seek/next, but receivers that
  * feed a native multiroom pipeline (LinkPlay masters) starve below ~1 s of
  * queued audio and render silence, so their caller asks for more. Values
- * <= 0 are ignored; the effective depth stays capped by the receiver's
- * reported (or assumed) buffer window.
+ * <= 0 are ignored and anything past 3000 ms is clamped to it with a warning;
+ * the effective depth stays capped by the receiver's reported buffer window
+ * on top of that.
  */
 void ap2cl_set_splice_depth_ms(struct ap2cl_s *p, int ms);
 

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -2058,8 +2058,9 @@ static void print_usage(const char *name)
     printf("  --port <port>              Device port (default: 5000)\n");
     printf("  --volume <0-100>           Initial volume level\n");
     printf("  --latency <ms>             Receiver buffer depth in ms (native AirPlay 2\n");
-    printf("                             only; default 600; deeper feeds devices whose\n");
-    printf("                             pipeline starves, at the cost of seek response)\n");
+    printf("                             only; default 600, max 3000; deeper feeds devices\n");
+    printf("                             whose pipeline starves, at the cost of seek\n");
+    printf("                             response)\n");
     printf("  --dacp <id>                DACP ID\n");
     printf("  --activeremote <id>        Active Remote ID\n");
     printf("  --cmdpipe <path>           Required named pipe for commands and metadata\n");

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -1604,6 +1604,55 @@ static void test_splice_depth_override_vs_reported_buffer(void)
     puts("ap2_client splice depth override tests passed");
 }
 
+/* A receiver that reports no window leaves the override unbounded, so the
+ * setter bounds it: past the maximum the depth is clamped rather than taken,
+ * keeping it inside the caller's EOF drain budget. */
+static void test_splice_depth_bounds(void)
+{
+    ap2_device_info_t device = {
+        .name = "depth bounds test",
+        .address = "127.0.0.1",
+        .port = 7000,
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client =
+        ap2cl_create(&device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_set_splice(client, true);
+
+    /* Nothing set yet: the compiled default, itself under the assumed window. */
+    assert(ap2cl_warm_lead_ms(client) == 600);
+
+    /* Junk and negatives stay ignored, leaving the default in place. */
+    ap2cl_set_splice_depth_ms(client, 0);
+    assert(ap2cl_warm_lead_ms(client) == 600);
+    ap2cl_set_splice_depth_ms(client, -1750);
+    assert(ap2cl_warm_lead_ms(client) == 600);
+
+    /* The maximum itself is taken as given. */
+    ap2cl_set_splice_depth_ms(client, 3000);
+    assert(ap2cl_warm_lead_ms(client) == 3000);
+
+    /* Beyond it the depth is clamped, not truncated to junk or refused: the
+     * pacing window follows the clamped depth, not the value asked for. */
+    ap2cl_set_splice_depth_ms(client, 60000);
+    assert(ap2cl_warm_lead_ms(client) == 3000);
+    assert(ap2cl_test_pacing_window_frames(client) == 132300);
+
+    /* A clamped depth is still an override, so it outranks the assumed window
+     * and a reported buffer still clamps it further. */
+    ap2cl_test_set_dev_latency_max(client, 88200);
+    assert(ap2cl_warm_lead_ms(client) == 1750);
+
+    assert(ap2cl_destroy(client));
+    puts("ap2_client splice depth bounds tests passed");
+}
+
 /* A start committed before the receiver's first timing probe arms the
  * post-commit verification; the poll then verifies, corrects forward, or
  * closes the window, exactly once per commit. */
@@ -2037,6 +2086,7 @@ int main(void)
     test_apple_model_resolution();
     test_pacing_window_rate_scaling();
     test_splice_depth_override_vs_reported_buffer();
+    test_splice_depth_bounds();
     test_clock_verified_anchor();
     test_clock_readiness_report();
     test_clock_stall_detection();


### PR DESCRIPTION
`--latency` (the receiver buffer depth) had no upper bound — the value was taken as given, so an absurd one broke elapsed reporting and made the binary report end-of-input while the receiver was still playing. Its documentation also still described the flag as the playback lead, which it stopped being in #55.

Not reachable from Music Assistant, which already caps the option at 3000 ms, so this is hardening plus doc debt.

- Clamp the buffer depth at 3000 ms and log a warning when a deeper value is asked for
- Correct the README and DESIGN.md description of `--latency`: it is the receiver buffer depth, not the playback lead
- Document the ceiling in `--help`, the README option table and DESIGN.md
- Add a test covering the clamp alongside the existing junk/negative handling