### PR TITLE
Fix pairing with Apple TV and HomePod on the tvOS 26 / HomePod OS 26 beta

### DIFF
--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -564,7 +564,7 @@ static bool ap2_rtsp_write_request(struct ap2cl_s *p, const char *method,
 {
     char hdr[1024];
     int hdr_len = snprintf(hdr, sizeof(hdr),
-        "%s %s RTSP/1.0\r\nCSeq: %d\r\nUser-Agent: AirPlay/670.6.2\r\n"
+        "%s %s RTSP/1.0\r\nCSeq: %d\r\nUser-Agent: " AP2_USER_AGENT "\r\n"
         "DACP-ID: %s\r\nActive-Remote: %s\r\n%s%s%s%s"
         "Content-Length: %d\r\n\r\n",
         method, uri, cseq,

--- a/src/ap2_hap.c
+++ b/src/ap2_hap.c
@@ -552,6 +552,7 @@ static int hap_post_pair_setup_path(int sock_fd, const char *path, int cseq, int
     char http_req[256];
     int hdr_len = snprintf(http_req, sizeof(http_req),
         "POST %s RTSP/1.0\r\n"
+        "User-Agent: " AP2_USER_AGENT "\r\n"
         "Content-Type: application/octet-stream\r\n"
         "X-Apple-HKP: %d\r\n"
         "CSeq: %d\r\n"
@@ -711,6 +712,7 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd,
     char http_req[512];
     int hdr_len = snprintf(http_req, sizeof(http_req),
         "POST /pair-verify RTSP/1.0\r\n"
+        "User-Agent: " AP2_USER_AGENT "\r\n"
         "Content-Type: application/octet-stream\r\n"
         "X-Apple-HKP: 3\r\n"
         "CSeq: 1\r\n"
@@ -955,6 +957,7 @@ bool ap2_hap_pair_verify(struct ap2_hap_ctx *ctx, int sock_fd,
     /* Send M3 */
     hdr_len = snprintf(http_req, sizeof(http_req),
         "POST /pair-verify RTSP/1.0\r\n"
+        "User-Agent: " AP2_USER_AGENT "\r\n"
         "Content-Type: application/octet-stream\r\n"
         "X-Apple-HKP: 3\r\n"
         "CSeq: 2\r\n"

--- a/src/ap2_hap.h
+++ b/src/ap2_hap.h
@@ -12,6 +12,14 @@
 #include <stdint.h>
 
 /*
+ * Sender identification sent on every request to the receiver. AirTunes 980.77.2
+ * (tvOS/HomePod OS 26) answers 403 Forbidden to a pair-setup POST that carries no
+ * User-Agent, so this belongs on the pairing endpoints as much as on the RTSP
+ * control channel.
+ */
+#define AP2_USER_AGENT "AirPlay/670.6.2"
+
+/*
  * HAP pairing context.
  *
  * Credentials format (192 hex chars = 96 bytes):


### PR DESCRIPTION
Apple TVs and HomePods running the tvOS 26 / HomePod OS 26 beta (AirTunes 980.77.2) refuse to pair: the device answers `403 Forbidden` and never shows a PIN. Devices on the previous build are unaffected.

The cause is a missing `User-Agent` header. That build rejects `/pair-pin-start`, `/pair-setup` and `/pair-verify` when the request does not identify the sender. These four requests were the only ones in the binary that omitted it, which is why `GET /info` still succeeded on the same socket moments before the rejection.

Because `/pair-verify` is affected too, this also broke every connect to an already-paired device on that build, not just first-time pairing.

- Send `User-Agent` on `/pair-pin-start`, `/pair-setup` and both `/pair-verify` legs
- Share the one `AP2_USER_AGENT` value with the RTSP control channel instead of repeating the literal

Verified against an Apple TV on 980.77.2: the released binary gets `403`, the same binary with this change gets `200` and the device shows its PIN. An Apple TV on 960.13.1 and a Sonos speaker accept the request either way, so nothing changes for them.