### PR TITLE
Record why resuming a parked stream needs no extra re-anchor

### DIFF
--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3939,11 +3939,12 @@ void ap2cl_play(struct ap2cl_s *p)
          * Re-anchor here instead, the same fresh line ap2cl_resume freezes
          * for a commanded START on this path.
          *
-         * A standby park (AP2_CONNECTED) leaves an equally stale head and is
-         * still deliberately not covered: PLAY and PAUSE act on the transport
-         * alone, while STANDBY parks the session engine and only START
-         * un-parks it — so a PLAY out of standby sends no frames at all, and
-         * the START that has to follow re-anchors through ap2cl_resume. */
+         * A standby park is deliberately not covered: STANDBY drops this path
+         * back to AP2_CONNECTED with an equally stale head, but PLAY and PAUSE
+         * act on the transport alone while STANDBY parks the session engine,
+         * and only START un-parks it. Re-anchoring for a PLAY out of standby
+         * would change nothing — the loop reads no frames until that START,
+         * which re-anchors through ap2cl_resume. */
         uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
         if (p->head_ts <= now_ts) {
             ap2_reanchor_after_drain(p);

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3941,10 +3941,10 @@ void ap2cl_play(struct ap2cl_s *p)
          *
          * A standby park is deliberately not covered: STANDBY drops this path
          * back to AP2_CONNECTED with an equally stale head, but PLAY and PAUSE
-         * act on the transport alone while STANDBY parks the session engine,
-         * and only START un-parks it. Re-anchoring for a PLAY out of standby
-         * would change nothing — the loop reads no frames until that START,
-         * which re-anchors through ap2cl_resume. */
+         * leave the session engine untouched while STANDBY parks it, and only
+         * START resumes delivery. Re-anchoring for a PLAY out of standby would
+         * change nothing — the loop reads no frames until that START, which
+         * re-anchors through ap2cl_resume. */
         uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
         if (p->head_ts <= now_ts) {
             ap2_reanchor_after_drain(p);

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -3937,7 +3937,13 @@ void ap2cl_play(struct ap2cl_s *p)
          * and neither recovery helper sees it either: the delivery-stall
          * guard is splice-only and the starvation guard needs a dry input.
          * Re-anchor here instead, the same fresh line ap2cl_resume freezes
-         * for a commanded START on this path. */
+         * for a commanded START on this path.
+         *
+         * A standby park (AP2_CONNECTED) leaves an equally stale head and is
+         * still deliberately not covered: PLAY and PAUSE act on the transport
+         * alone, while STANDBY parks the session engine and only START
+         * un-parks it — so a PLAY out of standby sends no frames at all, and
+         * the START that has to follow re-anchors through ap2cl_resume. */
         uint64_t now_ts = NTP2TS(raopcl_get_ntp(NULL), p->format.sample_rate);
         if (p->head_ts <= now_ts) {
             ap2_reanchor_after_drain(p);


### PR DESCRIPTION
Following a review of #64: the fallback (non-splice) resume path re-anchors the timeline for a paused stream but not for a parked one, which looks like the same problem one state over.

It isn't. Play and pause act on the transport directly, but a park is only lifted by a start — so a play on a parked stream sends nothing at all, and the start that has to follow already re-anchors. A branch there would be code that can never run, so this records the reason instead.

- Explain in the resume path why a parked stream is deliberately left out
- No behaviour change
