### PR TITLE
Fix stuttering audio when resuming a paused stream on the fallback path

### DIFF
--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3879,6 +3879,19 @@ void ap2cl_pause(struct ap2cl_s *p)
     ap2_mrp_publish_playback(p, AP2_MRP_PLAYBACK_PAUSED, true);
 }
 
+/* Freeze a fresh anchor line one minimum lead ahead of now — the clean
+ * session-start shape over a pipeline the receiver has already drained. The
+ * next packet carries the RTP marker and a fresh sync ahead of its payload,
+ * so the receiver re-seats on the new line. */
+static void ap2_reanchor_after_drain(struct ap2cl_s *p)
+{
+    p->start_ntp = raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS);
+    p->head_ts = NTP2TS(p->start_ntp, p->format.sample_rate);
+    p->rtp_timestamp = (uint32_t)p->head_ts + atomic_load(&p->rtp_offset);
+    p->rt_anchor_valid = false;
+    p->first_packet = true;
+}
+
 void ap2cl_play(struct ap2cl_s *p)
 {
     if (!p) return;
@@ -3909,13 +3922,26 @@ void ap2cl_play(struct ap2cl_s *p)
             /* Lapsed line (receiver drained long ago): re-anchor fresh over
              * the idle pipeline, the clean session-start shape. */
             p->splice_pad_frames = 0;
-            p->start_ntp = raopcl_get_ntp(NULL) + MS2NTP(AP2_MIN_WARM_LEAD_MS);
-            p->head_ts = NTP2TS(p->start_ntp, p->format.sample_rate);
-            p->rtp_timestamp = (uint32_t)p->head_ts +
-                               atomic_load(&p->rtp_offset);
-            p->rt_anchor_valid = false;
-            p->first_packet = true;
+            ap2_reanchor_after_drain(p);
             LOG_INFO("[AP2] splice un-pause after drain: fresh anchor line");
+        }
+    } else if (p->flow == FLOW_NATIVE_AP2 && !p->splice_timeline &&
+               p->state == AP2_PAUSED) {
+        /* Stock un-pause. The pause parked delivery and left the head frozen,
+         * so it now sits a whole pause behind the wall clock while the
+         * receiver rendered on. While its queue still reaches the head the
+         * wire is unbroken and delivery just resumes on the frozen line; once
+         * that queue has drained the head is in the past, and resuming there
+         * would burst the pending content on elapsed timestamps. Pacing
+         * cannot catch that — the gate only holds frames that are too EARLY —
+         * and neither recovery helper sees it either: the delivery-stall
+         * guard is splice-only and the starvation guard needs a dry input.
+         * Re-anchor here instead, the same fresh line ap2cl_resume freezes
+         * for a commanded START on this path. */
+        uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
+        if (p->head_ts <= now_ts) {
+            ap2_reanchor_after_drain(p);
+            LOG_INFO("[AP2] un-pause after drain: fresh anchor line");
         }
     }
     p->state = AP2_STREAMING;

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -950,6 +950,103 @@ static void test_splice_pause_keeps_line_hot(void)
     puts("ap2_client splice pause keepalive tests passed");
 }
 
+/* The stock (non-splice) pause/resume pair. No receiver reaches this path
+ * today — ap2_splice_denied's prefix list is empty, so every native session
+ * takes the splice timeline — so this pins the behavior for work that would
+ * route a deep-queue receiver onto it. */
+static void test_stock_pause_resume_reanchors(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    assert(fcntl(sockets[1], F_SETFL, O_NONBLOCK) == 0);
+
+    ap2_device_info_t device = {
+        .name = "stock pause test",
+        .address = "127.0.0.1",
+        .port = 7000,
+        .txt_records = "model=AppleTV11,1 features=0x4A7FDFD5,0x3C177FDE",
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+    ap2cl_test_set_splice(client, false);
+    assert(ap2cl_start(client, 0, NULL) == AP2_COMMIT_OK);
+    ap2cl_test_set_first_packet(client, false);
+    ap2cl_test_set_anchor_valid(client, true);
+
+    /* A pause the receiver's queue outlasts: the head is still ahead of the
+     * wall clock, so the buffered audio covers the whole gap and delivery
+     * resumes on the frozen line. Moving it here would jump the stamps under
+     * audio the receiver is still rendering. */
+    uint64_t head_hot = ap2cl_test_head_ts(client);
+    uint32_t rtp_hot = ap2cl_test_rtp_timestamp(client);
+    ap2cl_pause(client);
+    assert(ap2cl_state(client) == AP2_PAUSED);
+    assert(!ap2cl_is_playing(client));
+    assert(!ap2cl_test_anchor_valid(client));
+    assert(ap2cl_test_head_ts(client) == head_hot);
+
+    ap2cl_play(client);
+    assert(ap2cl_state(client) == AP2_STREAMING);
+    assert(ap2cl_is_playing(client));
+    assert(ap2cl_test_head_ts(client) == head_hot);
+    assert(ap2cl_test_rtp_timestamp(client) == rtp_hot);
+    assert(!ap2cl_test_first_packet(client));
+
+    /* A pause long enough to drain the receiver: the head lapses behind the
+     * wall clock. Resuming on it would hand the pending content elapsed
+     * timestamps — the pacing gate passes them (it only holds frames that are
+     * too EARLY) and neither recovery helper covers this path, so the
+     * un-pause has to re-anchor. Drag the head 5 s back to stand in for the
+     * pause span. */
+    ap2cl_pause(client);
+    assert(ap2cl_state(client) == AP2_PAUSED);
+    uint64_t lapsed = ap2cl_test_head_ts(client) - 5 * 44100;
+    ap2cl_test_set_head_ts(client, lapsed);
+    uint32_t rtp_lapsed = ap2cl_test_rtp_timestamp(client);
+    uint64_t reanchors_before = ap2cl_test_timeline_reanchors(client);
+
+    ap2cl_play(client);
+    assert(ap2cl_state(client) == AP2_STREAMING);
+
+    /* The line moved forward by the lapse plus the minimum lead. The wall
+     * clock advances between the two calls, so the bounds are sanity rails
+     * around the injected 5 s; the stamp delta below is exact. */
+    uint64_t head_after = ap2cl_test_head_ts(client);
+    uint64_t shift = head_after - lapsed;
+    assert(shift > 4 * 44100 && shift < 7 * 44100);
+    /* The wire timestamp tracks the head 1:1 (both carry the same per-process
+     * offset), so the receiver re-seats on one consistent line. */
+    assert(ap2cl_test_rtp_timestamp(client) - rtp_lapsed == (uint32_t)shift);
+    /* The next packet carries the RTP marker and a fresh sync, and the anchor
+     * is re-derived from the new start. */
+    assert(ap2cl_test_first_packet(client));
+    assert(!ap2cl_test_anchor_valid(client));
+    /* A commanded un-pause is not drift: it must not land in the REANCHOR
+     * accounting Music Assistant tracks. */
+    assert(ap2cl_test_timeline_reanchors(client) == reanchors_before);
+    /* The stock path owes no splice pad. */
+    assert(ap2cl_splice_pad_frames(client) == 0);
+
+    /* The whole pair put nothing on the RTSP socket. */
+    char scratch[16];
+    assert(recv(sockets[1], scratch, sizeof(scratch), 0) == -1);
+    assert(errno == EAGAIN || errno == EWOULDBLOCK);
+
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+    puts("ap2_client stock pause/resume re-anchor tests passed");
+}
+
 static bool bytes_contain(const uint8_t *data, size_t data_len,
                           const void *needle, size_t needle_len)
 {
@@ -2080,6 +2177,7 @@ int main(void)
     test_splice_timeline_warm_path();
     test_splice_delivery_gap_recovery();
     test_splice_pause_keeps_line_hot();
+    test_stock_pause_resume_reanchors();
     test_mrp_bundle_and_pause_publish();
     test_feedback_miss_tolerated_then_recovered();
     test_dead_channel_writes_farewell_teardown();


### PR DESCRIPTION
Pausing and resuming a stream on the fallback (non-splice) timeline left the playback position frozen at the moment of the pause. Once the receiver had played out its buffer, resuming pushed the queued audio out with timestamps that were already in the past — the receiver either drops those frames or renders them late, which is audible.

The delivery pacing can't catch this (it only holds back audio that is too *early*), and neither of the two existing recovery paths applies here. Resuming now re-anchors onto a fresh timeline once the receiver has drained, which is what a commanded start already does.

No receiver takes this path today — every native AirPlay 2 session uses the splice timeline — so this is hardening ahead of the work on receivers with deep buffers, not a fix for a reported issue.

- Re-anchor the timeline on resume when the receiver has drained
- Leave a short pause untouched, so audio still covered by the receiver's buffer stays seamless
- Share the re-anchor between the two resume paths
- Add a regression test for the pause/resume pair