### PR TITLE
Play to AirPlay 2 TVs that never answer the PTP clock

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -52,7 +52,9 @@ accepted as `ft=`) and the status flags (`flags=`/`sf=`) drive the decision:
 Decision order:
 
 1. **Protocol** — bit 38 or 48 set ⇒ AirPlay 2, else legacy RAOP.
-   `--ap2-native` forces AirPlay 2 regardless.
+   `--ap2-native` forces AirPlay 2 regardless, and `--protocol
+   airplay2-compat` forces the auth-setup + RAOP flow for receivers whose
+   native flow misbehaves.
 2. **Native vs RAOP-compat** — stored credentials (`--auth`) ⇒ native with
    pair-verify. `--ap2-native` ⇒ native with transient pairing.
    Otherwise a device that advertises pairing (bit 46 or 48) with no PIN and
@@ -61,9 +63,12 @@ Decision order:
    `--protocol airplay2` takes that route on the same terms, and also when the
    TXT advertises no features at all — an AirPlay-2-only receiver, with no
    `_raop` service behind it. Everything else ⇒ the RAOP-compat flow.
-3. **Timing** — `--ptp` forces PTP; otherwise the SupportsPTP feature bit
-   selects PTP vs the NTP responder. If PTP is selected but UDP 319/320
-   cannot be bound (no privilege, no daemon), the session falls back to NTP.
+3. **Timing** — `--timing ptp|ntp` (or the legacy `--ptp`) forces it;
+   otherwise the SupportsPTP feature bit selects PTP vs the NTP responder.
+   Forced NTP is the escape for receivers that advertise the bit but never
+   answer a clock probe (AirPlay-2 video-class TVs). If PTP is selected but
+   UDP 319/320 cannot be bound (no privilege, no daemon), the session falls
+   back to NTP.
 4. **Stream type** — on a native PTP route, buffered (103) when the receiver
    advertises SupportsBufferedAudio (bit 40) and its model is not on the
    in-code buffered deny-list; realtime (96) otherwise. `--buffered` forces

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ cliairplay [options] --cmdpipe <path> <host_ip>
 
 | Option | Description |
 |--------|-------------|
-| `--protocol <auto\|raop\|airplay2>` | Streaming protocol (default: `auto`, which resolves the full route — RAOP vs AirPlay 2, native vs compat, PTP vs NTP — from the mDNS TXT records in `--txt`). `raop`/`airplay2` force the protocol; `airplay2` picks native vs RAOP-compat on the same terms as `auto`, and goes native when `--txt` advertises no features at all (an AirPlay-2-only receiver). |
+| `--protocol <auto\|raop\|airplay2\|airplay2-compat>` | Streaming protocol (default: `auto`, which resolves the full route — RAOP vs AirPlay 2, native vs compat, PTP vs NTP — from the mDNS TXT records in `--txt`). `raop`/`airplay2` force the protocol; `airplay2` picks native vs RAOP-compat on the same terms as `auto`, and goes native when `--txt` advertises no features at all (an AirPlay-2-only receiver); `airplay2-compat` forces the auth-setup + RAOP flow outright. |
 
 ### Common
 
@@ -218,6 +218,7 @@ cliairplay [options] --cmdpipe <path> <host_ip>
 | `--name <name>` | Device name (native flow). |
 | `--hostname <host>` | Device hostname (native flow). |
 | `--ptp` | Force PTP grandmaster timing (binds UDP 319/320, needs privilege). Default: auto by the SupportsPTP feature bit. |
+| `--timing <auto\|ptp\|ntp>` | Session timing. `auto` (default) follows the SupportsPTP bit (or `--ptp`); `ntp` forces the NTP responder — the escape for receivers that advertise PTP but never answer a clock probe (e.g. AirPlay-2 video-class TVs). An NTP-timed route never selects the buffered stream. |
 | `--buffered` | Force the buffered stream (type 103, RTP over TCP + PTP anchor) on a native PTP route. Default: auto by the SupportsBufferedAudio feature bit (in-code deny-list for measured-hostile models). `CLIAIRPLAY_BUFFERED=0\|1` outranks both — kill switch / fleet A/B lever. |
 | `--ptp-shared` | Prefer the shared PTP daemon clock (multi-room): attach the daemon's shm instead of running an engine; fall back to the in-process engine when no daemon is live. Picks the clock *source*, not the timing mode — pair it with `--ptp` or a `--txt` advertising SupportsPTP. |
 

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -1357,7 +1357,8 @@ ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char
     bool is_ap2;
     if (pref == AP2_PROTO_RAOP) {
         is_ap2 = false;
-    } else if (pref == AP2_PROTO_AIRPLAY2) {
+    } else if (pref == AP2_PROTO_AIRPLAY2 ||
+               pref == AP2_PROTO_AIRPLAY2_COMPAT) {
         is_ap2 = true;
     } else { /* AUTO */
         is_ap2 = AP2_FEAT(r.features, AP2_FEAT_UNIFIED_MEDIA) ||
@@ -1388,6 +1389,15 @@ ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char
     bool native = have_credentials || force_native || (pairable && !pairing_blocked);
     bool transient = native && !have_credentials;   /* stored keys => pair-verify */
 
+    /* An explicit compat preference outranks every native selector: it is the
+     * caller naming a receiver whose native flow misbehaves. */
+    if (pref == AP2_PROTO_AIRPLAY2_COMPAT) {
+        r.use_raop = false;
+        r.native = false;
+        r.reason = "AirPlay 2 (RAOP-compat, forced)";
+        return r;
+    }
+
     if (!native) {
         r.use_raop = false;
         r.native = false;
@@ -1399,12 +1409,11 @@ ap2_route_t ap2_resolve_route(ap2_proto_pref_t pref, const char *txt, const char
     r.native = true;
     r.transient = transient;
 
-    /* 3. Timing: PTP grandmaster when forced, else the SupportsPTP feature bit. */
+    /* 3. Timing: PTP when forced (a forced-OFF is the escape for receivers
+     * that advertise SupportsPTP and never answer a probe), else the
+     * SupportsPTP feature bit. The stream type (realtime vs buffered) is a
+     * separate decision on top of this route: see ap2_buffered_route. */
     r.ptp = ptp_forced ? ptp_enabled : (AP2_FEAT(r.features, AP2_FEAT_PTP) != 0);
-
-    /* Stream type is always realtime (type 96); it carries 16- and 24-bit —
-     * verified audible on device. Buffered (type 103) was investigated and
-     * removed: see DESIGN.md for the findings and rationale. */
     (void)bit_depth;
 
     if (transient)

--- a/src/ap2_client.h
+++ b/src/ap2_client.h
@@ -80,7 +80,17 @@ typedef enum {
     AP2_PROTO_AUTO = 0,
     AP2_PROTO_RAOP,
     AP2_PROTO_AIRPLAY2,
+    AP2_PROTO_AIRPLAY2_COMPAT,   /* force the auth-setup + RAOP flow */
 } ap2_proto_pref_t;
+
+/* Session timing preference (from --timing). AUTO derives PTP vs NTP from the
+ * SupportsPTP feature bit; PTP/NTP force it — NTP being the escape for
+ * receivers that advertise the bit but never answer a clock probe. */
+typedef enum {
+    AP2_TIMING_AUTO = 0,
+    AP2_TIMING_PTP,
+    AP2_TIMING_NTP,
+} ap2_timing_pref_t;
 
 /* Resolved streaming route: the concrete decision the caller acts on. */
 typedef struct {

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -2351,6 +2351,8 @@ int main(int argc, char *argv[])
         if (cfg.timing != AP2_TIMING_NTP) {
             cfg.route.ptp = true;
             cfg.route.reason = "buffered (type 103) forced";
+        } else {
+            cfg.route.reason = "native AP2 forced (buffered request on NTP timing)";
         }
     }
     /* Buffered (type 103) rides a native PTP route: forced, or auto when the

--- a/src/cliairplay.c
+++ b/src/cliairplay.c
@@ -102,6 +102,8 @@ typedef struct {
     bool force_native;      /* force native AP2 flow (transient pairing) */
     char *publish_ip;       /* address advertised to devices (multi-homed hosts) */
     bool ptp;               /* force PTP grandmaster timing for native AP2 */
+    ap2_timing_pref_t timing;   /* --timing auto|ptp|ntp (ntp = force the NTP
+                                   responder even when SupportsPTP is set) */
     int splice_depth_ms;    /* >0: override the splice receiver-queue depth */
     bool ptp_shared;        /* prefer a shared PTP daemon clock (multi-room) */
     bool buffered;          /* force the buffered audio stream (type 103) */
@@ -2053,9 +2055,11 @@ static void print_usage(const char *name)
     printf("cliairplay v%s - Unified AirPlay streaming CLI\n\n", CLIAIRPLAY_VERSION);
     printf("Usage: %s [options] --cmdpipe <path> <host_ip>\n\n", name);
     printf("Protocol selection:\n");
-    printf("  --protocol <auto|raop|airplay2>  Protocol to use (default: auto).\n");
-    printf("                             auto picks RAOP vs AirPlay 2 from the mDNS\n");
-    printf("                             features in --txt; raop/airplay2 force it.\n\n");
+    printf("  --protocol <auto|raop|airplay2|airplay2-compat>\n");
+    printf("                             Protocol to use (default: auto). auto picks\n");
+    printf("                             RAOP vs AirPlay 2 from the mDNS features in\n");
+    printf("                             --txt; raop/airplay2 force it; airplay2-compat\n");
+    printf("                             forces the auth-setup + RAOP flow.\n\n");
     printf("Common options:\n");
     printf("  --port <port>              Device port (default: 5000)\n");
     printf("  --volume <0-100>           Initial volume level\n");
@@ -2102,6 +2106,11 @@ static void print_usage(const char *name)
     printf("  --ptp                      Force PTP grandmaster timing (native AP2;\n");
     printf("                             binds UDP 319/320, needs root; else auto by\n");
     printf("                             SupportsPTP feature bit)\n");
+    printf("  --timing <auto|ptp|ntp>    Session timing (default: auto = the SupportsPTP\n");
+    printf("                             bit, or --ptp). ntp forces the NTP responder —\n");
+    printf("                             the escape for receivers that advertise PTP\n");
+    printf("                             but never answer a clock probe; buffered\n");
+    printf("                             audio then resolves off (needs PTP).\n");
     printf("  --buffered                 Force the buffered audio stream (type 103,\n");
     printf("                             native AP2, RTP over TCP + PTP anchor); else\n");
     printf("                             auto by the SupportsBufferedAudio feature bit.\n");
@@ -2180,6 +2189,7 @@ int main(int argc, char *argv[])
         {"ap2-native",   no_argument,       0, 1007},
         {"publish-ip",   required_argument, 0, 1008},
         {"ptp",          no_argument,       0, 1009},
+        {"timing",       required_argument, 0, 1014},
         {"buffered",     no_argument,       0, 1010},
         {"ptp-daemon",   no_argument,       0, 1011},
         {"ptp-shared",   no_argument,       0, 1012},
@@ -2200,7 +2210,15 @@ int main(int argc, char *argv[])
             if (strcmp(optarg, "auto") == 0) cfg.proto_pref = AP2_PROTO_AUTO;
             else if (strcmp(optarg, "raop") == 0) cfg.proto_pref = AP2_PROTO_RAOP;
             else if (strcmp(optarg, "airplay2") == 0) cfg.proto_pref = AP2_PROTO_AIRPLAY2;
+            else if (strcmp(optarg, "airplay2-compat") == 0)
+                cfg.proto_pref = AP2_PROTO_AIRPLAY2_COMPAT;
             else { fprintf(stderr, "Unknown protocol: %s\n", optarg); return 1; }
+            break;
+        case 1014:
+            if (strcmp(optarg, "auto") == 0) cfg.timing = AP2_TIMING_AUTO;
+            else if (strcmp(optarg, "ptp") == 0) cfg.timing = AP2_TIMING_PTP;
+            else if (strcmp(optarg, "ntp") == 0) cfg.timing = AP2_TIMING_NTP;
+            else { fprintf(stderr, "Unknown timing: %s\n", optarg); return 1; }
             break;
         case 'p': cfg.port = atoi(optarg); break;
         case 'v': cfg.volume = atoi(optarg); break;
@@ -2315,18 +2333,25 @@ int main(int argc, char *argv[])
      * cfg.route carries the AirPlay 2 sub-decisions applied in run_airplay2(). */
     bool have_creds = cfg.auth && strlen(cfg.auth) == 192;
     bool have_password = cfg.password && *cfg.password;
+    /* --timing outranks the legacy --ptp force-on: auto leaves the decision
+     * to --ptp / the SupportsPTP bit, ptp/ntp force it either way. */
+    bool timing_forced = cfg.timing != AP2_TIMING_AUTO || cfg.ptp;
+    bool timing_ptp = cfg.timing == AP2_TIMING_AUTO ? cfg.ptp
+                                                    : cfg.timing == AP2_TIMING_PTP;
     cfg.route = ap2_resolve_route(cfg.proto_pref, cfg.ap2_txt, cfg.pw, have_creds,
                                   have_password, cfg.bit_depth, cfg.force_native,
-                                  cfg.ptp, cfg.ptp);
+                                  timing_forced, timing_ptp);
     /* --buffered pulls the route onto native AP2 with PTP timing (the anchor
-     * needs a grandmaster); the client falls back to realtime if PTP later
-     * proves unavailable. */
+     * needs a grandmaster) — unless NTP timing was forced, which the client
+     * would only fall back from anyway; buffered then resolves off. */
     if (cfg.buffered) {
         cfg.route.use_raop = false;
         cfg.route.native = true;
         cfg.route.transient = !have_creds;
-        cfg.route.ptp = true;
-        cfg.route.reason = "buffered (type 103) forced";
+        if (cfg.timing != AP2_TIMING_NTP) {
+            cfg.route.ptp = true;
+            cfg.route.reason = "buffered (type 103) forced";
+        }
     }
     /* Buffered (type 103) rides a native PTP route: forced, or auto when the
      * receiver advertises SupportsBufferedAudio; CLIAIRPLAY_BUFFERED

--- a/tests/test_ap2_client.c
+++ b/tests/test_ap2_client.c
@@ -560,6 +560,44 @@ static void test_route_with_password(void)
  * advertises SupportsBufferedAudio (bit 40); --buffered forces it there, and
  * CLIAIRPLAY_BUFFERED overrides both ways. The deny-list ships empty — adding
  * an entry must consciously update the pins here. */
+/* Forced timing and the forced compat flow: NTP-forced routes drop PTP (and
+ * with it any buffered eligibility) even on receivers that advertise both
+ * bits, and an explicit airplay2-compat preference outranks every native
+ * selector. */
+static void test_forced_timing_and_compat_route(void)
+{
+    unsetenv("CLIAIRPLAY_BUFFERED");
+    const char *linkplay = "features=0x445F8A00,0x1C340";
+
+    /* (ptp_forced=true, ptp_enabled=false) = --timing ntp. */
+    ap2_route_t ntp = ap2_resolve_route(AP2_PROTO_AIRPLAY2, linkplay, NULL,
+                                        false, false, 16, false, true, false);
+    assert(ntp.native && !ntp.ptp);
+    assert(!ap2_buffered_route(&ntp, linkplay, NULL, false));
+    assert(!ap2_buffered_route(&ntp, linkplay, NULL, true));
+
+    /* Auto timing still follows the SupportsPTP bit. */
+    ap2_route_t auto_t = ap2_resolve_route(AP2_PROTO_AIRPLAY2, linkplay, NULL,
+                                           false, false, 16, false, false,
+                                           false);
+    assert(auto_t.ptp);
+
+    /* Forced compat beats a pairable device's native selection, and pulls a
+     * legacy-featured device onto AirPlay 2 rather than plain RAOP. */
+    ap2_route_t compat = ap2_resolve_route(AP2_PROTO_AIRPLAY2_COMPAT, linkplay,
+                                           NULL, false, false, 16, false,
+                                           false, false);
+    assert(!compat.use_raop && !compat.native);
+    assert(strcmp(compat.reason, "AirPlay 2 (RAOP-compat, forced)") == 0);
+    ap2_route_t compat_legacy = ap2_resolve_route(AP2_PROTO_AIRPLAY2_COMPAT,
+                                                  "features=0x0,0x0", NULL,
+                                                  false, false, 16, false,
+                                                  false, false);
+    assert(!compat_legacy.use_raop && !compat_legacy.native);
+
+    puts("ap2_client forced timing and compat route tests passed");
+}
+
 static void test_buffered_route_resolution(void)
 {
     unsetenv("CLIAIRPLAY_BUFFERED");
@@ -2234,6 +2272,7 @@ int main(void)
     test_retransmit_responder();
     test_route_with_password();
     test_buffered_route_resolution();
+    test_forced_timing_and_compat_route();
     test_route_explicit_airplay2();
     test_auth_error_kind();
     test_info_format_tables();


### PR DESCRIPTION
Some receivers advertise PTP support in their mDNS features but never answer a single clock probe — AirPlay 2 video-class TVs (Sony Bravia / Google TV, support#6087) are certified for video and don't participate in multiroom PTP audio at all. On such a device the PTP session looks healthy while rendering silence.

This makes the escape routes commandable, so the caller (Music Assistant) can route around measured device behavior:

- `--timing auto|ptp|ntp` — session timing tri-state. `ntp` forces the NTP responder these TVs actually work with (the lane the pre-PTP releases used); an NTP-timed route never selects the buffered stream, which needs a PTP anchor.
- `--protocol airplay2-compat` — forces the auth-setup + RAOP flow outright, completing the protocol matrix for receivers whose native flow misbehaves.

Route resolution is covered by new unit tests; docs updated. Pairs with the upcoming Music Assistant "streaming mode" player setting that auto-switches a PTP-dead receiver to NTP timing.

Note for release sequencing: no version tag until #68 has also landed — one binary release covers both.
