### PR TITLE
Let the keepalive miss budget be raised for receivers on a marginal wireless link

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -903,12 +903,16 @@ deny-list entry, not a policy retreat.
 - **Keepalive miss tolerance** — a timeout-shaped `/feedback` failure (the
   device riding out a short local network blackout with its buffered audio
   intact) does not kill the channel: up to three consecutive missed beats are
-  tolerated (the third kills), while hard peer errors (reset/EOF/protocol)
-  stay immediately fatal. Responses to abandoned beats arrive late once the
-  device recovers, so the response reader skips complete stale responses by
-  CSeq, and bytes of a response that was mid-flight at an abandoned deadline
-  carry over into the next exchange to keep the byte stream and the HAP
-  read-nonce sequence intact. A succeeded beat resets the miss count.
+  tolerated by default (the third kills), while hard peer errors
+  (reset/EOF/protocol) stay immediately fatal. The budget is fixed per session
+  from `CLIAIRPLAY_FEEDBACK_MISSES` (1–30) for receivers whose control channel
+  stalls longer than three beats on a marginal wireless link; the cap keeps a
+  genuinely dead channel detectable within about a minute. Responses to
+  abandoned beats arrive late once the device recovers, so the response reader
+  skips complete stale responses by CSeq, and bytes of a response that was
+  mid-flight at an abandoned deadline carry over into the next exchange to keep
+  the byte stream and the HAP read-nonce sequence intact. A succeeded beat
+  resets the miss count.
 - **Farewell teardown** — giving up on the channel writes one last `TEARDOWN`
   before the socket is shut down, because the regular teardown at disconnect
   cannot pass the fail-closed send gate any more. Without it the receiver keeps

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ cliairplay [options] --cmdpipe <path> <host_ip>
 | `--hostname <host>` | Device hostname (native flow). |
 | `--ptp` | Force PTP grandmaster timing (binds UDP 319/320, needs privilege). Default: auto by the SupportsPTP feature bit. |
 | `--buffered` | Force the buffered stream (type 103, RTP over TCP + PTP anchor) on a native PTP route. Default: auto by the SupportsBufferedAudio feature bit (in-code deny-list for measured-hostile models). `CLIAIRPLAY_BUFFERED=0\|1` outranks both — kill switch / fleet A/B lever. |
+| *(env)* `CLIAIRPLAY_FEEDBACK_MISSES=<1..30>` | Native AP2 sessions POST a `/feedback` keepalive every 2 s and give the session up after this many consecutive timed-out beats (default `3`, about six seconds of control-channel silence). Raise it for a receiver on a marginal wireless link that stalls its control channel for longer than that while its audio buffer is still fine — a Sonos on weak Wi-Fi is the measured case; a dead channel is then noticed within `n × 2 s`. Hard peer errors (reset/EOF/protocol) stay immediately fatal whatever the budget, and an out-of-range or malformed value is logged and ignored. |
 | `--ptp-shared` | Prefer the shared PTP daemon clock (multi-room): attach the daemon's shm instead of running an engine; fall back to the in-process engine when no daemon is live. Picks the clock *source*, not the timing mode — pair it with `--ptp` or a `--txt` advertising SupportsPTP. |
 
 ### Utility / daemon modes

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -85,8 +85,14 @@ extern log_level *loglevel;
  * receivers ride out multi-second local network blackouts (wifi roams, DFS
  * scans) with their buffered audio intact. Consecutive timeout-shaped misses
  * are tolerated up to this count (the final one kills), so a genuinely dead
- * channel is still detected within roughly misses x (interval + timeout). */
-#define AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES 3
+ * channel is still detected within roughly misses x (interval + timeout).
+ * The default suits a healthy LAN; CLIAIRPLAY_FEEDBACK_MISSES raises (or
+ * lowers) the per-session budget for receivers on a marginal wireless link
+ * that stall the control channel for longer than three beats while their
+ * audio buffer is still fine. The cap keeps a dead channel detectable within
+ * about a minute whatever the operator sets. */
+#define AP2_FEEDBACK_DEFAULT_MISSES  3
+#define AP2_FEEDBACK_MAX_MISSES      30
 #define AP2_EVENT_POLL_INTERVAL_MS   100
 #define AP2_RTSP_RX_BUF_SIZE         16384
 #define AP2_UDP_SEND_TIMEOUT_MS      20
@@ -276,6 +282,9 @@ struct ap2cl_s {
     uint64_t sync_packets_sent;
     uint64_t sync_packets_dropped;
     atomic_uint feedback_failures;
+    /* Consecutive missed beats that spend the keepalive budget (the miss that
+     * kills), fixed per session from CLIAIRPLAY_FEEDBACK_MISSES at creation. */
+    unsigned feedback_miss_budget;
     uint64_t timeline_reanchors;
     bool splice_timeline;         /* discard-free warm path on one immutable
                                      anchor line — the native default; false
@@ -672,14 +681,14 @@ static void ap2_mark_rtsp_dead(struct ap2cl_s *p, const char *method,
     int saved_errno = errno;
     unsigned prior_misses = atomic_load(&p->feedback_failures);
     if (ap2_io_feedback_miss_tolerated(uri, saved_errno, prior_misses,
-                                       AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES)) {
+                                       p->feedback_miss_budget)) {
         /* The device may just be riding out a short local network blackout
          * with its buffered audio intact. Leave the channel open — the next
          * exchange skips this beat's late response by CSeq — and only give
          * up after the consecutive-miss budget is spent. */
         LOG_WARN("[AP2] POST /feedback keepalive miss %u/%d (%s after %" PRIu64
                  "ms: %s); tolerating transient failure",
-                 prior_misses + 1, AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES, phase,
+                 prior_misses + 1, p->feedback_miss_budget, phase,
                  elapsed_ms, strerror(saved_errno));
         errno = saved_errno;
         return;
@@ -3044,6 +3053,20 @@ struct ap2cl_s *ap2cl_create(
     atomic_init(&p->rtsp_dead, false);
     atomic_init(&p->media_healthy, true);
     atomic_init(&p->feedback_failures, 0);
+    p->feedback_miss_budget = AP2_FEEDBACK_DEFAULT_MISSES;
+    const char *miss_setting = getenv("CLIAIRPLAY_FEEDBACK_MISSES");
+    if (miss_setting) {
+        if (ap2_io_parse_feedback_miss_budget(miss_setting, AP2_FEEDBACK_MAX_MISSES,
+                                              &p->feedback_miss_budget)) {
+            LOG_INFO("[AP2] keepalive miss budget set to %u beat(s) by "
+                     "CLIAIRPLAY_FEEDBACK_MISSES",
+                     p->feedback_miss_budget);
+        } else {
+            LOG_WARN("[AP2] Ignoring CLIAIRPLAY_FEEDBACK_MISSES=%s (want 1..%d); "
+                     "keeping the default budget of %u beat(s)",
+                     miss_setting, AP2_FEEDBACK_MAX_MISSES, p->feedback_miss_budget);
+        }
+    }
     atomic_init(&p->mrp_event_health, -1);
     atomic_init(&p->feedback_stop, true);
     atomic_init(&p->rtp_offset, 0);
@@ -4669,7 +4692,7 @@ bool ap2cl_control_healthy(struct ap2cl_s *p)
     if (!p || p->flow != FLOW_NATIVE_AP2) return true;
     if (atomic_load(&p->rtsp_dead) ||
         !atomic_load(&p->media_healthy) ||
-        atomic_load(&p->feedback_failures) >= AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES)
+        atomic_load(&p->feedback_failures) >= p->feedback_miss_budget)
         return false;
     return atomic_load(&p->mrp_event_health) != 0;
 }
@@ -5424,8 +5447,12 @@ void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd)
  * that spends it whatever the budget is set to. */
 void ap2cl_test_prime_feedback_misses(struct ap2cl_s *p)
 {
-    atomic_store(&p->feedback_failures,
-                 AP2_FEEDBACK_MAX_CONSECUTIVE_MISSES - 1);
+    atomic_store(&p->feedback_failures, p->feedback_miss_budget - 1);
+}
+
+unsigned ap2cl_test_feedback_miss_budget(struct ap2cl_s *p)
+{
+    return p->feedback_miss_budget;
 }
 
 void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p)

--- a/src/ap2_io.c
+++ b/src/ap2_io.c
@@ -216,6 +216,22 @@ bool ap2_io_feedback_miss_tolerated(const char *uri, int err,
     return prior_misses + 1 < max_misses;
 }
 
+bool ap2_io_parse_feedback_miss_budget(const char *setting,
+                                       unsigned max_budget,
+                                       unsigned *budget)
+{
+    if (!setting || !*setting || !budget) return false;
+    for (const char *c = setting; *c; c++)
+        if (*c < '0' || *c > '9') return false;
+    /* Bounded by max_budget, so a decimal longer than that can only be an
+     * over-bound value; refuse it before strtoul can wrap. */
+    if (strlen(setting) > 9) return false;
+    unsigned long value = strtoul(setting, NULL, 10);
+    if (value < 1 || value > max_budget) return false;
+    *budget = (unsigned)value;
+    return true;
+}
+
 static size_t ap2_find_header_end(const uint8_t *data, size_t len)
 {
     for (size_t i = 0; i + 3 < len; i++) {

--- a/src/ap2_io.h
+++ b/src/ap2_io.h
@@ -85,6 +85,15 @@ bool ap2_io_feedback_miss_tolerated(const char *uri, int err,
                                     unsigned prior_misses,
                                     unsigned max_misses);
 
+/* Parses an operator-supplied keepalive miss budget (the CLIAIRPLAY_FEEDBACK_MISSES
+ * environment variable): a plain decimal count of consecutive missed beats,
+ * 1..max_budget inclusive. Returns false and leaves *budget untouched when the
+ * setting is absent, empty, not a bare decimal, zero, or above max_budget, so
+ * a typo can never silently disable channel-death detection. */
+bool ap2_io_parse_feedback_miss_budget(const char *setting,
+                                       unsigned max_budget,
+                                       unsigned *budget);
+
 /* Returns 1 for a complete response, 0 for incomplete input, and -1 for
  * malformed input. */
 int ap2_io_parse_rtsp_response(const uint8_t *data, size_t len,

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -2106,6 +2106,9 @@ static void print_usage(const char *name)
     printf("                             native AP2, RTP over TCP + PTP anchor); else\n");
     printf("                             auto by the SupportsBufferedAudio feature bit.\n");
     printf("                             CLIAIRPLAY_BUFFERED=0|1 overrides both.\n");
+    printf("                             CLIAIRPLAY_FEEDBACK_MISSES=<1..30> sets how many\n");
+    printf("                             consecutive missed 2 s keepalive beats end a\n");
+    printf("                             native AP2 session (default 3).\n");
     printf("  --ptp-shared               Prefer a shared PTP daemon clock (multi-room):\n");
     printf("                             read the elected clock from shared memory and do\n");
     printf("                             not bind 319/320 when a daemon is present; else\n");

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -32,6 +32,7 @@ void ap2cl_test_lock_mrp(struct ap2cl_s *p);
 void ap2cl_test_unlock_mrp(struct ap2cl_s *p);
 void ap2cl_test_attach_rtsp_socket(struct ap2cl_s *p, int fd);
 void ap2cl_test_prime_feedback_misses(struct ap2cl_s *p);
+unsigned ap2cl_test_feedback_miss_budget(struct ap2cl_s *p);
 void ap2cl_test_detach_rtsp_socket(struct ap2cl_s *p);
 bool ap2cl_test_first_packet(struct ap2cl_s *p);
 void ap2cl_test_set_first_packet(struct ap2cl_s *p, bool first_packet);
@@ -370,6 +371,86 @@ static void test_dead_channel_writes_farewell_teardown(void)
     assert(close(sockets[1]) == 0);
     assert(ap2cl_destroy(client));
     puts("ap2_client farewell teardown test passed");
+}
+
+static struct ap2cl_s *create_feedback_test_client(char *name)
+{
+    ap2_device_info_t device = {
+        .name = name,
+        .address = "127.0.0.1",
+        .port = 7000,
+    };
+    ap2_audio_format_t format = {
+        .sample_rate = 44100,
+        .bit_depth = 16,
+        .channels = 2,
+    };
+    struct ap2cl_s *client = ap2cl_create(
+        &device, &format, NULL, NULL, NULL, NULL, 2000, 100);
+    assert(client);
+    return client;
+}
+
+/* The keepalive miss budget is fixed per session from the environment at
+ * creation: a bare in-range count is taken, anything else keeps the default
+ * so a typo cannot disable channel-death detection. */
+static void test_feedback_miss_budget_from_env(void)
+{
+    assert(unsetenv("CLIAIRPLAY_FEEDBACK_MISSES") == 0);
+    char name_default[] = "budget default";
+    struct ap2cl_s *client = create_feedback_test_client(name_default);
+    assert(ap2cl_test_feedback_miss_budget(client) == 3);
+    assert(ap2cl_destroy(client));
+
+    assert(setenv("CLIAIRPLAY_FEEDBACK_MISSES", "8", 1) == 0);
+    char name_raised[] = "budget raised";
+    client = create_feedback_test_client(name_raised);
+    assert(ap2cl_test_feedback_miss_budget(client) == 8);
+    assert(ap2cl_destroy(client));
+
+    static const char *const rejected[] = { "0", "31", "abc", "8s", "" };
+    char name_rejected[] = "budget rejected";
+    for (size_t i = 0; i < sizeof(rejected) / sizeof(rejected[0]); i++) {
+        assert(setenv("CLIAIRPLAY_FEEDBACK_MISSES", rejected[i], 1) == 0);
+        client = create_feedback_test_client(name_rejected);
+        assert(ap2cl_test_feedback_miss_budget(client) == 3);
+        assert(ap2cl_destroy(client));
+    }
+    assert(unsetenv("CLIAIRPLAY_FEEDBACK_MISSES") == 0);
+    puts("ap2_client feedback miss budget env tests passed");
+}
+
+/* A budget of one restores single-strike behaviour: the very first missed
+ * beat kills the channel (and still says goodbye), with nothing primed. */
+static void test_feedback_miss_budget_of_one_kills_first_miss(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    feedback_peer_t peer = {
+        .fd = sockets[1],
+    };
+    pthread_t peer_thread;
+    assert(pthread_create(
+               &peer_thread, NULL, run_farewell_teardown_peer, &peer) == 0);
+
+    assert(setenv("CLIAIRPLAY_FEEDBACK_MISSES", "1", 1) == 0);
+    char name_one[] = "budget of one";
+    struct ap2cl_s *client = create_feedback_test_client(name_one);
+    assert(unsetenv("CLIAIRPLAY_FEEDBACK_MISSES") == 0);
+    assert(ap2cl_test_feedback_miss_budget(client) == 1);
+    ap2cl_force_native(client);
+    ap2cl_test_attach_rtsp_socket(client, sockets[0]);
+
+    assert(!ap2cl_feedback(client));
+    assert(!ap2cl_control_healthy(client));
+
+    assert(pthread_join(peer_thread, NULL) == 0);
+    assert(peer.ok);
+    ap2cl_test_detach_rtsp_socket(client);
+    assert(close(sockets[0]) == 0);
+    assert(close(sockets[1]) == 0);
+    assert(ap2cl_destroy(client));
+    puts("ap2_client feedback miss budget of one test passed");
 }
 
 typedef struct {
@@ -2249,6 +2330,8 @@ int main(void)
     test_mrp_bundle_and_pause_publish();
     test_feedback_miss_tolerated_then_recovered();
     test_dead_channel_writes_farewell_teardown();
+    test_feedback_miss_budget_from_env();
+    test_feedback_miss_budget_of_one_kills_first_miss();
     test_apple_model_resolution();
     test_pacing_window_rate_scaling();
     test_splice_depth_override_vs_reported_buffer();

--- a/tests/test_ap2_io.c
+++ b/tests/test_ap2_io.c
@@ -80,6 +80,30 @@ static bool test_feedback_miss_policy(void)
     return true;
 }
 
+static bool test_feedback_miss_budget_parser(void)
+{
+    unsigned budget = 3;
+    /* Bare decimals inside the bounds are taken as-is. */
+    CHECK(ap2_io_parse_feedback_miss_budget("1", 30, &budget) && budget == 1);
+    CHECK(ap2_io_parse_feedback_miss_budget("8", 30, &budget) && budget == 8);
+    CHECK(ap2_io_parse_feedback_miss_budget("30", 30, &budget) && budget == 30);
+    /* Everything else is refused and leaves the caller's default alone. */
+    budget = 3;
+    CHECK(!ap2_io_parse_feedback_miss_budget(NULL, 30, &budget));
+    CHECK(!ap2_io_parse_feedback_miss_budget("", 30, &budget));
+    CHECK(!ap2_io_parse_feedback_miss_budget("0", 30, &budget));
+    CHECK(!ap2_io_parse_feedback_miss_budget("31", 30, &budget));
+    CHECK(!ap2_io_parse_feedback_miss_budget("-1", 30, &budget));
+    CHECK(!ap2_io_parse_feedback_miss_budget("+4", 30, &budget));
+    CHECK(!ap2_io_parse_feedback_miss_budget("4 ", 30, &budget));
+    CHECK(!ap2_io_parse_feedback_miss_budget("4s", 30, &budget));
+    CHECK(!ap2_io_parse_feedback_miss_budget("0x8", 30, &budget));
+    CHECK(!ap2_io_parse_feedback_miss_budget("99999999999999999999", 30, &budget));
+    CHECK(!ap2_io_parse_feedback_miss_budget("5", 30, NULL));
+    CHECK(budget == 3);
+    return true;
+}
+
 static bool test_match_rtsp_response_skips_stale(void)
 {
     static const uint8_t stream[] =
@@ -377,6 +401,8 @@ int main(void)
     fprintf(stderr, "RTSP parser passed\n");
     if (!test_feedback_miss_policy()) return 1;
     fprintf(stderr, "feedback miss policy passed\n");
+    if (!test_feedback_miss_budget_parser()) return 1;
+    fprintf(stderr, "feedback miss budget parser passed\n");
     if (!test_match_rtsp_response_skips_stale()) return 1;
     fprintf(stderr, "stale response matcher passed\n");
     if (!test_read_timeout_is_bounded()) return 1;


### PR DESCRIPTION
## Why

A native AP2 session gives up after three consecutive timed-out `/feedback` beats — about six seconds of control-channel silence. That is the right default for a healthy LAN, but a Sonos on weak Wi-Fi can stall its RTSP channel for longer than that while its audio buffer is still fine.

Measured case (Music Assistant `2.10.0.dev2026080504`, cliairplay v0.4.7, Sonos SYMFONISK Bookshelf on Wi-Fi, playing a 6 h audiobook): nine kills in three hours, every one the same line —

```
ap2_mark_rtsp_dead: RTSP channel failed during POST /feedback read after 2002ms: Connection timed out; terminating native session
```

— while an identical SYMFONISK one room over never missed a beat in two weeks. The Sonos provider's own link to the same speaker (UPnP/websocket, no 2 s deadline) stayed up throughout, so it is the control channel that stalls, not the speaker dropping off. Each kill ends the session, the caller has to rebuild it, and the receiver's AirPlay service is unreachable (`GET /info` connect_failed) for tens of seconds afterwards.

## What

`CLIAIRPLAY_FEEDBACK_MISSES=<1..30>` fixes the miss budget per session at creation, in the same fleet-lever style as `CLIAIRPLAY_BUFFERED` / `CLIAIRPLAY_MRP`, so a caller that passes its environment through to the binary (Music Assistant does) needs no code change to try it.

- default unchanged (3); a budget of one restores the old single-strike behaviour
- hard peer errors (reset/EOF/protocol) stay immediately fatal whatever the budget
- cap of 30 keeps a genuinely dead channel detectable within about a minute
- out-of-range or malformed values are logged and ignored, never silently disabling channel-death detection
- `ap2cl_control_healthy` and the `keepalive miss n/N` log line use the same per-session budget

Docs: README (AirPlay 2 table), DESIGN.md §10, `--help`.

## Tests

- `test_ap2_io`: parser accepts bare in-range decimals, rejects empty/zero/over-cap/signed/hex/trailing junk/overflow, leaves the caller's default untouched.
- `test_ap2_client`: default / raised / rejected values through `ap2cl_create`; a budget of one kills on the first miss and still writes the farewell TEARDOWN (reuses the farewell peer, nothing primed). `ap2cl_test_prime_feedback_misses` now derives from the session's budget so the existing tolerance tests stay budget-agnostic.
- `make test STATIC=1 CC=clang CXX=clang++` on macOS arm64: all suites pass.

Happy to turn this into a `--feedback-misses` flag instead (or in addition) if you would rather have it plumbed explicitly from the server side.
