### PR TITLE
Record why a starving receiver can never be deny-listed

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -937,11 +937,13 @@ capture.
   REANCHOR, §12) instead of bursting the queued content on past timestamps when
   sending resumes. The 2026-07-31 fleet A/B validated the same mechanism on
   the third-party park (Sonos Era 100 pair and solo, Sonos Bookshelf, WiiM
-  Pro, Edifier MS50A, Samsung HW-LS60D:
+  Pro, Samsung HW-LS60D:
   cold/seek/next/pause/park/keepalive/late-join/group runs plus
   delivery-stall ladders), so it is the default for everyone; a code-level
   deny-list (`ap2_splice_denied`, empty) keeps the classic flush + re-anchor
-  path available for a receiver that measures splice-hostile. The commanded
+  path available for a receiver that measures splice-hostile. An Edifier
+  MS50A took part in that run but carries no verdict from it, being below
+  its render threshold (§6) at stock depth, silent throughout. The commanded
   START selects the splice instant on the line (the same instant for every
   member of a sync group, so a group splices sample-aligned); the pacing
   depth is kept shallow (600 ms) because the receiver's queued audio plays
@@ -960,7 +962,11 @@ capture.
   rounds, no convergence).
   A lapsed line (resume over a long-idle pipeline) re-anchors fresh — the
   clean session-start shape — and deny-listed receivers keep the classic
-  warm path throughout.
+  warm path throughout. The deny-list overrides the depth control: the
+  pacing window reads the splice depth only on this timeline, so a
+  deny-listed receiver's `--latency` stops doing anything and its queue
+  reverts to the reported or assumed window. A receiver that starves above
+  that window can therefore never be deny-listed.
 - **Realtime send outcomes** — local UDP backpressure is a bounded transient
   drop that advances sequence, RTP, and scheduling timestamps. Encode,
   allocation, encryption, socket, and control failures are terminal and produce

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -1217,11 +1217,23 @@ static bool ap2_features_has_ptp(const char *txt)
  * on an Apple TV 4K, tvOS 27, 2026-07-30; the only clean warm transitions
  * were a natural drain and a bitstream-continuous splice), and the
  * 2026-07-31 fleet A/B cleared the third-party park (Sonos Era 100 pair and
- * solo, Sonos Bookshelf, WiiM Pro, Edifier MS50A, Samsung HW-LS60D:
- * cold/seek/next/pause/park/keepalive/late-join/group runs, delivery-stall
- * ladders) on the same mechanism. Add a `model=` (_airplay TXT) / `am=`
- * (_raop) prefix here only when a receiver measures splice-hostile on
- * hardware. */
+ * solo, Sonos Bookshelf, WiiM Pro, Samsung HW-LS60D: cold/seek/next/pause/
+ * park/keepalive/late-join/group runs, delivery-stall ladders) on the same
+ * mechanism. An Edifier MS50A took part in that run but carries no verdict
+ * from it: that receiver renders nothing below a ~2500 ms queue and the run
+ * used the 600 ms stock depth, so it was silent throughout.
+ *
+ * Deny-listing also takes away the depth CONTROL, because
+ * ap2_pacing_window_frames() reads ap2_splice_depth_ms() only on the splice
+ * timeline. The queue reverts to the reported receiver window, or the assumed
+ * one when unreported — deeper than the stock depth, but a ceiling `--latency`
+ * can no longer lift, and ap2cl_set_splice_depth_ms() still logs an override
+ * that now does nothing. A receiver starving above that ceiling therefore
+ * cannot be deny-listed: the deny-list cannot trade its queue depth back for
+ * the classic path's instant flush, because the depth goes with it.
+ *
+ * Add a `model=` (_airplay TXT) / `am=` (_raop) prefix here only when a
+ * receiver measures splice-hostile on hardware. */
 static bool ap2_splice_denied(const char *txt, const char *am)
 {
     static const char *const prefixes[] = { NULL };
@@ -2698,7 +2710,9 @@ void ap2cl_set_publish_ip(struct ap2cl_s *p, const char *ip)
 /* Effective splice queue depth: the compiled default unless the caller
  * supplied --latency. Every consumer of the depth (pacing, warm lead,
  * clock-verification windows, connect log) reads it from here so an override
- * moves them all coherently. */
+ * moves them all coherently — and every one of them is additionally gated on
+ * p->splice_timeline, so off that timeline an override moves nothing at all
+ * (see ap2_splice_denied). */
 static uint32_t ap2_splice_depth_ms(struct ap2cl_s *p)
 {
     uint32_t depth = p->splice_depth_ms > 0 ? (uint32_t)p->splice_depth_ms

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -450,7 +450,8 @@ void ap2cl_set_ptp(struct ap2cl_s *p, bool enable);
  * queued audio and render silence, so their caller asks for more. Values
  * <= 0 are ignored and anything past 3000 ms is clamped to it with a warning;
  * the effective depth stays capped by the receiver's reported buffer window
- * on top of that.
+ * on top of that. A receiver that takes the classic warm path instead of the
+ * splice timeline ignores the depth entirely (see ap2_splice_denied).
  */
 void ap2cl_set_splice_depth_ms(struct ap2cl_s *p, int ms);
 


### PR DESCRIPTION
Comments only, no behaviour change.

The splice-timeline deny-list looks like the escape hatch for a receiver whose pause is slow, because its queue depth is also its pause latency. It is not: the pacing window reads the splice depth only on the splice timeline, so deny-listing a receiver silently throws its `--latency` away (and the `warm_lead_ms` derived from it) and drops the queue back to the reported or assumed window. A receiver that starves below that window would go silent again - which is exactly the class of device someone would reach for the deny-list to help.

The deny-list comment also credited the 2026-07-31 fleet A/B with clearing an Edifier MS50A. That device renders nothing below a ~2500 ms queue and the run used the 600 ms stock depth, so it was silent for the whole run and the result says nothing about it.

Changes:

- Record in `ap2_splice_denied()` that the deny-list and an explicit buffer depth are mutually exclusive, and why a starving receiver can never be deny-listed
- Drop the Edifier MS50A from the fleet-A/B pass list in both the comment and DESIGN.md, noting why it carries no verdict
