### PR TITLE
Fix buffered speakers lagging behind realtime players in a group

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -837,6 +837,13 @@ receiver has ingested 75 s ≈ 10 MB at line speed; a cold-clock one prefetches
 a few seconds until its servo trusts the timeline). Two sender rules follow,
 both learned the hard way:
 
+- **No realtime latency fields in the SETUP.** `latencyMin`/`latencyMax`
+  describe a live feed's buffering window and belong to the realtime stream
+  only; a buffered receiver handed them applies `latencyMax` as an extra
+  render delay on top of the anchor (Sonos: a constant 2 s lag against every
+  realtime member of a mixed group, ear-measured — invisible in homogeneous
+  buffered groups, where the shared constant cancels). Apple buffered
+  senders omit them.
 - **Read-throttling is not a fault.** The unwritten tail of a frame parks in
   a pending stash and the pacing gate holds new frames until it drains; a
   send deadline must never kill the session (the removed v0.2.0

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -837,7 +837,7 @@ receiver has ingested 75 s ≈ 10 MB at line speed; a cold-clock one prefetches
 a few seconds until its servo trusts the timeline). Two sender rules follow,
 both learned the hard way:
 
-- **No realtime latency fields in the SETUP.** `latencyMin`/`latencyMax`
+- **No realtime latency fields in the type-103 SETUP.** `latencyMin`/`latencyMax`
   describe a live feed's buffering window and belong to the realtime stream
   only; a buffered receiver handed them applies `latencyMax` as an extra
   render delay on top of the anchor (Sonos: a constant 2 s lag against every

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2083,8 +2083,8 @@ static bool ap2_native_connect(struct ap2cl_s *p)
      * receiver owns its buffer and playback is scheduled by the anchor
      * alone — and a receiver handed these fields applies them as an extra
      * render delay on top of the anchor (Sonos: latencyMax = a constant
-     * 2 s lag against every realtime group member, ear-measured). Real
-     * Apple buffered senders do not send them. */
+     * 2 s lag against every realtime group member, ear-measured).
+     * Apple's own buffered senders omit them. */
     if (!p->use_buffered) {
         ap2_plist_stream_add_int(ssp, "latencyMax", 88200);
         ap2_plist_stream_add_int(ssp, "latencyMin", 11025);

--- a/src/ap2_client.c
+++ b/src/ap2_client.c
@@ -2078,8 +2078,17 @@ static bool ap2_native_connect(struct ap2cl_s *p)
     if (!p->use_buffered)
         ap2_plist_stream_add_int(ssp, "dataPort", local_data_port);
     ap2_plist_stream_add_bool(ssp, "isMedia", true);
-    ap2_plist_stream_add_int(ssp, "latencyMax", 88200);
-    ap2_plist_stream_add_int(ssp, "latencyMin", 11025);
+    /* latencyMin/latencyMax are realtime-stream fields (the receiver's
+     * buffering window for a live RTP feed). On the buffered stream the
+     * receiver owns its buffer and playback is scheduled by the anchor
+     * alone — and a receiver handed these fields applies them as an extra
+     * render delay on top of the anchor (Sonos: latencyMax = a constant
+     * 2 s lag against every realtime group member, ear-measured). Real
+     * Apple buffered senders do not send them. */
+    if (!p->use_buffered) {
+        ap2_plist_stream_add_int(ssp, "latencyMax", 88200);
+        ap2_plist_stream_add_int(ssp, "latencyMin", 11025);
+    }
     ap2_plist_stream_add_data(ssp, "shk", p->audio_key, 32);
     ap2_plist_stream_add_int(ssp, "spf", 352);
     ap2_plist_stream_add_int(ssp, "sr", p->format.sample_rate);


### PR DESCRIPTION
Grouping a buffered speaker with a realtime one (e.g. a Sonos with an Apple TV) played the buffered member a constant ~2 seconds behind — while all-buffered groups stayed perfectly in sync, because every member carried the same hidden delay and it cancelled.

Root cause: the type-103 stream SETUP inherited `latencyMin`/`latencyMax` from the realtime dict. Those fields describe a live feed's buffering window; a buffered receiver handed them applies `latencyMax` (88200 frames = 2.0 s) as an extra render delay on top of the anchor. Apple's own buffered senders omit the fields on type 103.

- Omit `latencyMin`/`latencyMax` from the buffered stream SETUP (realtime keeps them)
- Documented the finding in DESIGN.md §9

Ear-verified: the same Apple TV + Sonos mixed group that was 1-2 s apart now plays in sync.
